### PR TITLE
Update createModel.m (reversibility)

### DIFF
--- a/reconstruction/createModel.m
+++ b/reconstruction/createModel.m
@@ -42,6 +42,8 @@ model.rxnGeneMat=sparse(0,0);
 model.rules=cell(0,1);
 model.grRules=cell(0,1);
 model.genes=cell(0,1);
+lbGivenFlag = true; %reversibility implied by lower bound
+revGivenFlag = true; %reversibility implied by revFlag
 
 if nargin < 1
     return;
@@ -60,16 +62,19 @@ if nargin < 7
 end
 if nargin < 5
     lowerBoundList = -1000*ones(nRxns,1);
+    lbGivenFlag = false; %reversibility not implied by lower bound
 end
 if nargin < 6
     upperBoundList = 1000*ones(nRxns,1);
 end
 if nargin < 4
     revFlagList = ones(nRxns,1);
+    revGivenFlag = false; %reversibility not implied by default revFlag
 end
 if isempty(revFlagList)
     revFlagList = zeros(nRxns,1);
-    revFlagList(find(lowerBoundList)< 0) = 1;
+    revFlagList(lowerBoundList< 0) = 1;
+    revGivenFlag = false; %reversibility not implied by default revFlag
 end
 
 for i = 1 : nRxns
@@ -87,7 +92,16 @@ for i = 1 : nRxns
           grRuleList{i}= (regexprep(grRuleList{i},'+',' and '));
        end
     end
-    [metaboliteList,stoichCoeffList] = parseRxnFormula(rxnList{i});
+    [metaboliteList,stoichCoeffList,revFlag_i] = parseRxnFormula(rxnList{i});
+    if ~lbGivenFlag
+        if ~revGivenFlag
+            %if both revFlag and lb are not given, update the revFlag 
+            %implied by the rxn formula
+            revFlagList(i) = revFlag_i;
+        end
+        %update the lower bound implied by revFlag
+        lowerBoundList(i) = revFlagList(i) * lowerBoundList(i);
+    end
     for q=1:length(metaboliteList)
         if length(metaboliteList{q})<=3 || ~strcmp(metaboliteList{q}(end-2),'[')
             %assuming the default compartment is cytoplasmic


### PR DESCRIPTION
This change aims to:
(i) set the correct rev and lb in the model if revFlag and lb are not given as input by inferring revFlag from rxn formula;
(ii) correct rev by lb or in the other way correct lb by rev if only one of them is given.
Note that if both rev and lb are given, nothing would be different from the original function output.

Detailed explanation:
In the original function, in the case that :
Only lb is given:
	modeltest = createModel({'test1'},{'t1'},{'A --> B'},[],-1) 
=> lb = -1, rev = 0, inconsistency (should be able to set rev = 1, if the given lb should overide the reversibility given in the formula)
This is because of a small typo in ln 76 ("find(lowerBoundList)<0"), corrected.

Only revFlag is given:
	modeltest = createModel({'test1'},{'t1'},{'A --> B'},0)
=> lb = -1000, rev = 0, inconsistency (should be able to set lb = 0)
Note that the inconsistency is generated by the function but not inputed by the user.

A more important thing is that if both rev and lb are not given, the function is unable to infer the reversibility from the reaction formula:
	modeltest = createModel({'test1'},{'t1'},{'A --> B'})
=> lb = -1000, rev = 1, inconsistent with the formula.
This means the user must input a correct revFlag or lb for implementing the correct reversibility.

So I propose to add several lines to:
(i) track down whether revFlag and lb are given or not (ln 45, 46, 65, 72, 77)
(ii) get the revFlag inferred from the rxn formula (ln 95)
(iii) if both lb and rev are not given, use revFlag from the reaction formula (ln 96 - 100)
(iv) if lb is not given, update the lower bound (= 0 if revFlag = 0) (ln 103)