### PR TITLE
Modifying the behaviour of addSinkReaction

### DIFF
--- a/metabotools/setMediumConstraints.m
+++ b/metabotools/setMediumConstraints.m
@@ -1,39 +1,39 @@
 function [modelMedium,basisMedium] = setMediumConstraints(model, set_inf, current_inf, medium_composition, met_Conc_mM, cellConc, t, cellWeight, mediumCompounds, mediumCompounds_lb, customizedConstraints, customizedConstraints_ub, customizedConstraints_lb, close_exchanges)
 
-% Calculates and sets constraints according to medium composition in mM. Is based on the function Conc2Rate. Returns a model with constraints.
-%
+% Calculates and sets constraints according to medium composition in mM. Is 
+% based on the function Conc2Rate. Returns a model with new constraints.
 %  INPUTS
 %
-%       model                     Metabolic model (Recon)
-%       current_inf               Models can have differently defined infinite constraints, e.g., 500
-%       set_inf                   New value for infinite constraints, e.g., 1000
-%       medium_composition        Vector of exchange reactions of metabolites in the cell medium, e.g., RPMI medium
-%       met_Conc_mM               Vector of the same length of 'Exchanges', providing the concentration (in Mm) of each metabolite in the respective row
-%       cellConc                  Cell concentration (cells per 1 ml)
-%       t                         Time in hours (in hours)
-%       cellWeight                Cellular dry weight
+%   model                     Global metabolic model (Recon)
+%   current_inf               Models can have differently defined infinite constraints, e.g., 500
+%   set_inf                   New value for infinite constraints, e.g., 1000
+%   medium_composition        Vector of exchange reactions of metabolites in the cell medium, e.g., RPMI medium
+%   met_Conc_mM               Vector of the same length of 'Exchanges', providing the concentration (in Mm) of each metabolite in the respective row
+%   cellConc                  Cell concentration (cells per 1 ml)
+%   t                         Time in hours (in hours)
+%   cellWeight                gDW per cell
 %
 %
-%       mediumCompounds           Composition of basic medium, which are usually not defined in the composition of the medium and need to be defined in addition.
-%       mediumCompounds_lb        Lower bound applied for all mediumCompounds (the same for all)
+%   mediumCompounds           Composition of basic medium, which are
+%                             usually not defined in the composition of the medium and need to be defined in addition.
+%   mediumCompounds_lb        lower bound applied for all mediumCompounds (the same for all)
 %
 %
 % optional inputs
 %
-%       customizedConstraints     If additional constraints should be set apart from the basic medium and medium composition, e.g. 'EX_o2(e)'
-%       customizedConstraints_lb  Vecor of lower bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
-%       customizedConstraints_ub  Vecor of upper bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
-%       close_exchanges           If exchange reactions except those specified should be closed (Defauld = 1) 1= close exchanges, 0=no
+%   customizedConstraints     If additional constraints should be set apart from the basic medium and medium composition, e.g. 'EX_o2(e)'
+%   customizedConstraints_lb  Vecor of lower bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
+%   customizedConstraints_ub  Vecor of upper bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
+%   close_exchanges           If exchange reactions except those specified should be closed (Defauld = 1)1= close exchanges, 0=no
 %
 %  OUTPUT
 %
-%       modelMedium              Model with set constraints, all exchanges not specified in  mediumCompounds, ions or customizedConstraints are set to secretion only
-%       basisMedium              Vector of adjusted constraints, for reference such that these constraints are not overwritten at a later stage
+%    modelMedium              Model with set constraints, all exchanges not specified in  mediumCompounds, ions or customizedConstraints are set to secretion only
+%    basisMedium              Vector of adjusted constraints, for reference such that these constraints are not overwritten at a later stage
 %
 % Please note that if metabolites of Medium_composition and mediumCompounds overlap, the constraints of the Medium_composition will
-% be set to 0 in the output model. The function depends on the functions conc2Rate, changeRxnBounds.
+% be set to 0 in the output model. The function depends on the functions Conc2Rate, changeRxnBounds.
 %
-% Ines Thiele
 % Maike K. Aurich 26/05/15
 
 %% 
@@ -71,7 +71,7 @@ if ~isempty(medium_composition)
     
     for i = 1 : length(medium_composition)
         
-        [flux_Medium(i,1)] = conc2Rate(met_Conc_mM(i), cellConc, t, cellWeight);%
+        [flux_Medium(i,1)] = Conc2Rate(met_Conc_mM(i), cellConc, t, cellWeight);%
         
     end
     

--- a/metabotools/setMediumConstraints.m
+++ b/metabotools/setMediumConstraints.m
@@ -93,5 +93,3 @@ if close_exchanges ==1
     
     modelMedium.lb(find(ismember(modelMedium.rxns,AllExMedium)))= 0; % all exchanges not specified are set to secretion only
 end
-
-end

--- a/metabotools/setMediumConstraints.m
+++ b/metabotools/setMediumConstraints.m
@@ -1,43 +1,42 @@
 function [modelMedium,basisMedium] = setMediumConstraints(model, set_inf, current_inf, medium_composition, met_Conc_mM, cellConc, t, cellWeight, mediumCompounds, mediumCompounds_lb, customizedConstraints, customizedConstraints_ub, customizedConstraints_lb, close_exchanges)
 
-% Calculates and sets constraints according to medium composition in mM. Is 
-% based on the function conc2Rate. Returns a model with new constraints.
+% Calculates and sets constraints according to medium composition in mM. Is based on the function Conc2Rate. Returns a model with constraints.
+%
 %  INPUTS
 %
-%   model                     Global metabolic model (Recon)
-%   current_inf               Models can have differently defined infinite constraints, e.g., 500
-%   set_inf                   New value for infinite constraints, e.g., 1000
-%   medium_composition        Vector of exchange reactions of metabolites in the cell medium, e.g., RPMI medium
-%   met_Conc_mM               Vector of the same length of 'Exchanges', providing the concentration (in Mm) of each metabolite in the respective row
-%   cellConc                  Cell concentration (cells per 1 ml)
-%   t                         Time in hours (in hours)
-%   cellWeight                gDW per cell
+%       model                     Metabolic model (Recon)
+%       current_inf               Models can have differently defined infinite constraints, e.g., 500
+%       set_inf                   New value for infinite constraints, e.g., 1000
+%       medium_composition        Vector of exchange reactions of metabolites in the cell medium, e.g., RPMI medium
+%       met_Conc_mM               Vector of the same length of 'Exchanges', providing the concentration (in Mm) of each metabolite in the respective row
+%       cellConc                  Cell concentration (cells per 1 ml)
+%       t                         Time in hours (in hours)
+%       cellWeight                Cellular dry weight
 %
 %
-%   mediumCompounds           Composition of basic medium, which are
-%                             usually not defined in the composition of the medium and need to be defined in addition.
-%   mediumCompounds_lb        lower bound applied for all mediumCompounds (the same for all)
+%       mediumCompounds           Composition of basic medium, which are usually not defined in the composition of the medium and need to be defined in addition.
+%       mediumCompounds_lb        Lower bound applied for all mediumCompounds (the same for all)
 %
 %
 % optional inputs
 %
-%   customizedConstraints     If additional constraints should be set apart from the basic medium and medium composition, e.g. 'EX_o2(e)'
-%   customizedConstraints_lb  Vecor of lower bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
-%   customizedConstraints_ub  Vecor of upper bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
-%   close_exchanges           If exchange reactions except those specified should be closed (Defauld = 1)1= close exchanges, 0=no
+%       customizedConstraints     If additional constraints should be set apart from the basic medium and medium composition, e.g. 'EX_o2(e)'
+%       customizedConstraints_lb  Vecor of lower bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
+%       customizedConstraints_ub  Vecor of upper bounds to be set (mmol/gDW/hr), must be of same length as customizedConstraints
+%       close_exchanges           If exchange reactions except those specified should be closed (Defauld = 1) 1= close exchanges, 0=no
 %
 %  OUTPUT
 %
-%    modelMedium              Model with set constraints, all exchanges not specified in  mediumCompounds, ions or customizedConstraints are set to secretion only
-%    basisMedium              Vector of adjusted constraints, for reference such that these constraints are not overwritten at a later stage
+%       modelMedium              Model with set constraints, all exchanges not specified in  mediumCompounds, ions or customizedConstraints are set to secretion only
+%       basisMedium              Vector of adjusted constraints, for reference such that these constraints are not overwritten at a later stage
 %
 % Please note that if metabolites of Medium_composition and mediumCompounds overlap, the constraints of the Medium_composition will
 % be set to 0 in the output model. The function depends on the functions conc2Rate, changeRxnBounds.
 %
+% Ines Thiele
 % Maike K. Aurich 26/05/15
 
 %% 
-
 if ~exist('customizedConstraints','var') || isempty(customizedConstraints)
     customizedConstraints = {};
 end

--- a/metabotools/setMediumConstraints.m
+++ b/metabotools/setMediumConstraints.m
@@ -1,7 +1,7 @@
 function [modelMedium,basisMedium] = setMediumConstraints(model, set_inf, current_inf, medium_composition, met_Conc_mM, cellConc, t, cellWeight, mediumCompounds, mediumCompounds_lb, customizedConstraints, customizedConstraints_ub, customizedConstraints_lb, close_exchanges)
 
 % Calculates and sets constraints according to medium composition in mM. Is 
-% based on the function Conc2Rate. Returns a model with new constraints.
+% based on the function conc2Rate. Returns a model with new constraints.
 %  INPUTS
 %
 %   model                     Global metabolic model (Recon)
@@ -32,7 +32,7 @@ function [modelMedium,basisMedium] = setMediumConstraints(model, set_inf, curren
 %    basisMedium              Vector of adjusted constraints, for reference such that these constraints are not overwritten at a later stage
 %
 % Please note that if metabolites of Medium_composition and mediumCompounds overlap, the constraints of the Medium_composition will
-% be set to 0 in the output model. The function depends on the functions Conc2Rate, changeRxnBounds.
+% be set to 0 in the output model. The function depends on the functions conc2Rate, changeRxnBounds.
 %
 % Maike K. Aurich 26/05/15
 
@@ -71,7 +71,7 @@ if ~isempty(medium_composition)
     
     for i = 1 : length(medium_composition)
         
-        [flux_Medium(i,1)] = Conc2Rate(met_Conc_mM(i), cellConc, t, cellWeight);%
+        [flux_Medium(i,1)] = conc2Rate(met_Conc_mM(i), cellConc, t, cellWeight);%
         
     end
     

--- a/reconstruction/addReaction.m
+++ b/reconstruction/addReaction.m
@@ -138,7 +138,7 @@ if (nargin < 8 | isempty(objCoeff))
         objCoeff = 0;
     end
 end
-if (nargin < 9)
+if (nargin < 9 | isempty(subSystem))
     if (oldRxnFlag) && (isfield(model,'subSystems'))
         subSystem = model.subSystems{rxnID};
     else
@@ -158,6 +158,10 @@ if (nargin < 10) && (isfield(model,'grRules'))
     else
         grRule = '';
     end
+end
+
+if isempty(grRule)
+    grRule = '';
 end
 
 if (~exist('checkDuplicate','var'))
@@ -305,12 +309,16 @@ end
 % if ~oldRxnFlag, model.rxnGeneMat(rxnID,:)=0; end
 
 if (isfield(model,'genes'))
-    if (nargin < 11)
+    if (nargin < 11) 
         model = changeGeneAssociation(model,rxnName,grRule);
     else
         %fprintf('In addReaction, the class of systNameList is %s',
         %class(systNameList)); % commented out by Thierry Mondeel
+        if ~isempty(geneNameList) && ~isempty(systNameList)
         model = changeGeneAssociation(model,rxnName,grRule,geneNameList,systNameList);
+        else
+            model = changeGeneAssociation(model,rxnName,grRule);
+        end
     end
 end
 

--- a/reconstruction/addSinkReactions.m
+++ b/reconstruction/addSinkReactions.m
@@ -23,6 +23,7 @@ if nargin < 3
     lb = ones(nMets,1)*min(model.lb);
     ub = ones(nMets,1)*max(model.ub);
 end
+
 if size(lb,2)==2
     ub = lb(:,2);
     lb = lb(:,1);
@@ -31,7 +32,7 @@ end
 rxnsInModel=-ones(length(metabolites),1);
 for i = 1 : nMets
     rxnName = strcat('sink_',metabolites{i});
-    [model,rxnIDs] = addReaction(model,rxnName,metabolites(i),-1,1,lb(i),ub(i),0,'Sink');
+    [model,rxnIDs] = addReaction(model,rxnName,metabolites(i),-1,1,lb(i),ub(i),0,'Sink', [], [], [], 0); % ignore duplicates
     if ~isempty(rxnIDs)
        rxnsInModel(i)=rxnIDs;
     end    


### PR DESCRIPTION
I made some modification to addSinkReaction.m to allow for adding duplicate reactions, which meant I had to modify the behaviour of addReaction.m also. The setMediumConstraints.m is just my internal clumsiness of first time working with forks. It is virtually unchanged from the original.

