### PR TITLE
Removing a for loop to speed up gpSampler

### DIFF
--- a/sampling/gpSampler.m
+++ b/sampling/gpSampler.m
@@ -122,39 +122,16 @@ end
 % ub = ub(~constInd);
 % [sampleStruct.A, sampleStruct.b, sampleStruct.csense, sampleStruct.lb, sampleStruct.ub] = deal(A, b, csense, lb, ub);
 
-[rA, dimx] = size(A);
 if (~ isfield(sampleStruct, 'internal'))
-    Anew = sparse(0, dimx);
-    Cnew = sparse(0, dimx);
-    Bnew = zeros(rA, 1);
-    Dnew = zeros(rA, 1);
-    rAnew = 0;
-    rCnew = 0 ;
-    for i = 1:size(A, 1)
-        switch csense(i)
-            case 'E'
-                rAnew = rAnew+1;
-                Anew(rAnew,:) = A(i,:);
-                Bnew(rAnew,:) = b(i);
-
-            case 'G'
-                rCnew=rCnew+1;
-                Cnew(rCnew,:) = -A(i,:);
-                Dnew(rCnew,:) = -b(i);
-            case 'L'
-                rCnew=rCnew+1;
-                Cnew(rCnew,:) = A(i,:);
-                Dnew(rCnew,:) = b(i);
-            otherwise
-                display ('whoops.  csense can only contain E, G, or L')
-                return;
-        end
+    Anew = A(csense == 'E', :);
+    Bnew = b(csense == 'E', :);
+    Cnew = [-A(csense == 'G', :); A(csense == 'L', :)];
+    Dnew = [-b(csense == 'G'); b(csense == 'L')];
+    if any(~(csense == 'E' | csense == 'G' | csense == 'L'))
+        display('bias does not have a method set');
+        return;
     end
     
-    %Anew = Anew(1:rAnew,:);
-    Bnew = Bnew(1:rAnew,:);
-    Dnew = Dnew(1:rCnew,:);
-
     % calculate offset
     if find(Bnew ~= 0)
         offset = Anew\Bnew;

--- a/sampling/gpSampler.m
+++ b/sampling/gpSampler.m
@@ -123,14 +123,18 @@ end
 % [sampleStruct.A, sampleStruct.b, sampleStruct.csense, sampleStruct.lb, sampleStruct.ub] = deal(A, b, csense, lb, ub);
 
 if (~ isfield(sampleStruct, 'internal'))
-    Anew = A(csense == 'E', :);
-    Bnew = b(csense == 'E', :);
-    Cnew = [-A(csense == 'G', :); A(csense == 'L', :)];
-    Dnew = [-b(csense == 'G'); b(csense == 'L')];
     if any(~(csense == 'E' | csense == 'G' | csense == 'L'))
-        display('whoops.  csense can only contain E, G, or L');
+        display ('whoops.  csense can only contain E, G, or L')
         return;
     end
+    Anew = A(csense == 'E', :);
+    Bnew = b(csense == 'E');
+    Cnew = sparse(sum(csense ~= 'E'), size(A,2));
+    Cnew(csense(csense ~= 'E') == 'G', :) = -A(csense == 'G', :);
+    Cnew(csense(csense ~= 'E') == 'L', :) = A(csense == 'L', :);
+    Dnew = zeros(sum(csense ~= 'E'), 1);    
+    Dnew(csense(csense ~= 'E') == 'G') = -b(csense == 'G');
+    Dnew(csense(csense ~= 'E') == 'L') = b(csense == 'L');
     
     % calculate offset
     if find(Bnew ~= 0)

--- a/sampling/gpSampler.m
+++ b/sampling/gpSampler.m
@@ -128,7 +128,7 @@ if (~ isfield(sampleStruct, 'internal'))
     Cnew = [-A(csense == 'G', :); A(csense == 'L', :)];
     Dnew = [-b(csense == 'G'); b(csense == 'L')];
     if any(~(csense == 'E' | csense == 'G' | csense == 'L'))
-        display('bias does not have a method set');
+        display('whoops.  csense can only contain E, G, or L');
         return;
     end
     


### PR DESCRIPTION
The for loop here with the vectors whose sizes are not predesignated makes the computation very slow when the size goes up. For models of several thousand metabolites, this can take up to 10 seconds while the proposed code takes >0.01. They produce exactly the same matrix Anew, Bnew and vector Cnew, Dnew and the check of input 'csense'. The present and the proposed codes have been tested on randomly generated matrix, vector and csense and they yield the same output.