### PR TITLE
Small fix in OptKnock and solveCobraMILP

### DIFF
--- a/design/OptKnock.m
+++ b/design/OptKnock.m
@@ -81,6 +81,7 @@ if ~exist('constrOpt','var')
     constrOpt.rxnInd = [];
     constrOpt.values = [];
     constrOpt.sense = [];
+    constrOpt.rxnList = [];
 end
 
 if (nargin < 5)

--- a/solvers/solveCobraMILP.m
+++ b/solvers/solveCobraMILP.m
@@ -417,6 +417,9 @@ switch solver
            solStat = 2; % Unbounded
         elseif strcmp(resultgurobi.status,'INF_OR_UNBD')
            solStat = 0; % Gurobi reports infeasible *or* unbounded
+        elseif strcmp(resultgurobi.status,'SUBOPTIMAL')
+           solStat = -1; % Suboptimal solution
+           [x,f] = deal(resultgurobi.x,resultgurobi.objval);
         else
            solStat = -1; % Solution not optimal or solver problem
         end


### PR DESCRIPTION
- OptKnock can run without constrOpt parameter

- solveCobraMILP returns suboptimal value from gurobi if no global solution found.
This can be useful at some cases. Note that the status is still -1 in case of SUBOPTIMAL solution.