### PR TITLE
Update convertToIrreversible.m

### DIFF
--- a/convertToIrreversible.m
+++ b/convertToIrreversible.m
@@ -132,6 +132,7 @@ if isfield(model,'genes')
     genemtxtranspose = model.rxnGeneMat';
     modelIrrev.rxnGeneMat = genemtxtranspose(:,irrev2rev)';
     modelIrrev.rules = model.rules(irrev2rev);
+    modelIrrev.grRules = model.grRules(irrev2rev); %added to allow model reduction 18/02/2016 Agnieszka
 end
 modelIrrev.reversibleModel = false;
 


### PR DESCRIPTION
When I wanted to sample my model I needed to first make it irreversible. However after applying convertToIrreversible function (which worked OK) I couldn't use the obtained model_Irrev for the sampleCbModel.m as it didn't have the grRules field in it. I updated the convertToIrreversible.m function to added that field to the newly created model.