### PR TITLE
Update to findRxnsFromMets

### DIFF
--- a/findRxnsFromMets.m
+++ b/findRxnsFromMets.m
@@ -21,24 +21,23 @@ function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, varargin)
 % rxnFormulaList    Reaction formulas coresponding to rxnList
 %
 %Richard Que (08/12/2010)
-%Richard Que (08/12/2010)
-% Almut Heinken (09/25/2015)- made change so formulas are not printed if reaction list 
+%Almut Heinken (09/25/2015)- made change so formulas are not printed if reaction list 
 %                             is empty.
-% Thomas Pfau (21/1/2016) - Additional Options, and minimal speedup of the indexing, 
+%Thomas Pfau (21/1/2016) - Additional Options, and minimal speedup of the indexing, 
 %                           also updated behaviour of verbFlag to accurately reflect the description.
 % 
 
 verbFlag = false;
 containsAll = false;
 
-if mod(numel(varargin), 2) == 1 % the first argument has to be verbFlag, the remainder Argument/Value pairs
+if mod(numel(varargin), 2) == 1 % the first argument has to be verbFlag, the remaining are property/value pairs
     verbFlag = varargin{1};
     if numel(varargin) > 1
         varargin = varargin(2:end);
     end
 end
 
-if numel(varargin) > 1 % we have already checked whether we have a verbFlag, now we can go for Argument value pairs
+if numel(varargin) > 1 % we have already checked whether we have a verbFlag, now we can go for property/value pairs
     for i=1:2:numel(varargin)
         key = varargin{i};
         value = varargin{i+1};

--- a/findRxnsFromMets.m
+++ b/findRxnsFromMets.m
@@ -1,4 +1,4 @@
-function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, verbFlag)
+function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, varargin)
 %findRxnsFromMets returns a list of reactions in which at least one
 %metabolite listed in metList participates.
 %
@@ -10,25 +10,62 @@ function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, verbFlag)
 %
 %OPTIONAL INPUT
 % verbFlag          Print reaction formulas to screen (Default = false)
+% Property/Value    Allowed Properties are: 
+%                   containsAll (True/False) - If true only reactions
+%                   containing all metabolites in metList are returned
+%                   verbFlag (True/False) as Above, will overwrite a
+%                   verbFlag set individually
 %
 %OUTPUTS
 % rxnList           List of reactions
 % rxnFormulaList    Reaction formulas coresponding to rxnList
 %
 %Richard Que (08/12/2010)
-% Almut Heinken (09/25/2015)- made change so formulas are not printed if reaction list
-% is empty.
+%Richard Que (08/12/2010)
+% Almut Heinken (09/25/2015)- made change so formulas are not printed if reaction list 
+%                             is empty.
+% Thomas Pfau (21/1/2016) - Additional Options, and minimal speedup of the indexing, 
+%                           also updated behaviour of verbFlag to accurately reflect description.
+% 
 
-if nargin < 3 || isempty(verbFlag), verbFlag = false; end
+verbFlag = false;
+containsAll = false;
+
+if mod(numel(varargin), 2) == 1 % the first argument has to be verbFlag, the remainder Argument/Value pairs
+    verbFlag = varargin{1};
+    if numel(varargin) > 1
+        varargin = varargin(2:end);
+    end
+end
+
+if numel(varargin) > 1 % we have already checked whether we have a verbFlag, now we can go for Argument value pairs
+    for i=1:2:numel(varargin)
+        key = varargin{i};
+        value = varargin{i+1};
+        switch key
+            case 'containsAll'
+                containsAll = value;
+            case 'verbFlag' 
+                verbFlag = value;
+            otherwise
+                msg = sprintf('Unexpected key %s',key)
+                error(msg);
+        end
+                
+    end
+end
 
 %Find met indicies
-[isMet index] = ismember(metList,model.mets);
-index = index(isMet);
-%expand rxns list for logical indexing
-rxns = repmat(model.rxns,1,length(index));
-%find reactions
-rxnList = unique(rxns(model.S(index,:)'~=0));
-if nargout > 1
+index = ismember(model.mets,metList);
+if containsAll
+   rxnList = model.rxns(sum(model.S(index,:) ~= 0) == numel(metList));   
+else
+    %rxns = repmat(model.rxns,1,length(index));
+    %find reactions i.e. all columns with at least one non zero value
+    rxnList = model.rxns(sum(model.S(index,:)~=0) > 0);
+end
+
+if verbFlag
     if ~isempty(rxnList)
     rxnFormulaList = printRxnFormula(model,rxnList,verbFlag);
     else

--- a/findRxnsFromMets.m
+++ b/findRxnsFromMets.m
@@ -25,7 +25,7 @@ function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, varargin)
 % Almut Heinken (09/25/2015)- made change so formulas are not printed if reaction list 
 %                             is empty.
 % Thomas Pfau (21/1/2016) - Additional Options, and minimal speedup of the indexing, 
-%                           also updated behaviour of verbFlag to accurately reflect description.
+%                           also updated behaviour of verbFlag to accurately reflect the description.
 % 
 
 verbFlag = false;
@@ -65,9 +65,9 @@ else
     rxnList = model.rxns(sum(model.S(index,:)~=0) > 0);
 end
 
-if verbFlag
+if (nargout > 1) | verbFlag
     if ~isempty(rxnList)
-    rxnFormulaList = printRxnFormula(model,rxnList,verbFlag);
+        rxnFormulaList = printRxnFormula(model,rxnList,verbFlag);
     else
         rxnFormulaList={};
     end

--- a/findRxnsFromMets.m
+++ b/findRxnsFromMets.m
@@ -29,6 +29,10 @@ function [rxnList, rxnFormulaList] = findRxnsFromMets(model, metList, varargin)
 
 verbFlag = false;
 containsAll = false;
+if isa(metList,'char')
+    metList = {metList};
+end
+    
 
 if mod(numel(varargin), 2) == 1 % the first argument has to be verbFlag, the remaining are property/value pairs
     verbFlag = varargin{1};
@@ -57,11 +61,11 @@ end
 %Find met indicies
 index = ismember(model.mets,metList);
 if containsAll
-   rxnList = model.rxns(sum(model.S(index,:) ~= 0) == numel(metList));   
+   rxnList = model.rxns(sum(model.S(index,:) ~= 0,1) == numel(metList));   
 else
     %rxns = repmat(model.rxns,1,length(index));
     %find reactions i.e. all columns with at least one non zero value
-    rxnList = model.rxns(sum(model.S(index,:)~=0) > 0);
+    rxnList = model.rxns(sum(model.S(index,:)~=0,1) > 0);
 end
 
 if (nargout > 1) | verbFlag


### PR DESCRIPTION
Updated findRxnsFromMets to accurately reflect the verboseFlag description (printing the reactions, irrespective of number of outputs) and added options for Property/Value pairs.
In addition, I added a new property, allowing the selection of reactions which have to contain all of the provided metabolites.
The function is still compatible with any previous code (with the exception of actually providing output if verboseFlag is active irrespective of the number of requested outputs).
