### PR TITLE
Update addReaction.m

### DIFF
--- a/reconstruction/addReaction.m
+++ b/reconstruction/addReaction.m
@@ -202,7 +202,19 @@ end
 if isfield(model,'rxnECNumbers')
     model.rxnECNumbers{rxnID,1} = '';
 end
-
+% 17/02/2016 Update 4 additional fields that are present in Recon 2
+if isfield(model,'rxnKeggID')
+    model.rxnKeggID{rxnID,1} = '';
+end
+if isfield(model,'rxnConfidenceEcoIDA')
+    model.rxnConfidenceEcoIDA{rxnID,1} = '';
+end
+if isfield(model,'rxnConfidenceScores')
+    model.rxnConfidenceScores{rxnID,1} = '';
+end
+if isfield(model,'rxnsboTerm')
+    model.rxnsboTerm{rxnID,1} = '';
+end
 
 %Give warning and combine the coeffeicient if a metabolite appears more than once
  [metaboliteListUnique,~,IC] = unique(metaboliteList);
@@ -248,20 +260,29 @@ for i = 1:length(metaboliteList)
             warning(['Metabolite formula for ' metaboliteList{i} ' set to ''''']);
 %             model.metFormulas(end) = cellstr(input('Enter metabolite chemical formula, if available:', 's'));
         end
-        if isfield(model,'metChEBIID')
-            model.metChEBIID{end+1,1} = '';
+        if isfield(model,'metCHEBIID')
+            model.metCHEBIID{end+1,1} = ''; %changed to match Recon 2 nomenclature 
         end
-        if isfield(model,'metKEGGID')
-            model.metKEGGID{end+1,1} = '';
+        if isfield(model,'metKeggID')
+            model.metKeggID{end+1,1} = ''; %changed to match Recon 2 nomenclature
         end
         if isfield(model,'metPubChemID')
             model.metPubChemID{end+1,1} = '';
         end
-        if isfield(model,'metInChIString')
-            model.metInChIString{end+1,1} = '';
+        if isfield(model,'metInchiString')
+            model.metInchiString{end+1,1} = ''; %changed to match Recon 2 nomenclature
         end
         if isfield(model,'metCharge')
             model.metCharge(end+1,1) = 0;
+        end
+        if isfield(model,'metHepatoNetID')
+            model.metHepatoNetID{end+1,1} = ''; %added
+        end
+        if isfield(model,'metEHMNID')
+            model.metEHMNID{end+1,1} = ''; %added
+        end
+        if isfield(model,'metHMDB')
+            model.metHMDB{end+1,1} = ''; %added
         end
     end
 end


### PR DESCRIPTION
I encountered the issue with addReaction.m recently in my work with Recon 2. After modifying the model (used removeRxns.m and addReaction.m scripts) I couldn't use the removeRxns.m function anymore as it complained about index exceeding matrix dimensions. Turns out that removeRxns.m were deleting all the information from all the fields in respect to the removed reaction, however addReaction.m did not update certain reaction-related fields in the model (namely: rxnKeggID, rxnConfidenceEcoIDA, rxnConfidenceScores and rxnsboTerm). The same was true for some metabolite-related fields (metCHEBIID, metKeggID, metInchiString, metHepatoNetID, metEHMNID and metHMDB). I have fixed it by including this fields in the if isfield ..end loops in addReaction.m