### PR TITLE
Backward compatability

### DIFF
--- a/io/convertCobraToSBML.m
+++ b/io/convertCobraToSBML.m
@@ -1,0 +1,61 @@
+function sbmlModel = convertCobraToSBML(model,sbmlLevel,sbmlVersion,compSymbolList,compNameList)
+%convertCobraToSBML converts a cobra structure to an sbml
+%structure using the structures provided in the SBML toolbox 3.1.0
+%
+% sbmlModel = convertCobraToSBML(model,sbmlLevel,sbmlVersion,compSymbolList,compNameList)
+%
+%INPUTS
+% model             COBRA model structure
+%
+%OPTIONAL INPUTS
+% sbmlLevel         SBML Level (default = 2)
+% sbmlVersion       SBML Version (default = 1)
+% compSymbolList    List of compartment symbols
+% compNameList      List of copmartment names correspoding to compSymbolList
+% fbc               'true' - convert a COBRA model structure into a Matlab
+%                   SBML FBCv2 format. The default parameter is 'false',
+%                   which means FBCv2-supported format is not applied.
+%
+%OUTPUT
+% sbmlModel         SBML MATLAB structure
+%
+%
+
+%NOTE: The name mangling of reaction and metabolite ids is necessary
+%for compliance with the SBML sID standard.
+%
+%NOTE: Sometimes the Model_create function doesn't listen to the
+%sbmlVersion parameter, so it is essential that the items that
+%are added to the sbmlModel are defined with the sbmlModel's level
+%and version:  sbmlModel.SBML_level,sbmlModel.SBML_version
+%
+%NOTE:  Some of the structures are recycled to reduce to overhead for
+%their creation.  There's a chance this can cause bugs in the future.
+%
+%NOTE: Currently, I don't add in the boundary metabolites.
+%
+%NOTE: Speed could probably be improved by directly adding structures to
+%lists in a struct instead of using the SBML _addItem function, but this
+%could break in future versions of the SBML toolbox.
+%
+%POTENTIAL FUTURE BUG: To speed things up, sbml structs have been
+%recycled and are directly appended into lists instead of using _addItem
+
+
+% modified by Longfei Mao 24/09/15   FBCv2 support added
+% Reinstantiated for backward compatability by Thomas Pfau 19/09/2016
+
+if ~exist('compSymbolList','var') 
+	compSymbolList = [];
+	compNameList = [];
+end
+
+if (~exist('sbmlLevel','var') || isempty(sbmlLevel))
+    sbmlLevel = 2;
+end
+if (~exist('sbmlVersion','var') || isempty(sbmlVersion))
+    sbmlVersion = 1;
+end
+
+sbmlModel = writeCbModel(model,'sbml','Temp.xml',[],[],sbmlLevel,sbmlVersion);
+delete Temp.xml

--- a/io/utilities/writeCbToSBML.m
+++ b/io/utilities/writeCbToSBML.m
@@ -7,5 +7,5 @@ function writeCbToSBML(model,fileName)
 % model         COBRA model structure
 % fileName      Name of xml file output
 %
-        sbmlModel = convertCobraToSBML(model);
-        OutputSBML(sbmlModel, fileName);
+sbmlModel = convertCobraToSBML(model);
+OutputSBML(sbmlModel, fileName);

--- a/io/writeCbModel.m
+++ b/io/writeCbModel.m
@@ -4,7 +4,7 @@
 % FBCv2 file. The current version of the "writeSBML.m" does not require the
 % SBML toolbox (http://sbml.org/Software/SBMLToolbox).
 
-function writeCbModel(model,format,fileName,compSymbolList,compNameList,sbmlLevel,sbmlVersion)
+function outmodel = writeCbModel(model,format,fileName,compSymbolList,compNameList,sbmlLevel,sbmlVersion)
 %writeCbModel Write out COBRA models in various formats
 %
 % writeCbModel(model,format,fileName,compSymbolList,compNameList,sbmlLevel,sbmlVersion)
@@ -12,6 +12,9 @@ function writeCbModel(model,format,fileName,compSymbolList,compNameList,sbmlLeve
 %INPUTS
 % model             Standard COBRA model structure
 % format            File format to be used ('text','xls' or 'sbml')
+%
+% OPTIONAL OUTPUTS
+% outmodel          Only useable with sbml export. Will return the sbml structure, otherwise the input COBRA model structure is returned.
 %
 %OPTIONAL INPUTS
 % fileName          File name for output file (optional, default opens
@@ -37,7 +40,7 @@ if nargin < 6
     sbmlLevel = 2;
     sbmlVersion = 1;
 end
-
+outmodel = model;
 [nMets,nRxns] = size(model.S);
 
 formulas = printRxnFormula(model,model.rxns,false,false,false,1,false);
@@ -262,7 +265,7 @@ switch format
         %% SBML
     case 'sbml'
         % sbmlModel = convertCobraToSBML(model,sbmlLevel,sbmlVersion,compSymbolList,compNameList);
-        writeSBML(model,fileName,compSymbolList,compNameList)
+        outmodel = writeSBML(model,fileName,compSymbolList,compNameList)
 %         if exist('fileName','var')&&~isempty(fileName)
 %             OutputSBML(sbmlModel,fileName);
 %         else

--- a/io/writeCbToSBML.m
+++ b/io/writeCbToSBML.m
@@ -1,0 +1,11 @@
+function writeCbToSBML(model,fileName)
+%writeCbToSBML write a COBRA model to SBML
+%
+% writeCbToSBML(model,fileName)
+%
+%INPUTS
+% model         COBRA model structure
+% fileName      Name of xml file output
+%
+convertCobraToSBML(model);
+


### PR DESCRIPTION
Reinstantiation of the old convertCobraToSBML and writeCbToSBML files now using the new writeCbModel function.
Added an (optional) return argument to the writeCbModel function to allow the user to obtain the SBML structure created in the conversion process, and to allow a proper use of  convertCobraToSBML.