### PR TITLE
Fixed bug with && vs. & in an if statement 

### DIFF
--- a/findTransRxns.m
+++ b/findTransRxns.m
@@ -1,4 +1,4 @@
-function [transRxns,nonTransRxns] = findTransRxns(model,inclExc, ... 
+function [transRxns,nonTransRxns,transRxnsBool] = findTransRxns(model,inclExc, ... 
     rxnInds,inclObjAsExc,irrevFlag)
 %findTransRxns identify all transport reactions in a model, which are
 %defined as reactions involved with metabolites in more than 1 compartment
@@ -27,6 +27,9 @@ function [transRxns,nonTransRxns] = findTransRxns(model,inclExc, ...
 % 
 % modified the function to work with arbitrary compartments, to accept 
 % rxnInds, & to use findExcRxns. Jonathan Dreyfuss, 10/9/12
+%
+% modified to also output a boolean vector version of transRxns. Thierry
+% Mondeel, 07/15/15
 
 if nargin < 2
     inclExc = false;
@@ -68,5 +71,6 @@ end
 rxnAbbrevs=model.rxns(rxnInds);
 % if inclExc==1, exchange rxns will have isExc==1, and should be counted as
 % transport rxns; else, all isExc will be 0.
-transRxns = rxnAbbrevs(isNonexchTrans==1 | isExc==1);
+transRxnsBool = isNonexchTrans==1 | isExc==1;
+transRxns = rxnAbbrevs(transRxnsBool);
 nonTransRxns = setdiff(rxnAbbrevs, transRxns);

--- a/printRxnFormula.m
+++ b/printRxnFormula.m
@@ -177,7 +177,7 @@ for i = 1:length(rxnAbbrList);
         end
         formulaStr = 'NA';
     end
-    if printFlag && gprFlag
+    if printFlag & gprFlag
         if (rxnID > 0) && (isfield(model,'grRules'))
             if (isempty(model.grRules{rxnID}))
                 fprintf('\t');


### PR DESCRIPTION
It is a minor issue, but the && leads to an error when calling printRxnFormula with empty arguments
 printRxnFormula(model,model.rxns,[],[],[],[],false)
the [] generates an error with &&, & behaves OK. 