### PR TITLE
Reactions with unknown Reactions are now flagged as unbalanced 

### DIFF
--- a/checkMassChargeBalance.m
+++ b/checkMassChargeBalance.m
@@ -70,7 +70,9 @@ for j = 1 : length(Elements)
     end
 end
 
-imBalancedRxnBool=any(massImbalance,2);
+%Add everything that either has mass imbalances or where metabolites with
+%missing formulas are present.
+imBalancedRxnBool=any(massImbalance,2) | any(model.S(missingFormulaeBool,:))';
 
 imBalancedMass=cell(nRxn,1);
 for i = 1 : nRxn

--- a/testing/testMassChargeBalance/createToyModel.m
+++ b/testing/testMassChargeBalance/createToyModel.m
@@ -1,0 +1,33 @@
+function model = createToyModel(unknownmetabolites, unbalancedCharge,imbalancedreactions)
+%This is a simple function to create a small toy model with so
+%The Reactions are: -> A ; A -> B ; A -> C ; B + C -> D ; D ->
+%It also has 
+model.S = sparse([-1 -1 -1 0 0; 0 1 0 -1 0;0 0 1 -1 0; 0 0 0 1 -1]);
+
+model.mets = {'A[c]','B[c]','C[c]','D[c]'}';
+model.rxns = {'Ex_A','R2','R3','R4','Ex_D'}';
+model.rev = [1,0,0,0,1]';
+model.rxnNames = model.rxns;
+model.metFormulas = {'CHO','CHO','CHO','C2H2O2'};
+model.metCharges = [ -1 -1 -1 -2]';
+model.b = [0,0,0,0]';
+model.c = [0,0,0,0,1]';
+model.lb = [ -1000,0,0,0,0];
+model.ub = [ 0,1000,1000,1000,1000];
+model.metNames = strrep(model.mets,'[c]','');
+model.genes = {'G1','G2'}';
+model.rules = {'','','x(1) & x(2)','x(2) | x(1)',''}';
+model.grRules = {'','','G1 and G2','G2 or G1',''}';
+
+
+if unknownmetabolites
+    model.metFormulas{2} = '';
+end
+
+if imbalancedreactions
+    model.S(2,4) = -3;
+end
+
+if unbalancedCharge
+    model.metCharges(3) = 1;
+end

--- a/testing/testMassChargeBalance/testMassChargeBalance.m
+++ b/testing/testMassChargeBalance/testMassChargeBalance.m
@@ -1,0 +1,56 @@
+function status = testMassChargeBalance()
+
+options = logical([0 0 0; 0 0 1; 0 1 0 ; 0 1 1; 1 0 0 ; 1 0 1 ; 1 1 0 ; 1 1 1]);
+status = 1;
+for i= 1:size(options,1)
+    model = createToyModel(options(i,1),options(i,2),options(i,3));
+    [massImbalance,imBalancedMass,imBalancedCharge,imBalancedRxnBool,Elements,missingFormulaeBool,balancedMetBool] = checkMassChargeBalance(model);
+    if options(i,1)
+        if ~any(imBalancedRxnBool(2:4)) || ~any(missingFormulaeBool) || ~any(any(isnan(massImbalance)))
+            %There should be at least one imbalanced internal reaction and
+            %one missing formula bool if we look at a network with missing
+            %formulas Also, if we have unknown formulas, we should have NaN
+            %values.
+            status = 0;
+        end
+    else
+        if any(missingFormulaeBool)
+            %There should be no missing formulas (but we can't say anything
+            %more
+            status = 0;
+        end
+        if ~options(i,3) && ~any(balancedMetBool)
+            %if we don't have a problem with the balanceing of reaction 4
+            %we should have at least one balanced Metabolite
+            status = 0;
+        end
+    end
+    
+    if options(i,2)
+        if ~any(imBalancedCharge(2:4)) 
+            %if we have a wrong charge this should come up in at least one
+            %internal 
+            status = 0;                    
+        end
+    else
+        %Our reaction imbalanceing is happening in reaction 4, so 2 and 3
+        %should have acceptable charge balances
+        if any(imBalancedCharge(2:3))
+            status = 0
+        end
+    end
+    
+    if options(i,3)
+        %Now, we have an imbalanced reaction
+        if ~any(imBalancedRxnBool(2:4)) || ~any(imBalancedCharge(2:4)) || ~any(cellfun(@isempty , imBalancedMass(2:4)))
+            status = 0;
+        end
+    else
+        if ~options(i,1) && ~options(i,2)
+            if any(imBalancedRxnBool(2:4)) || any(imBalancedCharge(2:4)) || any(any(massImbalance(2:4,:)))
+                status = 0;
+            end
+        end
+    end
+end
+            


### PR DESCRIPTION
This is a change for the issue discussed here:
https://github.com/opencobra/cobratoolbox/issues/200

It simply flags all reactions that contain unknown metabolites in the result from checkMassChargeBalance. Further it leads to massImbalance displaying the NaN value that those reactions should have. 