### PR TITLE
Minor changes to verifiedTests

### DIFF
--- a/test/verifiedTests/testElementalBalance/testElementalBalance.m
+++ b/test/verifiedTests/testElementalBalance/testElementalBalance.m
@@ -11,7 +11,7 @@ pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
 % change to the test folder
-initTest([CBTDIR '/test/verifiedTests/testElementalBalance']);
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testElementalBalance']);
 
 % load the model and data
 load('testElementalBalanceData.mat');

--- a/test/verifiedTests/testFBA/testFBA.m
+++ b/test/verifiedTests/testFBA/testFBA.m
@@ -21,7 +21,7 @@ global path_GUROBI
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-initTest([CBTDIR '/test/verifiedTests/testFBA']);
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testFBA']);
 
 % set the tolerance
 tol = 1e-8;

--- a/test/verifiedTests/testFVA/testFVA.m
+++ b/test/verifiedTests/testFVA/testFVA.m
@@ -18,7 +18,7 @@ global path_TOMLAB
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-initTest([CBTDIR '/test/verifiedTests/testFVA'])
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testFVA'])
 
 % set the tolerance
 tol = 1e-8;

--- a/test/verifiedTests/testFindBlockedReaction/testFindBlockedReaction.m
+++ b/test/verifiedTests/testFindBlockedReaction/testFindBlockedReaction.m
@@ -18,9 +18,9 @@ global path_GUROBI
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-initTest([CBTDIR '/test/verifiedTests/testFindBlockedReaction'])
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testFindBlockedReaction'])
 
-load ecoli_core_model.mat;
+load('ecoli_core_model.mat', 'model');
 
 ecoli_blckd_rxn = {'EX_fru(e)', 'EX_fum(e)', 'EX_gln_L(e)', 'EX_mal_L(e)', ...
                    'FRUpts2', 'FUMt2_2', 'GLNabc', 'MALt2_2'};
@@ -78,3 +78,6 @@ for k = 1:length(solverPkgs)
     % output a success message
     fprintf('Done.\n');
 end
+
+% change the directory
+cd(CBTDIR)

--- a/test/verifiedTests/testMetaboTools/testFluxSplits.m
+++ b/test/verifiedTests/testMetaboTools/testFluxSplits.m
@@ -18,7 +18,7 @@ global path_TOMLAB
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-initTest([CBTDIR '/test/verifiedTests/testMetaboTools']);
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testMetaboTools']);
 
 % define a toy model with single internal loop
 model.mets = {'A'; 'B'; 'C'};

--- a/test/verifiedTests/testModelManipulation/testChangeObjective.m
+++ b/test/verifiedTests/testModelManipulation/testChangeObjective.m
@@ -8,31 +8,32 @@
 % define the path to The COBRA Toolbox
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
-cd([CBTDIR '/test/verifiedTests/testModelManipulation'])
+
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testModelManipulation'])
 
 % define the test model
-toyModel=struct;
-toyModel.rxns={'Rxn1'; 'Rxn2'; 'Rxn3'};
-toyModel.c=[0 ; 0 ; 0];
+toyModel = struct;
+toyModel.rxns = {'Rxn1'; 'Rxn2'; 'Rxn3'};
+toyModel.c = [0 ; 0 ; 0];
 
 % test default coefficient (1)
-modelNew = changeObjective(toyModel,'Rxn1');
-assert(modelNew.c(1)==1 && modelNew.c(2)==0 && modelNew.c(3)==0)
+modelNew = changeObjective(toyModel, 'Rxn1');
+assert(modelNew.c(1) == 1 && modelNew.c(2) == 0 && modelNew.c(3) == 0)
 
 % test that error is thrown if objective rnx not in model
 try
-    modelNew = changeObjective(toyModel,'Rxn4');
+    modelNew = changeObjective(toyModel, 'Rxn4');
 catch ME
     assert(length(ME.message) > 0)
 end
 
 % test multiple rxns and 1 rxn not in model, default coefficient (1)
 modelNew = changeObjective(toyModel,{'Rxn1'; 'Rxn2'; 'Rxn4'});
-assert(modelNew.c(1)==1 && modelNew.c(2)==1 && modelNew.c(3)==0)
+assert(modelNew.c(1) == 1 && modelNew.c(2) == 1 && modelNew.c(3) == 0)
 
 % test multiple rxns, different coefficients
 modelNew = changeObjective(toyModel,{'Rxn1'; 'Rxn2'},[0.3 ; 0.7]);
-assert(modelNew.c(1)==0.3 && modelNew.c(2)==0.7 && modelNew.c(3)==0)
+assert(modelNew.c(1) == 0.3 && modelNew.c(2) == 0.7 && modelNew.c(3) == 0)
 
 % change the directory
 cd(CBTDIR)

--- a/test/verifiedTests/testModelManipulation/testChangeRxnBounds.m
+++ b/test/verifiedTests/testModelManipulation/testChangeRxnBounds.m
@@ -9,7 +9,7 @@
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-cd([CBTDIR '/test/verifiedTests/testModelManipulation'])
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testModelManipulation'])
 
 % define the test model
 toyModel = struct;

--- a/test/verifiedTests/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/testModelManipulation/testModelManipulation.m
@@ -17,7 +17,7 @@
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end-(length('initCobraToolbox.m') + 1));
 
-cd([CBTDIR '/test/verifiedTests/testModelManipulation']);
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep,'testModelManipulation']);
 
 % Test with non-empty model
 fprintf('>> Starting non-empty model tests:\n');
@@ -65,37 +65,7 @@ model = removeRxns(model, {'ABC_def'});
 addExchangeRxn(model, {'glc-D[e]'; 'glc-D';})
 
 %check if rxns length was decremented by 1
-assert(length(model.rxns) == rxns_length);v2irrev, irrev2rev] = convertToIrreversible(model);
-
-% test if both models are the same
-assert(isSameCobraModel(modelIrrev, testModelIrrev));
-
-% Convert to reversible
-fprintf('>> Testing convertToReversible\n');
-testModelRev = convertToReversible(testModelIrrev);
-load('testModelManipulation.mat','modelRev');
-
-% test if both models are the same
-assert(isSameCobraModel(modelRev,testModelRev));
-
-% test irreversibility of model
-fprintf('>> Testing convertToIrreversible (2)\n');
-load('testModelManipulation.mat','model','modelIrrev');
-
-% set a lower bound to positive (faulty model)
-modelRev.lb(1) = 10;
-[testModelIrrev, matchRev, rev2irrev, irrev2rev] = convertToIrreversible(model);
-
-% test if both models are the same
-assert(isSameCobraModel(modelIrrev, testModelIrrev));
-
-% test irreversibility of model
-fprintf('>> Testing convertToIrreversible (3)\n');
-load('testModelManipulation.mat','model','modelIrrev');
-
-% set a reaction as not reversible although the reaction is reversible as suggested by the bounds
-model.rev(1) = 0;
-[testModelIrrev, matchRev, rev2irrev, irrev2r
+assert(length(model.rxns) == rxns_length);
 
 % add a new reaction to the model
 model = addReaction(model,'newRxn1','A -> B + 2 C');
@@ -137,7 +107,7 @@ model = addReaction(model,'newRxn1','A -> B + 2 C');
 assert(length(model.rxns) == rxns_length + 1);
 
 % check if the number of metabolites was incremented by 3
-assert(length(model.mets) == mets_length+3);
+assert(length(model.mets) == mets_length + 3);
 
 % change the reaction bounds
 model = changeRxnBounds(model, model.rxns, 2, 'u');

--- a/test/verifiedTests/testOptimizeCbModel/testOptimizeCbModel.m
+++ b/test/verifiedTests/testOptimizeCbModel/testOptimizeCbModel.m
@@ -16,7 +16,7 @@ global path_TOMLAB
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-initTest([CBTDIR '/test/verifiedTests/testOptimizeCbModel']);
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testOptimizeCbModel']);
 
 % set the tolerance
 tol = 1e-6;

--- a/test/verifiedTests/testSBML/testReadSBML.m
+++ b/test/verifiedTests/testSBML/testReadSBML.m
@@ -44,7 +44,7 @@ assert(length(model.metFormulas) == length(testModel.metFormulas))
 assert(length(model.b) == length(testModel.b))
 
 % initialize the test
-initTest([CBTDIR '/test/models'])
+initTest([CBTDIR, filesep, 'test', filesep, 'models'])
 
 % add the path of the TOMLAB solver
 addpath(genpath(path_TOMLAB));

--- a/test/verifiedTests/testSBML/testWriteSBML.m
+++ b/test/verifiedTests/testSBML/testWriteSBML.m
@@ -13,7 +13,8 @@ pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end-(length('initCobraToolbox.m') + 1));
 
 % read in the .xml model first
-cd([CBTDIR '/test/verifiedTests/testSBML'])
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSBML'])
+
 testModelXML = readCbModel('Ec_iJR904.xml');
 
 % write the model as a .sbml file
@@ -29,7 +30,7 @@ testModelSBML = readCbModel('testModelSBML.sbml');
 assert(~any(numDiff))
 
 % remove the written file to clean up
-cd([CBTDIR '/test/verifiedTests/testSBML'])
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSBML'])
 system('rm testModelSBML.sbml.xml')
 
 % change the directory

--- a/test/verifiedTests/testTools/testCheckCobraModelUnique.m
+++ b/test/verifiedTests/testTools/testCheckCobraModelUnique.m
@@ -9,32 +9,32 @@
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-cd([CBTDIR '/test/verifiedTests/testTools'])
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testTools'])
 
 % define the test model
-toyModel=struct;
-toyModel.rxns={'Rxn1';'Rxn2';'Rxn2'};
-toyModel.mets={'Met1';'Met2';'Met2'};
+toyModel = struct;
+toyModel.rxns = {'Rxn1'; 'Rxn2'; 'Rxn2'};
+toyModel.mets = {'Met1'; 'Met2'; 'Met2'};
 
 % define output mets when replacing duplicate met names
-metsReplaced={'Met1';'Met2_1';'Met2_2'};
+metsReplaced = {'Met1'; 'Met2_1'; 'Met2_2'};
 
 % define output mets when replacing duplicate met names
-rxnsReplaced={'Rxn1';'Rxn2_1';'Rxn2_2'};
+rxnsReplaced = {'Rxn1'; 'Rxn2_1'; 'Rxn2_2'};
 
 % run function without replacing rxn/met names
-modelTest=checkCobraModelUnique(toyModel);
+modelTest = checkCobraModelUnique(toyModel);
 
 % check if met and rxn outputs are identical
-assert(isequal(toyModel.mets,modelTest.mets));
-assert(isequal(toyModel.rxns,modelTest.rxns));
+assert(isequal(toyModel.mets, modelTest.mets));
+assert(isequal(toyModel.rxns, modelTest.rxns));
 
 % run function and replace duplicate rxn/met names
-modelTest=checkCobraModelUnique(toyModel,1);
+modelTest=checkCobraModelUnique(toyModel, 1);
 
 % check if duplicate met and rxn names have been changed correctly
-assert(isequal(metsReplaced,modelTest.mets));
-assert(isequal(rxnsReplaced,modelTest.rxns));
+assert(isequal(metsReplaced, modelTest.mets));
+assert(isequal(rxnsReplaced, modelTest.rxns));
 
 % change the directory
 cd(CBTDIR)

--- a/test/verifiedTests/testTools/testJaccardIndex.m
+++ b/test/verifiedTests/testTools/testJaccardIndex.m
@@ -11,7 +11,7 @@
 pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
-cd([CBTDIR '/test/verifiedTests/testTools'])
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testTools'])
 
 % define the test vectors
 testVect1 = [0; -1; -2; -3; -4; -5; -6];

--- a/test/verifiedTests/testTools/testPrintMatrix.m
+++ b/test/verifiedTests/testTools/testPrintMatrix.m
@@ -24,7 +24,7 @@ assert(printMatrix(A, '%3.2f\t', 'testPrintMatrix.txt') == 1);
 
 % remove the generated file
 cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testTools']);
-system(['rm ', CBTDIR, '/testPrintMatrix.txt']);
+system(['rm ', CBTDIR, filesep, 'testPrintMatrix.txt']);
 
 % test for a cell matrix
 A = {0, 1, 2;

--- a/test/verifiedTests/testTools/testPrintMatrix.m
+++ b/test/verifiedTests/testTools/testPrintMatrix.m
@@ -23,8 +23,8 @@ assert(printMatrix(A, '%3.2f\t') == 1);
 assert(printMatrix(A, '%3.2f\t', 'testPrintMatrix.txt') == 1);
 
 % remove the generated file
-cd([CBTDIR '/test/verifiedTests/testTools']);
-system('rm testPrintMatrix.txt');
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testTools']);
+system(['rm ', CBTDIR, '/testPrintMatrix.txt']);
 
 % test for a cell matrix
 A = {0, 1, 2;

--- a/test/verifiedTests/testXls2Model/testXls2Model.m
+++ b/test/verifiedTests/testXls2Model/testXls2Model.m
@@ -17,7 +17,7 @@ pth = which('initCobraToolbox.m');
 CBTDIR = pth(1:end-(length('initCobraToolbox.m') + 1));
 
 % remove the generated file
-cd([CBTDIR '/test/verifiedTests/testXls2Model']);
+cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testXls2Model']);
 
 % convert the model
 model = xls2model('cobra_import_toy_model.xlsx');


### PR DESCRIPTION
Minor changes overall.
- removed duplicated code in `testModelManipulation.m`
- Windows compatibility for tests in `verifiedTests`
- changes to load `ecoli_core_model` (load only `model` variable) as original file contains a wrong CBTDIR (Windows path)

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/documentation/.github/CONTRIBUTING.md) document
- [X] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/documentation/.github/CONTRIBUTING.md#code-styleguide)
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [X] Written platform-independent code
- [X] Used `pwd` to get the current directory
- [X] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)

**I hereby confirm that I have:**

- [X] Written a sensible test according to the [Test styleguide](#test-styleguide)
- [X] Tested your PR locally prior to submission
- [X] Checked that all tests pass
- [X] Tested the code on Linux
