### PR TITLE
Improving convertIrrevFluxDistribution.m and convertToIrreversible.m

### DIFF
--- a/convertIrrevFluxDistribution.m
+++ b/convertIrrevFluxDistribution.m
@@ -1,4 +1,4 @@
-function vRev = convertIrrevFluxDistribution(model,vIrrev,matchRev)
+function vRev = convertIrrevFluxDistribution(vIrrev, matchRev)
 %convertInrrevFluxDistribution  Convert irreversible flux distribution to
 %reversible
 %
@@ -16,7 +16,7 @@ function vRev = convertIrrevFluxDistribution(model,vIrrev,matchRev)
 % Markus Herrgard 1/30/07
 %
 % Brandon Barker, Yiping Wang 6/23/2013
-% Updated to correctly negate strictly backward reactions
+%     - correctly negate strictly backward reactions
 % 
 processedFlux = false*ones(length(vIrrev),1);
 
@@ -24,16 +24,19 @@ vRev = [];
 
 for i = 1:length(vIrrev)
     if (~processedFlux(i))
-        if (matchRev(i) > 0)
+        vRevlen = length(vRev);
+        if matchRev(i) > 0
             vRev(end+1) = vIrrev(i)-vIrrev(matchRev(i));
             processedFlux(matchRev(i)) = true;
-        else
-	    vRevlen = length(vRev);
-	    if model.ub(vRevlen+1) <= 0
+        elseif matchRev(i) < 0
+            if mod(matchRev(vRevlen+1), 1) > 0                
                 vRev(vRevlen+1) = -vIrrev(i);
             else
                 vRev(vRevlen+1) = vIrrev(i);
 	    end
+        else
+            disp(['Warning: rev_rxn ' num2str(vRevlen+1) ', irrev rxn ' ...
+                  num2str(i) ' missed in matchRev.']);
         end
         processedFlux(i) = true;
     end

--- a/convertToIrreversible.m
+++ b/convertToIrreversible.m
@@ -9,7 +9,9 @@ function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model
 %OUTPUTS
 % modelIrrev    Model in irreversible format
 % matchRev      Matching of forward and backward reactions of a reversible
-%               reaction
+%               reaction. Negative non-integer values are strictly backward
+%               reaction indices in the reversible model; negative 
+%               integer values are stricly forward.
 % rev2irrev     Matching from reversible to irreversible reactions
 % irrev2rev     Matching from irreversible to reversible reactions
 %
@@ -24,6 +26,7 @@ function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model
 %
 % Modified by Markus Herrgard 7/25/05
 % Modified by Jan Schellenberger 9/9/09 for speed.
+% Modified by Brandon Barker 11/20/2013 to add more fields, fix rev bug.
 
 %declare variables
 modelIrrev.S = spalloc(size(model.S,1),0,2*nnz(model.S));
@@ -54,7 +57,6 @@ for i = 1:nRxns
         warning(cat(2,'Reaction: ',model.rxns{i},' is classified as irreversible, but bounds are positive and negative!'))
 
     end
-   
     % Reaction entirely in the negative direction
     if (model.ub(i) <= 0 && model.lb(i) < 0)
         % Retain original bounds but reversed
@@ -65,8 +67,13 @@ for i = 1:nRxns
         modelIrrev.c(cnt) = -model.c(i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
         model.rev(i) = false;
-        modelIrrev.rev(cnt) = false;
+        matchRev(cnt) = -i - 0.5;
     else
+        if (model.lb(i) >= 0 && model.ub(i) > 0)
+            model.rev(i) = false;
+            modelIrrev.rev(cnt) = false;
+            matchRev(cnt) = -i;
+        end
         % Keep positive upper bound
         modelIrrev.ub(cnt) = model.ub(i);
         %if the lb is less than zero, set the forward rxn lb to zero 
@@ -78,10 +85,10 @@ for i = 1:nRxns
         modelIrrev.S(:,cnt) = model.S(:,i);
         modelIrrev.c(cnt) = model.c(i);
         modelIrrev.rxns{cnt} = model.rxns{i};
-        modelIrrev.rxnNames{cnt} = model.rxnNames{i};
-
+        if isfield(model, 'rxnNames')
+            modelIrrev.rxnNames{cnt} = model.rxnNames{i};
+        end
     end
-
    
     %if the reaction is reversible, add a new rxn to the irrev model and
     %update the names of the reactions with '_f' and '_b'
@@ -90,10 +97,12 @@ for i = 1:nRxns
         matchRev(cnt) = cnt - 1;
         matchRev(cnt-1) = cnt;
         modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
-        modelIrrev.rxnNames{cnt-1} = [model.rxnNames{i} ' forward'];
         modelIrrev.S(:,cnt) = -model.S(:,i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
-        modelIrrev.rxnNames{cnt} = [model.rxnNames{i} ' backward'];
+        if isfield(model, 'rxnNames')
+            modelIrrev.rxnNames{cnt-1} = [model.rxnNames{i} ' forward'];
+            modelIrrev.rxnNames{cnt} = [model.rxnNames{i} ' backward'];
+        end
         modelIrrev.rev(cnt) = true;
         modelIrrev.lb(cnt) = 0;
         modelIrrev.ub(cnt) = -model.lb(i);
@@ -101,7 +110,6 @@ for i = 1:nRxns
         rev2irrev{i} = [cnt-1 cnt];
         irrev2rev(cnt) = i;
     else
-        matchRev(cnt) = 0;
         rev2irrev{i} = cnt;
     end
 end
@@ -118,10 +126,12 @@ modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
 modelIrrev.rev = modelIrrev.rev(1:cnt);
 modelIrrev.rev = columnVector(modelIrrev.rev == 1);
 modelIrrev.rxns = columnVector(modelIrrev.rxns); 
-modelIrrev.rxnNames = columnVector(modelIrrev.rxnNames); 
 modelIrrev.mets = model.mets;
 matchRev = columnVector(matchRev(1:cnt));
 modelIrrev.match = matchRev;
+if isfield(model, 'rxnNames')
+    modelIrrev.rxnNames = columnVector(modelIrrev.rxnNames); 
+end
 if (isfield(model,'b'))
     modelIrrev.b = model.b;
 end


### PR DESCRIPTION
I've revised based on your suggestions - thanks again for those, it has
been helpful. Please see the previous pull request for the original intent
of the features:
https://github.com/opencobra/cobratoolbox/pull/7

First the good news: testOptKnock works identically with the submitted
code. Now some bad news:

In the E. coli core model, there are several reactions (see below)
whose bounds disagree with the reversibility flag; I realize
that at the model annotation level, this is currently OK - and (unfortunately)
it doesn't seem to be standardized. Correcting for this in
convertToIrreversible.m causes the SMILEY algorithm (run from testGrowthExpMatch) to find no solution.

As a non-expert SMILEY user, I really do not know what to make of this,
but I suppose it is possible that the SMILEY code or algorithm may lack some robustness to this form of model annotation.

> > load('./ecoli_core_model.mat');
> > lbRxns = find(model.rev & (model.lb >= 0)) % These are all exchange reactions.

lbRxns =

```
20
21
22
24
25
26
27
29
30
33
34
38
39
```

> > ubRxns = find(model.rev & (model.ub <= 0))

ubRxns =

   Empty matrix: 0-by-1

A related problem will occur in isSameCobraModel.m (which is used in a test) if
the models have discrepancies between lb/ub and rev.

A possible solution (that doesn't involve looking too much at SMILEY) is to have convertToIrreversible ignore exchange reactions by calling findExcRxns.

Another possible solution is to take the opposite approach and assign all
reversible reactions to have negative lb and positive ub. But I feel we are
getting in to annotation problems here. Also I haven't yet tested to see how growthExpMatch would work in the test case in this scenario. 

Yet another solution is to leave the .rev annotation alone, but it is already 
changed in convertToIrreversible.m in the case where the reaction is operating strictly in the negative direction (but NOT strictly in the positive direction, which seems a bit strange). The pull request I've submitted removes these inconsistencies but causes the above problems.

Truthfully, these rev versus lb/ub issues have caused me a little 
consternation over the last year and I really wonder if it would be better that .rev didn't exist at all. Take as an example from programming the OOP or abstract
interface approach with get/set methods. You really don't want different interfaces
to change the behavior of the same variable (or in this case, different variables
basically describing the same object); it increases the code complexity 
and likelihood of introducing errors. 

In the short term, maybe the right thing to do is to never use it in an algorithm implementation and deprecate its use. In the long term, maybe remove the flag altogether from new models? Either way I'd really like to hear what other people think. 

Going a little further down the road of discussing annotation (and further afield from the current problems stated above): it seems that .rev and .lb/.ub are condition dependent anyway; in microbes it might change depending on the media, in animals it might change depending on the
tissue, etc. I would think that a better approach would be to have multiple sets
of lbs/ubs published for each model - the "base" lb/ub should only contain directionality constraints for non-biological reactions (e.g. biomass, IsA, sources/sinks not normally present biologically). 
