### PR TITLE
very basic change to removeRxns

### DIFF
--- a/reconstruction/removeRxns.m
+++ b/reconstruction/removeRxns.m
@@ -81,7 +81,9 @@ end
 if (isfield(model, 'rxnNotes'))
   modelOut.rxnNotes = model.rxnNotes(selectRxns);
 end
-
+if (isfield(model, 'confidenceScores'))
+  modelOut.confidenceScores = model.confidenceScores(selectRxns);
+end
 
 % Reconstruct the match list
 if (irrevFlag)


### PR DESCRIPTION
Just testing out the pull request feature with an extremely simple change, that makes sure the confidenceScore field (which is included in the Recon 2 COBRA model) is also appropriately reduced to the remaining number of reactions.
