### PR TITLE
Improved SBML IO

### DIFF
--- a/io/utilities/parseSBMLNotesField2012.m
+++ b/io/utilities/parseSBMLNotesField2012.m
@@ -1,0 +1,81 @@
+function [genes,rule,subSystem,grRule,formula,confidenceScore,citation,comment,ecNumber,charge] = parseSBMLNotesField2012(notesField)
+%parseSBMLNotesField Parse the notes field of an SBML file to extract
+%gene-rxn associations
+%
+% [genes,rule] = parseSBMLNotesField(notesField)
+%
+% Markus Herrgard 8/7/06
+% Ines Thiele 1/27/10 Added new fields
+% Handle different notes fields
+
+
+if isempty(regexp(notesField,'html:p', 'once'))
+    tag = 'p';
+else
+    tag = 'html:p';
+end
+
+
+
+
+subSystem = '';
+grRule = '';
+genes = {};
+rule = '';
+formula = '';
+confidenceScore = '';
+citation = '';
+ecNumber = '';
+comment = '';
+charge = [];
+Comment = 0;
+
+[tmp,fieldList] = regexp(notesField,['<' tag '>.*?</' tag '>'],'tokens','match');
+
+%We need a version compatible with old matlabs (prior to 2013a)
+
+for i = 1:length(fieldList)
+    fieldTmp = regexp(fieldList{i},['<' tag '>(.*)</' tag '>'],'tokens');
+    fieldStr = strtrim(fieldTmp{1}{1});
+    if (regexp(fieldStr,'^GENE_ASSOCIATION'))
+        gprStr = regexprep(strrep(fieldStr,'GENE_ASSOCIATION:',''),'^(\s)+','');
+        grRule = gprStr;
+        [genes,rule] = parseBoolean(gprStr);
+    elseif (regexp(fieldStr,'^GENE ASSOCIATION'))
+        gprStr = regexprep(strrep(fieldStr,'GENE ASSOCIATION:',''),'^(\s)+','');
+        grRule = gprStr;
+        [genes,rule] = parseBoolean(gprStr);
+    elseif (regexp(fieldStr,'^SUBSYSTEM'))
+        subSystem = regexprep(strrep(fieldStr,'SUBSYSTEM:',''),'^(\s)+','');
+        subSystem = strrep(subSystem,'S_','');
+        subSystem = regexprep(subSystem,'_+',' ');
+        
+        
+%%%% The following commented three lines of codes assigns the SubSystem
+%%%% 'Exchange' to any reaction that has SUBSYSTEM showing up in its notes
+%%%% field but with no subsystem assigne
+
+%         if (isempty(subSystem))
+%             subSystem = 'Exchange';
+%         end
+    elseif (regexp(fieldStr,'^EC Number'))
+        ecNumber = regexprep(strrep(fieldStr,'EC Number:',''),'^(\s)+','');
+    elseif (regexp(fieldStr,'^FORMULA'))
+        formula = regexprep(strrep(fieldStr,'FORMULA:',''),'^(\s)+','');
+    elseif (regexp(fieldStr,'^CHARGE'))
+        charge = str2num(regexprep(strrep(fieldStr,'CHARGE:',''),'^(\s)+',''));
+    elseif (regexp(fieldStr,'AUTHORS'))
+        if isempty(citation)
+            citation = strcat(regexprep(strrep(fieldStr,'AUTHORS:',''),'^(\s)+',''));
+        else
+            citation = strcat(citation,';',regexprep(strrep(fieldStr,'AUTHORS:',''),'^(\s)+',''));
+        end
+    elseif (regexp(fieldStr,'^Confidence Level'))
+        confidenceScore = regexprep(strrep(fieldStr,'Confidence Level:',''),'^(\s)+','');
+    elseif (regexp(fieldStr,'^NOTES'))
+	comment = strcat(comment,';',regexprep(strrep(fieldStr,'AUTHORS:',''),'^(\s)+',''));
+    else 
+	%we are not in a known field, thus we will assume any remaining stuff is a simple Note and add it to the comment
+        comment = strcat(comment,';',fieldStr);
+    end
+end

--- a/io/utilities/writeSBML.m
+++ b/io/utilities/writeSBML.m
@@ -719,7 +719,7 @@ for i=1:size(model.rxns, 1)
         tmp_note = [ tmp_note ' <p>AUTHORS: ' model.rxnReferences{i} '</p>'];
     end
     if isfield(model, 'rxnNotes')&&i<=length(model.rxnNotes)%&&~isempty(model.rxnNotes{i})
-        tmp_note = [ tmp_note ' <p>' model.rxnNotes{i} '</p>'];
+        tmp_note = [ tmp_note ' <p>NOTES: ' model.rxnNotes{i} '</p>'];
     end
     if ~isempty(tmp_note)
         tmp_note = ['<body xmlns="http://www.w3.org/1999/xhtml">' tmp_note '</body>'];


### PR DESCRIPTION
The current SBML io is unable to restore e.g. rxnNotes. It is also prone to notes not having the specified format (<tag>CATEGORY: categorydata </tag>), since it only checks for the CATEGORY to be present anywhere in the string  at which point it might replace the proper category by the latter.
It was also unable to handle notes (or notes without a tag properly, these could only ever be read if they were written after a Confidence score (for whatever reason).

The updated version relies on some functionality introduced after 2013a, and will therefore check the version and use a corrected (at least with respect to additional Notes handling) version of the old code if the employed Matlab version is too old.

finally I added the NOTES category to the output comments again, as other tools that try to parse COBRA annotations rely on all fields having a specified structure as defined in the original COBRA paper (and shown above).