### PR TITLE
Handle repeated metabolites in a reaction formula

### DIFF
--- a/reconstruction/addReaction.m
+++ b/reconstruction/addReaction.m
@@ -199,6 +199,25 @@ if isfield(model,'rxnECNumbers')
 end
 
 
+%Give warning and combine the coeffeicient if a metabolite appears more than once
+ [metaboliteListUnique,~,IC] = unique(metaboliteList);
+ if numel(metaboliteListUnique) ~= numel(metaboliteList)
+     warning('Repeated mets in the formula for rxn ''%s''. Combine the stoichiometry.', rxnName)
+     stoichCoeffListUnique = zeros(size(metaboliteListUnique));
+     for nMetsUnique = 1:numel(metaboliteListUnique)
+        stoichCoeffListUnique(nMetsUnique) = sum(stoichCoeffList(IC == nMetsUnique));
+     end
+     %preserve the order of metabolites:
+     metOrder = [];
+     for i = 1:numel(IC)
+         if ~ismember(IC(i), metOrder)
+             metOrder = [metOrder; IC(i)];
+         end
+     end
+     metaboliteList = metaboliteListUnique(metOrder);
+     stoichCoeffList = stoichCoeffListUnique(metOrder);
+ end
+ 
 % Figure out which metabolites are already in the model
 [isInModel,metID] = ismember(metaboliteList,model.mets);
 


### PR DESCRIPTION
The function addReaction.m would add a reaction incorrectly if the reaction formula contains multiple appearance of the same metabolite but the function does not distinguish and gives no warning so this can be a source of error. (Obviously it is not a well written formula but sometimes it happens. And this annoyed me a lot as I tried to work on some models in the literature.) 
This suggestion aims to solve the potential problem.

If we have a reaction formula with repeated appearance of a metabolite, for example:

model=struct()
model.rxns={}
model.lb=[]
model.ub=[]
model.mets={}
model.S=[]
model = addReaction(model,'test',{'ATP','AMP','ADP','ADP'},[-1 -1 1 1])
model = addReaction(model,'test2',{'ATP','ATP','ADP','ADP'},[-1 1 -1 1])

Then:
full(model.S)
ans = 
    -1     1
    -1     0
     1     1
     1     0

Therefore I suggest adding several lines to give warning if a metabolite appears more than once in the reaction formula and combine the stoichiometry to give an S correctly represent the formula.
With this change, a warning would occur and the S column would still make sense:

full(model.S)
ans = 
    -1     0
    -1     0
     2     0