### PR TITLE
fixing parseBoolean bug

### DIFF
--- a/tools/parseBoolean.m
+++ b/tools/parseBoolean.m
@@ -1,10 +1,12 @@
-function [elements,newRule,rxnGeneMat] = parseBoolean(str,tokens,allowedElementChars)
+function [elements, newRule, rxnGeneMat] = ...
+        parseBoolean(str, tokens, allowedElementChars)
 %parseBoolean Parses a Boolean logic statement
 %
 % [elements,newRule] = parseBoolean(str,tokens,allowedElementChars)
 %
 % str                   Input string or cell array of boolean statements
-% tokens                Allowed operators in boolean statements (optional, default '()&|~')
+% tokens                Allowed operators in boolean statements (optional, 
+%                         default '()&|~')
 % allowedElementChars   Allowed characters in elements of the statement
 %
 % elements              Non-operator elements
@@ -26,10 +28,10 @@ if (nargin < 3)
     % Allowed characters in elements
     allowedElementChars = '[A-Za-z0-9_\.\-]'; 
 end
-% changes (and, not, or) for (&, ~, |) within the string
 
-if isstr(str) %if it's a string, use MH's code
+if ischar(str) %if it's a string, use MH's code
     
+    % changes (and, not, or) for (&, ~, |) within the string
     str1=str;
     %str1 = regexprep(str1, '+',' & ');
     %str1 = regexprep(str1, ',',' | ');
@@ -70,22 +72,24 @@ if isstr(str) %if it's a string, use MH's code
                 ruleLength = length(newRule);
                 % Loop through all the instances
                 replaceThisVector = false(length(s),1);
-                % Find out which instances to replace (do not want to replace
-                % instances that are parts of other tokens)
+                % Find out which instances to replace (do not want to
+                % replace instances that are parts of other tokens)
                 for i = 1:length(s)
                     % It's the only token so go ahead and replace
-                    if ((s(i) == 1) & (f(i) == ruleLength))
+                    if ((s(i) == 1) && (f(i) == ruleLength))
                        replaceThisFlag = true;
-                    elseif (s(i) == 1) % Token at the beginning of string
-                        if (isempty(regexp(newRule(f(i)+1),allowedElementChars)))
+                    elseif (s(i) == 1) % Token at the beginning
+                        if (isempty(regexp(newRule(f(i)+1), ...
+                                allowedElementChars)))
                             % It's not a part of another token - replace
                             replaceThisFlag = true;    
                         else
                             % Part of another token - do not replace
                             replaceThisFlag = false;
                         end
-                    elseif (f(i) == ruleLength) % Token at the end of string
-                        if (isempty(regexp(newRule(s(i)-1),allowedElementChars)))
+                    elseif (f(i) == ruleLength) % Token at the end
+                        if (isempty(regexp(newRule(s(i)-1), ...
+                                allowedElementChars)))
                             % It's not a part of another token - replace
                             replaceThisFlag = true;    
                         else
@@ -93,7 +97,10 @@ if isstr(str) %if it's a string, use MH's code
                             replaceThisFlag = false;
                         end
                     else % Token in the middle of the string
-                        if (isempty(regexp(newRule(f(i)+1),allowedElementChars)) & isempty(regexp(newRule(s(i)-1),allowedElementChars)))
+                        if (isempty(regexp(newRule(f(i)+1), ...
+                                allowedElementChars)) && ...
+                                isempty(regexp(newRule(s(i)-1), ...
+                                allowedElementChars)))
                             % It's not a part of another token - replace
                             replaceThisFlag = true;
                         else
@@ -118,8 +125,8 @@ if isstr(str) %if it's a string, use MH's code
                     end
                     % Add the new token
                     tmpRule = [tmpRule newTok];
-                    % Add the remainder of the string until the next token (if
-                    % there is one)
+                    % Add the remainder of the string until the next token
+                    % (if there is one)
                     if (i < nRep)
                         tmpRule = [tmpRule newRule((f(i)+1):(s(i+1)-1))];    
                     end
@@ -134,9 +141,13 @@ if isstr(str) %if it's a string, use MH's code
             end
         end
     end
+    
     if nargout == 3 % deal with a bad function call
         rxnGeneMat = [];
-        warning('rxnGeneMat is not meaningful when parseBoolean is called with a string. Did you mean to use a cell array? Empty matrix returned.')
+        string = ['rxnGeneMat is not meaningful when parseBoolean ' ...
+            'is called with a string. Did you mean to use a cell '...
+            'array? Empty matrix returned for rxnGeneMat.'];
+        warning(string);
     end
     
 elseif iscell(str) % if it's a cell array, use BH code
@@ -147,36 +158,46 @@ elseif iscell(str) % if it's a cell array, use BH code
     newRule = regexprep(newRule, 'not ', '~ ','ignorecase');
     newRule = regexprep(newRule,'\[','');
     newRule = regexprep(newRule,'\]','');
-    newRule = regexprep(newRule,'\s',''); % get rid of whitespace
 
-    % make a cell array of all genes in each rule. This regexp assumes genes
-    % are named with word characters, dashes, and/or hyphens.
+    % make a cell array of all genes in each rule. This regexp assumes
+    % genes are named with word characters, dashes, and/or hyphens.
     elements = regexp(newRule,'[\w-\.]*','match'); 
     elements = unique([elements{:}])';
 
     % initialize rxnGeneMat
-
-    rxnGeneMat = sparse(length(str),length(elements));
+    rxnGeneMat = zeros(length(str),length(elements));
 
     % pad gene names in grRules with a space to facilitate later regexp -
     % thanks to James Eddy for this bit of cleverness
-    grRules_tmp = regexprep(strcat(str,{' '}),'\)',' )');
+    grRules_tmp = regexprep(strcat(newRule,{' '}),'\)',' )');
 
-    % loop over genes, replace grRules gene names with index from gene list and
-    % build rxnGeneMat
+    % loop over genes, replace grRules gene names with index from gene list
+    % and build rxnGeneMat    
     for gene_index = 1:length(elements)
-        %build rxnGeneMat
+        %populate rxnGeneMat
         rxnGeneMat(:,gene_index) = ~cellfun('isempty', ...
             regexp(grRules_tmp,[elements{gene_index},'\s']));
 
         % build newRule
         number = int2str(gene_index);
-        string =  ['x(' number ')'];
-        newRule = regexprep(newRule,elements(gene_index),string);
+        string =  ['x(' number ') '];
+        grRules_tmp = regexprep(grRules_tmp, ...
+            strcat(elements(gene_index), {' '}), string);
     end
+    rxnGeneMat = sparse(rxnGeneMat);
+    
+    newRule = grRules_tmp;
+    
+    % string-based approach has & and | padded by whitespace, but rules
+    % aren't. So manage the whitespace to ensure backwards compatibility
+    newRule = regexprep(newRule,'\s',''); % remove whitespace
+    newRule = regexprep(newRule, '&', ' & '); % pad &
+    newRule = regexprep(newRule, '\|', ' | ');% pad |
     
 else
-    error('Wrong type', 'The str variable passed to parseBoolean must be a string or cell array.')
+    string = ['The str variable passed to parseBoolean must be a '...
+        'string or cell array.'];
+    error(string)
 end
 
 end


### PR DESCRIPTION
When comparing the rules generated by my recent changes to parseBoolean with the existing iND750 rules, I found 2 bugs: Markus' code generated rules with whitespace around & and | characters, and my code's regexes were too greedy, and missed ORFs with suffixes like -A.

So, my code was generating rules like this:

'(x(96)-A&x(282))|(x(97)&x(525))|(x(97)&x(593))'

instead of like this:
'(x(97) & x(282)) | (x(97) & x(525)) | (x(97) & x(593))'

This change fixes that, changes the way the rxnGeneMat is initialized to avoid a MATLAB memory warning, and does some reformatting to the existing code to clean it up.

commit 803b7fb6bb0c45e9e65110acd03f51e839597cc9
Author: Ben Heavner bheavner@gmail.com
Date:   Wed Jun 19 13:21:25 2013 -0700

```
fixed parseBoolean bugs and reformatted code
```

commit b49936ccee97c838015d64de3c9ae035ccab8c1c
Author: Ben Heavner bheavner@gmail.com
Date:   Wed Jun 19 12:13:48 2013 -0700

```
fixed -A bug
```

commit 15916a97f9613db586dec9c2925906ff8b3f4b89
Author: Ben Heavner bheavner@gmail.com
Date:   Wed Jun 19 10:22:52 2013 -0700

```
fixed the & and | whitespace problem
```
