### PR TITLE
also warning when single input reaction ID is not found

### DIFF
--- a/changeRxnBounds.m
+++ b/changeRxnBounds.m
@@ -36,7 +36,7 @@ rxnID = findRxnIDs(model,rxnNameList);
 if (iscell(rxnNameList))
     missingRxns = rxnNameList(rxnID == 0);
     for i = 1:length(missingRxns)
-        fprintf('Reaction %s not in model\n',missingRxns{i});    
+        warning('Reaction %s not in model',missingRxns{i});    
     end
     if (length(boundType) > 1)
         boundType = boundType(rxnID ~= 0);
@@ -47,8 +47,10 @@ if (iscell(rxnNameList))
     rxnID = rxnID(rxnID ~= 0);    
 end
 
-if (isempty(rxnID) | sum(rxnID) == 0)
-    warning('No such reaction in model');
+if (isempty(rxnID))
+    warning('Reaction %s not in model',rxnNameList{1});
+elseif (sum(rxnID) == 0)
+    warning('Reaction %s not in model',rxnNameList);
 else
     nRxns = length(rxnID);
     if (length(boundType) > 1)


### PR DESCRIPTION
Currently, "named" warnings are given only for the reactions not found, when the input is a list. If a single reaction is input, either as a cell array of size 1, or as a single char array, no "named" warnings are given, indicating what reaction is not found. 

While this may be by design, sometimes, if there are a bunch of `changeRxnBound` commands inside a script, such warnings will be more useful.

Also, converted the `fprintf` for rxns not found, to a `warning`.