### PR TITLE
SBML level 3 without FBC

### DIFF
--- a/io/writeCbToSBMLfbc.m
+++ b/io/writeCbToSBMLfbc.m
@@ -1,30 +1,21 @@
-function writeCbToSBMLfbc(model,fileName,fbc)
+function writeCbToSBMLfbc(model,fileName)
 %
 % Write a COBRA model to a SBML with FBC file
 %
 %INPUTS
 % model         COBRA model structure fileName      
 %
-%OPTIONAL INPUT
-%
-% fileName      Name of xml file output
-% fbc           'true' - strictly export the COBRA model strcuture into a
-%               FBCv2 compliant format (Note: the COBRA model structure
-%               should be produced from a FBCv2 file)
-%               
-%
 % Longfei Mao 25/09/2015
 %
 if nargin<2;
     fileName='sbmlModel' % If no file name is provided, a default name 'sbmlModel' is used.
 end
-if nargin<3;
-    fbc=''; % By default the format conversion is not run in the strict mode. 
-end
+
 modelSBML=convertCobraToSBML(model,3,1,[],[],[],'true');
-if isfield(model,'fbc2str')||strcmp(fbc,'true');
+try
     convertCobra2Fbc2(modelSBML,fileName); % Correct any discrepancies and ensure all FBC-related information are to be written to the SBML file.  
-else
-    OutputSBML(modelSBML, fileName);
+catch
+    disp('conversion to SBML3+fbc2 failed, falling back to SBML2');
+    writeCbToSBML(model,fileName);
 end
 


### PR DESCRIPTION
I received a file written by the COBRA toolbox with SBML level 3 without FBC v2, which sounds like a bug to me. Looking at ```io/writeCbToSBMLfbc.m``` it seems like this type of file can get written pretty easily by the COBRA toolbox, so this patch removes that.

There are already so many different SBML formats for COBRA models, and we shouldn't have yet another one floating around.

I think it should just be:
 - SBML2 without fbc
 - SBML3 with fbc

Having sbml3 without fbc creates just another SBML variant that will be floating around until the tend of time. I'm also adding a warning into cobrapy whenever these types of models are detected.