### PR TITLE
Update checkCobraModelUnique.m

### DIFF
--- a/src/checkCobraModelUnique.m
+++ b/src/checkCobraModelUnique.m
@@ -14,6 +14,9 @@ function model = checkCobraModelUnique(model,renameFlag)
 % model         COBRA model structure
 %
 % Markus Herrgard 10/17/07
+% Stefania Magnusdottir 07/02/17    Replace use of findRxnIDs and
+%                                   findMetIDs, both only return one index
+%                                   even if more are found in model.
 
 if (nargin < 2)
     renameFlag = false;
@@ -28,7 +31,7 @@ if ~isempty(rxnInd)
         fprintf('%s\t%d\n',thisRxnName,rxnCnt(rxnInd(i)));
         if (renameFlag)
             fprintf('Renaming non-unique reactions\n');
-            rxnIDs = findRxnIDs(model,thisRxnName);
+            rxnIDs = find(ismember(model.rxns,thisRxnName));
             for j = 1:length(rxnIDs)
                 model.rxns{rxnIDs(j)} = [thisRxnName '_' num2str(j)];
                 fprintf('%s\n',model.rxns{rxnIDs(j)});
@@ -46,10 +49,10 @@ if ~isempty(metInd)
         fprintf('%s\n',thisMetName);
         if (renameFlag)
             fprintf('Renaming non-unique metabolites\n');
-            metIDs = findMetIDs(model,thisMetName);
+            metIDs = find(ismember(model.mets,thisMetName));
             for j = 1:length(metIDs)
                 model.mets{metIDs(j)} = [thisMetName '_' num2str(j)];
-                fprintf('%s\n',model.mets{rxnIDs(j)});
+                fprintf('%s\n',model.mets{metIDs(j)});
             end
         end
     end

--- a/src/checkCobraModelUnique.m
+++ b/src/checkCobraModelUnique.m
@@ -18,41 +18,41 @@ function model = checkCobraModelUnique(model,renameFlag)
 %                                   findMetIDs, both only return one index
 %                                   even if more are found in model.
 
-if (nargin < 2)
+if nargin < 2
     renameFlag = false;
 end
 
-[rxnName,rxnCnt] = countUnique(model.rxns);
+[rxnName, rxnCnt] = countUnique(model.rxns);
 rxnInd = find(rxnCnt > 1);
 if ~isempty(rxnInd)
     fprintf('Model contains non-unique reaction names - consider renaming reactions using checkCobraModelUnique\n');
     for i = 1:length(rxnInd)
         thisRxnName = rxnName{rxnInd(i)};
-        fprintf('%s\t%d\n',thisRxnName,rxnCnt(rxnInd(i)));
-        if (renameFlag)
+        fprintf('%s\t%d\n', thisRxnName, rxnCnt(rxnInd(i)));
+        if renameFlag
             fprintf('Renaming non-unique reactions\n');
-            rxnIDs = find(ismember(model.rxns,thisRxnName));
+            rxnIDs = find(ismember(model.rxns, thisRxnName));
             for j = 1:length(rxnIDs)
                 model.rxns{rxnIDs(j)} = [thisRxnName '_' num2str(j)];
-                fprintf('%s\n',model.rxns{rxnIDs(j)});
+                fprintf('%s\n', model.rxns{rxnIDs(j)});
             end
         end
     end
 end
 
-[metName,metCnt] = countUnique(model.mets);
+[metName, metCnt] = countUnique(model.mets);
 metInd = find(metCnt > 1);
 if ~isempty(metInd)
     fprintf('Model contains non-unique metabolite names - consider renaming metabolites using checkCobraModelUnique\n');
     for i = 1:length(metInd)
         thisMetName = metName{metInd(i)};
-        fprintf('%s\n',thisMetName);
-        if (renameFlag)
+        fprintf('%s\n', thisMetName);
+        if renameFlag
             fprintf('Renaming non-unique metabolites\n');
-            metIDs = find(ismember(model.mets,thisMetName));
+            metIDs = find(ismember(model.mets, thisMetName));
             for j = 1:length(metIDs)
                 model.mets{metIDs(j)} = [thisMetName '_' num2str(j)];
-                fprintf('%s\n',model.mets{metIDs(j)});
+                fprintf('%s\n', model.mets{metIDs(j)});
             end
         end
     end

--- a/test/verifiedTests/testTools/testCheckCobraModelUnique.m
+++ b/test/verifiedTests/testTools/testCheckCobraModelUnique.m
@@ -1,0 +1,40 @@
+% The COBRAToolbox: checkCobraModelUnique.m
+%
+% Purpose:
+%     - Tests the checkCobraModelUnique function
+% Author:
+%     - Original file: Stefania Magnusdottir
+
+% define the path to The COBRA Toolbox
+pth = which('initCobraToolbox.m');
+CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
+
+cd([CBTDIR '/test/verifiedTests/testTools'])
+
+% define the test model
+toyModel=struct;
+toyModel.rxns={'Rxn1';'Rxn2';'Rxn2'};
+toyModel.mets={'Met1';'Met2';'Met2'};
+
+% define output mets when replacing duplicate met names
+metsReplaced={'Met1';'Met2_1';'Met2_2'};
+
+% define output mets when replacing duplicate met names
+rxnsReplaced={'Rxn1';'Rxn2_1';'Rxn2_2'};
+
+% run function without replacing rxn/met names
+modelTest=checkCobraModelUnique(toyModel);
+
+% check if met and rxn outputs are identical
+assert(isequal(toyModel.mets,modelTest.mets));
+assert(isequal(toyModel.rxns,modelTest.rxns));
+
+% run function and replace duplicate rxn/met names
+modelTest=checkCobraModelUnique(toyModel,1);
+
+% check if duplicate met and rxn names have been changed correctly
+assert(isequal(metsReplaced,modelTest.mets));
+assert(isequal(rxnsReplaced,modelTest.rxns));
+
+% change the directory
+cd(CBTDIR)


### PR DESCRIPTION
Referring to issue #21 . Repace use of findRxnIDs and findMetIDs. Both functions return the first index of rxn/met found in model even if multiple entries are found in the model. Add test for checkCobraModelUnique.m.