### PR TITLE
Commented out all "pause(eps)" statements

### DIFF
--- a/external/m2html/mdot.m
+++ b/external/m2html/mdot.m
@@ -48,7 +48,7 @@ else
             URLnames{i}=mfiles{i}(length(options.mFiles{1})+2:end-2);
         end
     end
-    pause(eps)
+    %pause(eps)
 end
 
 fid = fopen(dotfile,'w');

--- a/fluxVariability.m
+++ b/fluxVariability.m
@@ -194,7 +194,7 @@ if PCT_status &&(~exist('parpool') || poolsize == 0)  %aka nothing is active
             %quadratic optimization
             solution = solveCobraQP(QPproblem);
             if isempty(solution.full)
-                pause(eps)
+                %pause(eps)
             end
             Vmax(:,rxnBool)=solution.full(1:nRxns,1);
         end

--- a/modelGeneration/fluxConsistency/FASTCORE/fastcc.m
+++ b/modelGeneration/fluxConsistency/FASTCORE/fastcc.m
@@ -116,7 +116,7 @@ while ~isempty( J )
             
             %sanity check
             if norm(origModel.S*vf)>epsilon/100
-                pause(eps)
+                %pause(eps)
                 fprintf('%g%s\n',epsilon/100, '= epsilon/100')
                 fprintf('%s\t%g\n','should be zero :',norm(model.S*v)) % should be zero
                 fprintf('%s\t%g\n','should be zero :',norm(origModel.S*vf)) % should be zero

--- a/modelGeneration/massBalance/pHbalanceProtons.m
+++ b/modelGeneration/massBalance/pHbalanceProtons.m
@@ -125,7 +125,7 @@ for n=1:nRxn
         warning('vonBertalanffy:pHbalanceProtons:OriginallyUnbalancedRxn', [model.rxns{n} ' reconstruction reaction not balanced for H to begin with']); % Changed from error to warning and added a message ID - Hulda
     end
     if strcmp('ACITL',model.rxns{n})
-        pause(eps)
+        %pause(eps)
     end
 
     %no change for biomass reaction or exchange reactions or imbalanced
@@ -284,7 +284,7 @@ for n=1:nRxn
                         model.S(indexHRxn1,n)=model.S(indexHRxn1,n) - deltaHBound(metCompartBool1)*model.S(metCompartBool1,n);
                         model.S(indexHRxn2,n)=model.S(indexHRxn2,n) - deltaHBound(metCompartBool2)*model.S(metCompartBool2,n);
 
-                        pause(eps)
+                        %pause(eps)
                     end
                 end
             end
@@ -298,7 +298,7 @@ for n=1:nRxn
             error(['Failure to proton balance. Reaction ' model.rxns{n} ', #' int2str(n)])
         end
         if any(isnan(model.S(:,n)))
-            pause(eps);
+            %pause(eps);
         end
     end
     if aveHbound*model.S(:,n)>(eps*1e4)

--- a/reconstruction/checkFluxConsistency.m
+++ b/reconstruction/checkFluxConsistency.m
@@ -62,6 +62,6 @@ sol = solveCobraLP(LPproblem);
 
 fluxConsistent=[];
 
-pause(eps)
+%pause(eps)
  
 

--- a/reconstruction/connectedComponents.m
+++ b/reconstruction/connectedComponents.m
@@ -245,7 +245,7 @@ for j=1:m
         end
     end
 end
-pause(eps)
+%pause(eps)
 
 if strcmp(type,'largestComponent')
     if ~exist('largest_component')

--- a/reconstruction/createModel.m
+++ b/reconstruction/createModel.m
@@ -79,7 +79,7 @@ end
 
 for i = 1 : nRxns
     if i==nRxns
-        pause(eps)
+        %pause(eps)
     end
     if ~isempty(grRuleList{i})
         if ~isempty(strfind(grRuleList{i},','))

--- a/solvers/getCobraSolverParams.m
+++ b/solvers/getCobraSolverParams.m
@@ -108,4 +108,4 @@ for i=1:length(paramNames)
         end
     end
 end
-pause(eps)
+%pause(eps)

--- a/solvers/solveCobraLP.m
+++ b/solvers/solveCobraLP.m
@@ -150,7 +150,7 @@ if nargin ~=1
                 error([varargin{i} ' is not a valid optional parameter']);
             end
         end
-        pause(eps)
+        %pause(eps)
     else
         error('solveCobraLP: Invalid number of parameters/values')
     end

--- a/solvers/solveCobraMILP.m
+++ b/solvers/solveCobraMILP.m
@@ -151,7 +151,7 @@ if nargin ~=1
                 error([varargin{i} ' is not a valid optional parameter']);
             end
         end
-        pause(eps)
+        %pause(eps)
     else
         error('solveCobraLP: Invalid number of parameters/values')
     end

--- a/testing/testModels/sbmlTestModelToMat.m
+++ b/testing/testModels/sbmlTestModelToMat.m
@@ -64,7 +64,7 @@ for k=3:length(files)
             end
         else
             if strcmp(fileName,'textbook.xml')
-                pause(eps)
+                %pause(eps)
             end
             if printLevel>1
                 fprintf('%s%s\n',fileName, [' :already parsed and compatible with readCbModel'])

--- a/topology/FR/bilinearDecomposition.m
+++ b/topology/FR/bilinearDecomposition.m
@@ -58,7 +58,7 @@ end
 x=1;
 for n=1:nRxn
 %     if n==745%83%7384
-%         pause(eps);
+%         %pause(eps);
 %     end
     substrateInd=find(F(:,n)~=0);
     productInd  =find(R(:,n)~=0);

--- a/topology/FR/checkRankFR.m
+++ b/topology/FR/checkRankFR.m
@@ -387,7 +387,7 @@ if any(~model.FRnonZeroColBool & rxnBool3) && 0
     fprintf('\n')
 end
 
-pause(eps)
+%pause(eps)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % A4=F(:,rxnBool3)+R(:,rxnBool3);%invariant to direction of reaction
@@ -547,7 +547,7 @@ if 0
     tic
     [isit,partA,partB]=isbipartite(adj2adjL(adj));
     toc
-    pause(eps)
+    %pause(eps)
 end
 
 %check rank of bilinear version
@@ -564,7 +564,7 @@ if 1
     model.Frb=Frb;
     model.Rrb=Rrb;
     model.rankBilinearFrRr=rankBilinearFrRr;
-    pause(eps)
+    %pause(eps)
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/topology/FR/testBilinearDecomposition.m
+++ b/topology/FR/testBilinearDecomposition.m
@@ -53,7 +53,7 @@ switch testS
         S2=model.S(:,[1,6]);
         S=S2(sum(S2~=0,2)~=0,:);
         disp(full(S))
-        pause(eps)
+        %pause(eps)
         end
     case 10
         load /home/rfleming/workspace/graphStoich/data/modelCollection/121114_Recon2betaModel.mat

--- a/topology/extremeRays/extremePoolDriver.m
+++ b/topology/extremeRays/extremePoolDriver.m
@@ -36,7 +36,7 @@ end
 if 1
     signPl=sign(Pl);
     nnzPl=sum(signPl,2);
-    pause(eps)
+    %pause(eps)
 end
 
 %draw certain pools within metabolites

--- a/topology/extremeRays/lrs/extremePathways.m
+++ b/topology/extremeRays/lrs/extremePathways.m
@@ -89,7 +89,7 @@ sh=0;
 %                         D*x>=(d)
 lrsInputHalfspace(A,D,filename,positivity,inequality,a,d,f,sh);
 
-pause(eps)
+%pause(eps)
 if isunix
     if ~isempty(unix('which lrs'))
         %call lrs and wait until extreme pathways have been calculated

--- a/topology/extremeRays/lrs/extremePools.m
+++ b/topology/extremeRays/lrs/extremePools.m
@@ -81,7 +81,7 @@ sh=0;
 %                         D*x>=(d)
 lrsInputHalfspace(A,D,filename,positivity,inequality,a,d,f,sh);
 
-pause(eps)
+%pause(eps)
 if isunix
     if unix('which lrs') == 0
         %call lrs and wait until extreme pathways have been calculated

--- a/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
+++ b/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
@@ -10,7 +10,7 @@ function [R,V]=lrsOutputReadExt(filename)
 
 fid=fopen(filename);
 
-pause(eps)
+%pause(eps)
 while 1
     if strcmp(fgetl(fid),'begin')
         break;
@@ -74,7 +74,7 @@ for r=1:nRows
                 scannedLine(c)=int16(scannedLine(c));
             end
         end
-        pause(eps);
+        %pause(eps);
     end
 end
 fclose(fid);

--- a/topology/extremeRays/optimalRays/greedyExtremePoolBasis.m
+++ b/topology/extremeRays/optimalRays/greedyExtremePoolBasis.m
@@ -37,7 +37,7 @@ while nPools < (nMet-rankS)
         else
             %error as reports wrong rank if zero columns
             rankB = getRankLUSOL(B(1:nPools+1,:));
-            pause(eps)
+            %pause(eps)
         end
     end
     if rankB==(nPools+1)


### PR DESCRIPTION
This is a bugfix for a problem identified in solvers/getCobraSolverParams.m.
Profiling results indicated that pause(eps) calls accounted for a large majority
of the time spent in this function (and in the program that called it). Further
discussion with Ronan Fleming confirmed that this behavior is not intentional,
and the pause statement should be removed. In this commit I remove it from all
(non-doc) files.

See here for our (brief) communication in the Google group:
https://groups.google.com/forum/#!topic/cobra-toolbox/spNdyPaPtG8

Keith Ma
Research Computing Services
Boston University
