### PR TITLE
checking for empty reaction rules

### DIFF
--- a/deleteModelGenes.m
+++ b/deleteModelGenes.m
@@ -82,8 +82,10 @@ if (all(isInModel))
         constrainRxn = false(length(rxnInd),1);
         % Figure out if any of the reaction states is changed
         for j = 1:length(rxnInd)
-            if (~eval(model.rules{rxnInd(j)}))
-                constrainRxn(j) = true;
+            if (~isempty(model.rules{rxnInd(j)})) %To avoid errors if the rule is empty                
+                if (~eval(model.rules{rxnInd(j)}))
+                    constrainRxn(j) = true;
+                end
             end
         end
         % Constrain flux through the reactions associated with these genes


### PR DESCRIPTION
I added a fix to check for empty rules in the model. This seems to be a problem, esp. with older models? I have an _iNJ_661 model of _M. tuberculosis_, which I am able to run `singleGeneDeletion` on, only with this fix...