### PR TITLE
Corrected charge assignment

### DIFF
--- a/extractSubNetwork.m
+++ b/extractSubNetwork.m
@@ -79,5 +79,5 @@ if (isfield(model,'rules'))
     subModel.rules = model.rules(selRxns);
 end
 if (isfield(model,'metCharge'))
-    subModel.metCharge = model.metCharge(selRxns);
+    subModel.metCharge = model.metCharge(selMets);
 end

--- a/extractSubNetwork.m
+++ b/extractSubNetwork.m
@@ -55,7 +55,7 @@ end
 if (isfield(model,'ub'))
     subModel.ub = model.ub(selRxns);
 end
-if (isfield(model,'r'))
+if (isfield(model,'c'))
     subModel.c = model.c(selRxns);
 end
 if (isfield(model,'genes'))


### PR DESCRIPTION
Corrections to extractSubNetwork.m

Corrected charge assignment to be based on selected metabolites (selMets) rather than selected reactions (selRxns).  It had been throwing an index out of range error, due to the difference in number of reactions and metabolites.

Also corrected assignment of 'c' to submodel.