### PR TITLE
FastCore compatability with original code

### DIFF
--- a/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
+++ b/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
@@ -23,7 +23,10 @@ function A = fastcore(C, model, epsilon, printlevel)
 % (c) Nikos Vlassis, Maria Pires Pacheco, Thomas Sauter, 2013
 %     LCSB / LSRU, University of Luxembourg
 
-tic
+if ~exist('printLevel','var')
+    %For Compatability with the original fastcore syntax
+    printLevel = 1;
+end
 
 N = 1:numel(model.rxns);
 %reactions assumed to be irreversible in forward direction


### PR DESCRIPTION
The Original Fastcore code had only 3 arguments, the COBRA code contains 4, making programs working with the original code incompatible.
This should fix the problem. 