### PR TITLE
first link changed to http://opencobra.github.io/cobratoolbox/

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@ body {
       </hgroup>
       <!--<p class="entry-content"> -->
       <p class="letter"> Dear All,</p>
-      <p class="letter"> As of Jan 30, 2015, I am now the Lead Developer for the COBRA Toolbox. I and others have already begun bringing the COBRA Toolbox up to date and the latest version is and will henceforth be available here: (<a href="https://github.com/opencobra/cobratoolbox/" target="new"> http://opencobra.github.io/cobratoolbox/ </a>). Older, but more stable versions are available here: (<a href="https://github.com/opencobra/cobratoolbox/archive/master.zip" target="new"> https://github.com/opencobra/cobratoolbox/archive/master.zip </a>) </p>
+      <p class="letter"> As of Jan 30, 2015, I am now the Lead Developer for the COBRA Toolbox. I and others have already begun bringing the COBRA Toolbox up to date and the latest version is and will henceforth be available here: (<a href="https://github.com/opencobra/cobratoolbox/" target="new"> https://github.com/opencobra/cobratoolbox/ </a>). Older, but more stable versions are available here: (<a href="https://github.com/opencobra/cobratoolbox/archive/master.zip" target="new"> https://github.com/opencobra/cobratoolbox/archive/master.zip </a>) </p>
       <p class="letter"> Everyone is encouraged to work together to improve the latest version of the COBRA Toolbox by cloning the master version available here:
         https://github.com/opencobra </p>
       <p class="letter"> Instructions on how to use git are available here (<a href="http://gitref.org/" target="new"> http://gitref.org/ </a> for *nix users and <a href="https://windows.github.com" target="new">https://windows.github.com</a> for windows users). </p>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ body {
             $("a[rel^='prettyPhoto']").prettyPhoto();
           });
         </script>
-<!--The following script tag downloads a font from the Adobe Edge Web Fonts server for use within the web page. We recommend that you do not modify it.-->
+<!--The following script tag downloads a font from the Adobe Edge Web Fonts server for use within the web page.
 <script>var __adobewebfontsappname__="dreamweaver"</script>
 <script src="//use.edgefonts.net/calligraffitti:n4:default;crafty-girls:n4:default.js" type="text/javascript"></script>
 </head>
@@ -54,10 +54,10 @@ body {
   <div class="navbar navbar-inverse navbar-fixed-top">
     <div class="navbar-inner">
       <div class="container">
-        <!-- Responsive Navbar Part 1: Button for triggering responsive navbar (not covered in tutorial). Include responsive CSS to utilize. -->
+
         <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse"> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </a>
         <h1 class="brand"><a href="#top">COBRA Toolbox</a></h1>
-        <!-- Responsive Navbar Part 2: Place all navbar contents you want collapsed withing .navbar-collapse.collapse. -->
+
         <nav class="pull-right nav-collapse collapse">
           <ul id="menu-main" class="nav">
             <li><a title="a letter" href="#a letter"> Dr Fleming's letter </a></li>
@@ -111,7 +111,7 @@ body {
       </hgroup>
       <!--<p class="entry-content"> -->
       <p class="letter"> Dear All,</p>
-      <p class="letter"> As of Jan 30, 2015, I am now the Lead Developer for the COBRA Toolbox. I and others have already begun bringing the COBRA Toolbox up to date and the latest version is and will henceforth be available here: (<a href="http://opencobra.github.io/cobratoolbox" target="new"> http://opencobra.github.io/cobratoolbox/ </a>). Older, but more stable versions are available here: (<a href="https://github.com/opencobra/cobratoolbox/archive/master.zip" target="new"> https://github.com/opencobra/cobratoolbox/archive/master.zip </a>) </p>
+      <p class="letter"> As of Jan 30, 2015, I am now the Lead Developer for the COBRA Toolbox. I and others have already begun bringing the COBRA Toolbox up to date and the latest version is and will henceforth be available here: (<a href="https://github.com/opencobra/cobratoolbox/" target="new"> http://opencobra.github.io/cobratoolbox/ </a>). Older, but more stable versions are available here: (<a href="https://github.com/opencobra/cobratoolbox/archive/master.zip" target="new"> https://github.com/opencobra/cobratoolbox/archive/master.zip </a>) </p>
       <p class="letter"> Everyone is encouraged to work together to improve the latest version of the COBRA Toolbox by cloning the master version available here:
         https://github.com/opencobra </p>
       <p class="letter"> Instructions on how to use git are available here (<a href="http://gitref.org/" target="new"> http://gitref.org/ </a> for *nix users and <a href="https://windows.github.com" target="new">https://windows.github.com</a> for windows users). </p>


### PR DESCRIPTION
Ronan's instruction: "change the http://opencobra.github.io/cobratoolbox/ page so that the first link is to the git page"