### PR TITLE
directParams can overwrite gurobi5 default params when using MILP

### DIFF
--- a/optimizeCbModel.m
+++ b/optimizeCbModel.m
@@ -238,6 +238,7 @@ elseif length(minNorm)> 1 || minNorm > 0
         minNorm=ones(nRxns,1)*minNorm;
     end
     LPproblem.F = spdiags(minNorm,0,nRxns,nRxns);
+    LPproblem.osense=1;
     
     if allowLoops
         %quadratic optimization will get rid of the loops unless you are maximizing a flux which is

--- a/solvers/solveCobraMILP.m
+++ b/solvers/solveCobraMILP.m
@@ -355,6 +355,7 @@ switch solver
         % http://www.gurobi.com/html/academic.html
         resultgurobi = struct('x',[],'objval',[]);
         MILPproblem.A = deal(sparse(MILPproblem.A));
+
         clear params            % Use the default parameter settings
         
         if solverParams.printLevel == 0 
@@ -391,6 +392,14 @@ switch solver
             MILPproblem.osense = 'max';
         else
             MILPproblem.osense = 'min';
+        end
+
+        %overwrite default params with directParams
+        if parametersStructureFlag
+            fieldNames = fieldnames(directParamStruct);
+            for i = 1:size(fieldNames,1)
+                params.(fieldNames{i}) = directParamStruct.(fieldNames{i});
+            end
         end
         
         MILPproblem.vtype = vartype;

--- a/solvers/solveCobraQP.m
+++ b/solvers/solveCobraQP.m
@@ -364,12 +364,16 @@ switch solver
         % http://www.gurobi.com/html/academic.html
         resultgurobi = struct('x',[],'objval',[],'pi',[]);
         clear params            % Use the default parameter settings
-        if printLevel == 0 
-            params.OutputFlag = 0;
-            params.DisplayInterval = 1;
-        else
-            params.OutputFlag = 1;
-            params.DisplayInterval = 5;
+        switch printLevel
+            case 0
+                params.OutputFlag = 0;
+                params.DisplayInterval = 1;
+            case printLevel>1
+                params.OutputFlag = 1;
+                params.DisplayInterval = 5;
+            otherwise
+                params.OutputFlag = 0;
+                params.DisplayInterval = 1;
         end
 
         params.Method = 0;    %-1 = automatic, 0 = primal simplex, 1 = dual simplex, 2 = barrier, 3 = concurrent, 4 = deterministic concurrent


### PR DESCRIPTION
This branch adds the possibility to use direct parameters passed to the gurobi5 solver.

A bug is fixed in  optimizeCbModel: When second optimization problem was invoked for instance through singleGeneDeletion(model,'MOMA'), it caused an error, because the osense flag was not set correctly. It was maximizing the fluxes instead of minimizng.

The default OutputFlag of gurobi5 solver in qp problems is set to zero.

András Hartmann