### PR TITLE
Fix variable name

### DIFF
--- a/solvers/solveCobraMILP.m
+++ b/solvers/solveCobraMILP.m
@@ -77,7 +77,7 @@ else
     error('No solver found.  Run changeCobraSolver');
 end
 
-if ~isstruct(MILPproplem)
+if ~isstruct(MILPproblem)
     error('MILPproblem needs to be a strcuture array');
 end
 


### PR DESCRIPTION
Using `createTissueSpecificModel` fails with the following error:
```
>> [tissueModel, rxns] = createTissueSpecificModel(model, expdata, 1, 1, [], 'iMAT')
Undefined function or variable 'MILPproplem'.

Error in solveCobraMILP (line 80)
if ~isstruct(MILPproplem)

Error in createTissueSpecificModel (line 235)
        solution = solveCobraMILP(MILPproblem);
```

This commit hopefully fixes that issue.