### PR TITLE
changeRxnBounds, changing multiple rxn bounds at once

### DIFF
--- a/changeRxnBounds.m
+++ b/changeRxnBounds.m
@@ -60,10 +60,10 @@ else
                 case 'u'
                     model.ub(rxnID(i)) = value(i);
                 case 'l'
-                    model.lb(rxnID) = value(i);
+                    model.lb(rxnID(i)) = value(i);
                 case 'b'
-                    model.lb(rxnID) = value(i);
-                    model.ub(rxnID) = value(i);
+                    model.lb(rxnID(i)) = value(i);
+                    model.ub(rxnID(i)) = value(i);
             end
         end
     else


### PR DESCRIPTION
changeRxnBounds has the option to input multiple reactions and specify separate bound values for each of them. The part that loops through the reaction list is missing the index specification for the 'l' and 'b' cases. When there's no index specified, the 'l' and/or 'u' bounds of all the reactions in the list are put to the same value, regardless of the specified input.