### PR TITLE
Corrected Mass Balance to collect all imbalances

### DIFF
--- a/modelGeneration/massBalance/checkBalance.m
+++ b/modelGeneration/massBalance/checkBalance.m
@@ -65,7 +65,7 @@ for m=1:nMet
 end
 
 dE=model.S'*E; 
-dE(dE < 1e-12) = 0;
+dE(abs(dE) < 1e-12) = 0;
 
 if exist('fid','var')
     fclose(fid);


### PR DESCRIPTION
checkBalance was discarding all negative balances since the check was only on value < 1e-12 but not abs(value) < 1e-12.
This can easily lead to unbalanced reactions in a model not noticed by the checkMassChargeBalance function.