### PR TITLE
additional condition on reversibility

### DIFF
--- a/src/convertToIrreversible.m
+++ b/src/convertToIrreversible.m
@@ -52,7 +52,9 @@ for i = 1:nRxns
     if (model.ub(i) > 0 && model.lb(i) < 0) && model.rev(i) == false
         model.rev(i) = true;
         warning(cat(2,'Reaction: ',model.rxns{i},' is classified as irreversible, but bounds are positive and negative!'))
-    elseif (sign(model.ub(i)) == sign(model.lb(i)) ) && model.rev(i) == true
+    elseif (sign(model.ub(i)) == sign(model.lb(i)) ) ||...
+            (sign(model.ub(i)) * sign(model.lb(i)) == 0) &&...
+            model.rev(i) == true
         model.rev(i) = false;
     end
    

--- a/src/convertToIrreversible.m
+++ b/src/convertToIrreversible.m
@@ -26,45 +26,43 @@ function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model
 % Modified by Jan Schellenberger 9/9/09 for speed.
 
 %declare variables
-modelIrrev.S = spalloc(size(model.S,1),0,2*nnz(model.S));
+modelIrrev.S = spalloc(size(model.S, 1), 0, 2 * nnz(model.S));
 modelIrrev.rxns = [];
-modelIrrev.rev = zeros(2*length(model.rxns),1);
-modelIrrev.lb = zeros(2*length(model.rxns),1);
-modelIrrev.ub = zeros(2*length(model.rxns),1);
-modelIrrev.c = zeros(2*length(model.rxns),1);
-matchRev = zeros(2*length(model.rxns),1);
+modelIrrev.rev = zeros(2 * length(model.rxns), 1);
+modelIrrev.lb = zeros(2 * length(model.rxns), 1);
+modelIrrev.ub = zeros(2 * length(model.rxns), 1);
+modelIrrev.c = zeros(2 * length(model.rxns), 1);
+matchRev = zeros(2 * length(model.rxns), 1);
 
-nRxns = size(model.S,2);
-irrev2rev = zeros(2*length(model.rxns),1);
+nRxns = size(model.S, 2);
+irrev2rev = zeros(2 * length(model.rxns), 1);
 
 %loop through each column/rxn in the S matrix building the irreversible
 %model
 cnt = 0;
 for i = 1:nRxns
     cnt = cnt + 1;
-    
-    %expand the new model (same for both irrev & rev rxns  
+
+    %expand the new model (same for both irrev & rev rxns
     modelIrrev.rev(cnt) = model.rev(i);
     irrev2rev(cnt) = i;
 
     % Check if reaction is declared as irreversible, but bounds suggest
     % reversible (i.e., having both positive and negative bounds
-    if (model.ub(i) > 0 && model.lb(i) < 0) && model.rev(i) == false
+    if model.ub(i) > 0 && model.lb(i) < 0 && model.rev(i) == false
         model.rev(i) = true;
-        warning(cat(2,'Reaction: ',model.rxns{i},' is classified as irreversible, but bounds are positive and negative!'))
-    elseif (sign(model.ub(i)) == sign(model.lb(i)) ) ||...
-            (sign(model.ub(i)) * sign(model.lb(i)) == 0) &&...
-            model.rev(i) == true
+        warning(cat(2, 'Reaction: ', model.rxns{i}, ' is classified as irreversible, but bounds are positive and negative!'))
+    elseif (sign(model.ub(i)) == sign(model.lb(i)) || sign(model.ub(i)) * sign(model.lb(i)) == 0) && model.rev(i) == true
         model.rev(i) = false;
     end
-   
+
     % Reaction entirely in the negative direction
-    if (model.ub(i) <= 0 && model.lb(i) < 0)
+    if model.ub(i) <= 0 && model.lb(i) < 0
         % Retain original bounds but reversed
         modelIrrev.ub(cnt) = -model.lb(i);
         modelIrrev.lb(cnt) = -model.ub(i);
         % Reverse sign
-        modelIrrev.S(:,cnt) = -model.S(:,i);
+        modelIrrev.S(:, cnt) = -model.S(:, i);
         modelIrrev.c(cnt) = -model.c(i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
         model.rev(i) = false;
@@ -72,19 +70,19 @@ for i = 1:nRxns
     else
         % Keep positive upper bound
         modelIrrev.ub(cnt) = model.ub(i);
-        %if the lb is less than zero, set the forward rxn lb to zero 
+        %if the lb is less than zero, set the forward rxn lb to zero
         if model.lb(i) < 0
             modelIrrev.lb(cnt) = 0;
         else
             modelIrrev.lb(cnt) = model.lb(i);
         end
-        modelIrrev.S(:,cnt) = model.S(:,i);
+        modelIrrev.S(:, cnt) = model.S(:, i);
         modelIrrev.c(cnt) = model.c(i);
         modelIrrev.rxns{cnt} = model.rxns{i};
 
     end
 
-   
+
     %if the reaction is reversible, add a new rxn to the irrev model and
     %update the names of the reactions with '_f' and '_b'
     if model.rev(i) == true
@@ -92,11 +90,11 @@ for i = 1:nRxns
         matchRev(cnt) = cnt - 1;
         matchRev(cnt-1) = cnt;
         modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
-        modelIrrev.S(:,cnt) = -model.S(:,i);
+        modelIrrev.S(:, cnt) = - model.S(:, i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
         modelIrrev.rev(cnt) = true;
         modelIrrev.lb(cnt) = 0;
-        modelIrrev.ub(cnt) = -model.lb(i);
+        modelIrrev.ub(cnt) = - model.lb(i);
         modelIrrev.c(cnt) = 0;
         rev2irrev{i} = [cnt-1 cnt];
         irrev2rev(cnt) = i;
@@ -117,7 +115,7 @@ modelIrrev.lb = columnVector(modelIrrev.lb(1:cnt));
 modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
 modelIrrev.rev = modelIrrev.rev(1:cnt);
 modelIrrev.rev = columnVector(modelIrrev.rev == 1);
-modelIrrev.rxns = columnVector(modelIrrev.rxns); 
+modelIrrev.rxns = columnVector(modelIrrev.rxns);
 modelIrrev.mets = model.mets;
 matchRev = columnVector(matchRev(1:cnt));
 modelIrrev.match = matchRev;
@@ -137,9 +135,8 @@ end
 if isfield(model,'genes')
     modelIrrev.genes = model.genes;
     genemtxtranspose = model.rxnGeneMat';
-    modelIrrev.rxnGeneMat = genemtxtranspose(:,irrev2rev)';
+    modelIrrev.rxnGeneMat = genemtxtranspose(:, irrev2rev)';
     modelIrrev.rules = model.rules(irrev2rev);
     modelIrrev.grRules = model.grRules(irrev2rev); %added to allow model reduction 18/02/2016 Agnieszka
 end
 modelIrrev.reversibleModel = false;
-

--- a/test/verifiedTests/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/testModelManipulation/testModelManipulation.m
@@ -164,7 +164,7 @@ assert(isSameCobraModel(modelIrrev, testModelIrrev));
 % set a reaction as not reversible although the reaction is reversible as
 % suggested by the bounds (case2)
 model=modelSave;
-model.rev(20) = 0;
+model.rev(20) = 1;
 [testModelIrrev, matchRev, rev2irrev, irrev2rev] = convertToIrreversible(model);
 
 % test if both models are the same

--- a/test/verifiedTests/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/testModelManipulation/testModelManipulation.m
@@ -151,9 +151,20 @@ assert(isSameCobraModel(modelIrrev, testModelIrrev));
 % test irreversibility of model
 fprintf('>> Testing convertToIrreversible (3)\n');
 load('testModelManipulation.mat','model','modelIrrev');
+modelSave=model;
 
-% set a reaction as not reversible although the reaction is reversible as suggested by the bounds
+% set a reaction as not reversible although the reaction is reversible as
+% suggested by the bounds (case1)
 model.rev(1) = 0;
+[testModelIrrev, matchRev, rev2irrev, irrev2rev] = convertToIrreversible(model);
+
+% test if both models are the same
+assert(isSameCobraModel(modelIrrev, testModelIrrev));
+
+% set a reaction as not reversible although the reaction is reversible as
+% suggested by the bounds (case2)
+model=modelSave;
+model.rev(20) = 0;
 [testModelIrrev, matchRev, rev2irrev, irrev2rev] = convertToIrreversible(model);
 
 % test if both models are the same


### PR DESCRIPTION
*(Note: You may replace [ ] with [X] to check the box)*

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/documentation/.github/CONTRIBUTING.md) document
- [x] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/documentation/.github/CONTRIBUTING.md#code-styleguide)
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [x] Written platform-independent code
- [x] Used `pwd` to get the current directory
- [x] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [x] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)

#### Previous output

[*Include here information of the current version of The COBRA Toolbox*]

#### Output of PR-merged version

[*Include here information of modified version of The COBRA Toolbox after your proposed PR is accepted*]

###  Documentation updates

[*Include here information on how the documentation has been updated*]

**I hereby confirm that I have:**

- [ ] Documented your code based on the [Documentation styleguide](#documentation-and-comments-styleguide).
- [ ] Documented the `Input` and `Output` arguments
- [ ] Followed the guidelines to automatically generate the documentation

###  Tests tailored to test the PR

[*Include here information on how new tests and/or how existing tests have been adapted*]

**I hereby confirm that I have:**

- [ ] Written a sensible test according to the [Test styleguide](#test-styleguide)
- [ ] Tested your PR locally prior to submission
- [ ] Checked that all tests pass
- [ ] Tested the code on Linux
