### PR TITLE
small bug in extractGPRs subfunction of createTissueSpecificModel

### DIFF
--- a/reconstruction/createTissueSpecificModel.m
+++ b/reconstruction/createTissueSpecificModel.m
@@ -559,7 +559,7 @@ end
 
 i =1 ;
 sizeP = size(parsedGPR,1);
-while i < sizeP
+while i <= sizeP
     if strcmp(parsedGPR{i,1},{''}) == 1
         parsedGPR = [parsedGPR(1:i-1,:);parsedGPR(i+1:end,:)];
         corrRxn = [corrRxn(1:i-1,:);corrRxn(i+1:end,:)];


### PR DESCRIPTION
The function [parsedGPR,corrRxn] = extractGPRs(model) is buggy, as it does not check whether the last row only contains empty cells. 

To showcase what spurious results this leads to, with my model, corrRxn was a 7160x1 cell array with the final 2 entries being 'URIt5le' , 'URIt5le'. parsedGPR was a 7160x45 cell with the last entry row containing only empty cells and the row just before it containing the cell '64078.1'. (Note that the GPR for the reaction 'URIt5le' is (64078.1).)

Now, the truth is that I was only interested in using the extractGPRs function (which I had copied into a new file to be able to use it) and not the createTissueSpecificModel function. Thus, I am not too sure, if by fixing this bug, other bugs in createTissueSpecificModel could show up. I did successfully run the unit test (testTissueModel), but as it is really minimal and only checks if a model with less reactions than the original is returned, I am not too confident about it. 
