### PR TITLE
FastCore compatability with original code

### DIFF
--- a/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
+++ b/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
@@ -23,7 +23,10 @@ function A = fastcore(C, model, epsilon, printlevel)
 % (c) Nikos Vlassis, Maria Pires Pacheco, Thomas Sauter, 2013
 %     LCSB / LSRU, University of Luxembourg
 
-tic
+if ~exist('printLevel','var')
+    %For Compatability with the original fastcore syntax
+    printLevel = 1;
+end
 
 N = 1:numel(model.rxns);
 %reactions assumed to be irreversible in forward direction

--- a/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
+++ b/modelGeneration/fluxConsistency/FASTCORE/fastcore.m
@@ -25,7 +25,7 @@ function A = fastcore(C, model, epsilon, printlevel)
 
 if ~exist('printLevel','var')
     %For Compatability with the original fastcore syntax
-    printLevel = 1;
+    printlevel = 1;
 end
 
 N = 1:numel(model.rxns);


### PR DESCRIPTION
The original fastcore algorithm used three arguments. Cobra added a printlevel flag, that was not optional, making the cobra code incompatible with the original code.
