### PR TITLE
Bugfix for glpk solver unsuppressed output. Bugfix for createTissueSpecificModel to work with geneids containing some letters.

### DIFF
--- a/findRxnsFromGenes.m
+++ b/findRxnsFromGenes.m
@@ -1,4 +1,4 @@
-function [results ListResults] = findRxnsFromGenes(model, genes, humanFlag,ListResultsFlag)
+function [results ListResults] = findRxnsFromGenes(model, genes, ListResultsFlag)
 %findRxnsFromGenes print every reaction associated with a gene of interest
 %
 % [results ListResults] = findRxnsFromGenes(model, genes, humanFlag,ListResultsFlag)
@@ -9,7 +9,6 @@ function [results ListResults] = findRxnsFromGenes(model, genes, humanFlag,ListR
 %                       genes for which rxns are desired.
 %
 %OPTIONAL INPUTS
-% humanFlag             1 if using Human Recon  (Default = 0)
 % ListResultsFlag       1 if you want to output ListResults (Default = 0)
 %
 %OPUTPUTS
@@ -22,9 +21,8 @@ function [results ListResults] = findRxnsFromGenes(model, genes, humanFlag,ListR
 % edited 04/05/09 (MUCH faster now -- NL)
 % edited 06/11/10 (yet even faster now -- NL)
 
-if nargin< 3
-    humanFlag = 0;
-    ListResultsFlag = 0;
+if nargin<3
+	ListResultsFlag = 0;
 end
 
 if ~iscell(genes)
@@ -76,10 +74,17 @@ for i = 1:length(GeneID)
             if isempty(results)
                 results = struct;
             end
-            if humanFlag == 1
-                tempGene = cat(2,'gene_',genes{i});
+			%Ensures that geneids can become field names for structures
+            if regexp(genes{i},'[^a-zA-Z0-9_]')
+				tempGene = regexprep(genes{i},'[^a-zA-Z0-9_]','_')
             else tempGene = genes{i};
             end
+			
+			%If gene starts with a digit it cannot be a field name, prepend gene_ to correct
+			if regexp(tempGene,'^\d')
+				tempGene = cat(2,'gene_',tempGene);
+			end
+			
             results.(tempGene){k,1} = model.rxns(Ind_rxns(j));
             results.(tempGene)(k,2) = printRxnFormula(model,model.rxns(Ind_rxns(j)),0);
             if isfield(model,'subSystems')
@@ -114,4 +119,3 @@ else
     end
     
 end
-

--- a/reconstruction/createTissueSpecificModel.m
+++ b/reconstruction/createTissueSpecificModel.m
@@ -483,9 +483,11 @@ cnt = 1;
 for i = 1:length(model.rxns)
     if length(model.grRules{i}) > 1
         % Parsing each reactions gpr
-        [parsing{1,1},parsing{2,1}] = strtok(model.grRules{i},'or');
+		%Replace and/or which are surrounded by whitespace (e.g. not within a gene id) with the symbols &/| to make strtok parsing of geneids containing the letters "adnor" possible.
+		grRuleIn=regexprep(regexprep(model.grRules{i},'\s+or\s+','|'),'\s+and\s+','&');
+        [parsing{1,1},parsing{2,1}] = strtok(grRuleIn,'|');
         for j = 2:1000
-            [parsing{j,1},parsing{j+1,1}] = strtok(parsing{j,1},'or');
+            [parsing{j,1},parsing{j+1,1}] = strtok(parsing{j,1},'|');
             if isempty(parsing{j+1,1})==1
                 break
             end
@@ -493,7 +495,7 @@ for i = 1:length(model.rxns)
         
         for j = 1:length(parsing)
             for k = 1:1000
-                [parsing{j,k},parsing{j,k+1}] = strtok(parsing{j,k},'and');
+                [parsing{j,k},parsing{j,k+1}] = strtok(parsing{j,k},'&');
                 if isempty(parsing{j,k+1})==1
                     break
                 end

--- a/solvers/solveCobraLP.m
+++ b/solvers/solveCobraLP.m
@@ -121,7 +121,7 @@ if nargin ~=1
                     parameters.(varargin{i}) = varargin{i+1};
                 end
                 if strcmp(varargin{i},'solver');
-                    solver=varargin{i+1}
+                    solver=varargin{i+1};
                 end 
             else
                 error([varargin{i} ' is not a valid optional parameter']);


### PR DESCRIPTION
If using fluxVariability function with glpk solver, solver name is output repeatedly due to unsuppressed line in solveCobraLP.m.

The extractGPRs function in createTissueSpecificModel would not work if
geneids which contained containing any of the following letters: "adnor"
as the strtok function splits strings upon encountering any delimiter.
From the documentation for strtok:

If the delimiter input specifies more than one character, MATLAB® treats
each character as a separate delimiter; it does not treat the multiple
characters as a delimiting string.

Replacing and/or with &/| lets strtok parsing occur normally.