### PR TITLE
Update readSBML.m

### DIFF
--- a/io/utilities/readSBML.m
+++ b/io/utilities/readSBML.m
@@ -628,7 +628,8 @@ else    % in the case of fbc file
     if noObjective==0; % when there is an objective function
         indexObj=findRxnIDs(model,fbc_obj);
         % indexObj=find(strcmp(fbc_obj,model.rxns))
-        model.c(indexObj)=fbc_obj_value;
+        model.c(indexObj)=1;
+        model.osense=fbc_obj_value;
     end
     
     if all(cellfun('isempty',fbcMet.fbc_chemicalFormula))~=1  % if all formulas are empty


### PR DESCRIPTION
The objective sense is currently written into model.c. If the objective function in the SBML model is defined as maximized, model.c will have a value of -1 for the objective function, which results in a flux of zero when the objective function is maximized, and a negative flux when an irreversible reaction is minimized. The objective sense should instead be defined in model.osense.