### PR TITLE
Osense and field definitions :memo:

### DIFF
--- a/docs/source/Fields/ModelFields.md
+++ b/docs/source/Fields/ModelFields.md
@@ -1,0 +1,69 @@
+# Current Fields in the model structure
+
+## Official definition from Schellenberger et al 2011 (Supplementary File 1)
+<span style="color:red">The following field definitions are those used currently in the COBRA toolbox. 
+Except for the required fields, they are subject to changes and should not be relied on</span>.  
+### Required: 
+* mets: metabolite name abbreviation; metabolite ID; order corresponds to S matrix. S: Stoichiometric matrix in sparse format.
+* rev: logical array; true for reversible reactions, otherwise false
+* lb: lower flux bound for corresponding reactions
+* ub: upper flux bound for corresponding reactions
+* c: objective coefficient for corresponding reactions
+* metCharge: value of charge for corresponding metabolite
+* metFormulas: Elemental formula for each metabolite
+* rules: Boolean rule for the corresponding reaction which defines gene-reaction relationship.
+* genes: List of all genes within the model.
+* rxnGeneMat: matrix with rows corresponding to reactions and columns corresponding to genes
+* grRules: cell list of gene-protein-reaction strings for each reaction
+* subSystems: subSystem assignment for each reaction
+* description: string describing the model (i.e. model name)
+
+### Optional:
+* rxnNames: Full name of each corresponding reaction
+* rxnReferences: Cell array of strings which can contain optional information on references for
+each specific reaction.
+* rxnECNumbers: E. C. number for each reaction
+* rxnNotes: Cell array of strings which can contain optional information for each specific reaction.
+* confidenceScores: Confidence score for each reaction
+* proteins: proteins associated with each reaction
+* metNames: Full name of each corresponding metabolite
+* metChEBIID: ChEBI ID for each corresponding metabolite
+* metKeggID: KEGG ID for each corresponding metabolite
+* metPubChemID: Pub Chem ID for each corresponding metabolite
+* metInChIString: InChI String for each corresponding metabolite
+
+## Recent *required* additions 
+* model.modelVersion - the Version of the model
+* model.osenseStr - The String representation of the objective sense (either 'min' or 'max')
+* model.b - the b matrix 
+* model.csense - a Char Array to indicate whether the b vector is supposed to be used as an equality (E), lower then (L) or greater then (G) 
+
+
+## Recent optional fields
+*  model.metInchiString &rarr; model.annotation.metabolite.inchi
+*  model.rxnKeggID &rarr; model.annotation.metabolite.kegg\_\_46\_\_reaction
+*  model.metHMDB &rarr; model.annotation.metabolite.hmdb
+*  model.metEHMNID - Metabolite identifier from the Edinburgh Human Metabolic Network
+*  model.rxnConfidenceEcoIDA - I'm not entirely sure what this field (again recon2) is supposed to indicate.
+*  model.ExchRxnBool - logic array indicating exchange reactions
+*  model.EXRxnBool - see model.ExchRxnBool
+*  model.DMRxnBool - logic array indicating Demand Reactions 
+*  model.SinkRxnBool - (see model.DMRxnBool)
+*  model.SIntRxnBool - (see model.ExchRxnBool) anything thats not an exchange reaction should be internal...
+
+
+# Possible future changes
+The annotation fields linking to databases are currently under discussion, and could be reordered as follows. This includes in particular: metChEBIID, 
+metKeggID, metPubChemID, metInChIString
+
+*  model.annotation
+*  model.annotation.reaction - contains reaction database annotations (with identifiers.org IDs and dots in these replaced by \_\_46\_\_ )
+*  model.annotation.metabolite - contains metabolite database annotations (with identifiers.org IDs and dots in these replaced by \_\_46\_\_ )
+*  model.annotation.genes - contains gene database annotations (with identifiers.org IDs and dots in these replaced by \_\_46\_\_ )
+*  model.annotation.compartments - contains compartment database annotations (with identifiers.org IDs and dots in these replaced by \_\_46\_\_ )
+
+
+Each field under annotation can have subfields defined by bioql qualifiers (e.g. is, isDerivedFrom, isDescribedBy, isInstanceOf, hasPart etc...)
+These can directly be parsed to SBML Annotations. Would require to add functions that can manage this data during model curation (e.g. addGeneAnnotation(gene,databaseidentifier,database,varargin), 
+with varargin providing for example the option to set the relation)
+

--- a/src/MOMA.m
+++ b/src/MOMA.m
@@ -83,6 +83,9 @@ function [solutionDel,solutionWT,totalFluxDiff,solStatus] = ...
 
 if (nargin <3 || isempty(osenseStr))
     osenseStr = 'max';
+    if isfield(model,'osenseStr')
+        osenseStr = model.osenseStr;
+    end
 end
 if (nargin < 4)
     verbFlag = false;

--- a/src/cardOpt/sparseFBA/sparseFBA.m
+++ b/src/cardOpt/sparseFBA/sparseFBA.m
@@ -52,7 +52,11 @@ if exist('osenseStr', 'var')
         osenseStr = 'max';
     end
 else
-    osenseStr = 'max';
+    if isfield(model,'osenseStr')
+        osenseStr = model.osenseStr;
+    else
+        osenseStr = 'max';
+    end
 end
 
 if ~exist('checkMinimalSet', 'var')

--- a/src/fluxVariability.m
+++ b/src/fluxVariability.m
@@ -38,7 +38,11 @@ if (nargin < 2)
     optPercentage = 100;
 end
 if (nargin < 3)
-    osenseStr = 'max';
+    if isfield(model.osenseStr)
+        osenseStr = model.osenseStr
+    else
+        osenseStr = 'max';
+    end
 end
 if (nargin < 4)
     rxnNameList = model.rxns;

--- a/src/io/utilities/readSBML.m
+++ b/src/io/utilities/readSBML.m
@@ -275,19 +275,22 @@ for i = 1:nRxns
             
             if ismember(fbc_list(f),existed_fbc_list);
                 if f==1 % In the case of fbc_objective
-                    if ~isempty(modelSBML.(fbc_list{f}).fbc_fluxObjective)
-                        fbc_obj=modelSBML.(fbc_list{f}).fbc_fluxObjective.fbc_reaction; % the variable stores the objective reaction ID
+                    %TODO: Adapt this to properly import multiple
+                    %objectives. This will need to be also addressed in the
+                    %model structure (multiple c vectors and osense values)
+                    %For now, we only import the first objective!
+                    if ~isempty(modelSBML.(fbc_list{f}))
+                        fbc_obj=modelSBML.(fbc_list{f})(1).fbc_fluxObjective.fbc_reaction; % the variable stores the objective reaction ID
                         fbc_obj=regexprep(fbc_obj,'^R_','');
-                        if isfield(modelSBML.(fbc_list{f}).fbc_fluxObjective,'fbc_coefficient')
-                            fbc_obj_value=modelSBML.(fbc_list{f}).fbc_fluxObjective.fbc_coefficient;
+                        if isfield(modelSBML.(fbc_list{f})(1).fbc_fluxObjective,'fbc_coefficient')
+                            fbc_obj_value=modelSBML.(fbc_list{f})(1).fbc_fluxObjective.fbc_coefficient;
                         else
-                            ind_obj=find(strcmp(listOffbc_type,modelSBML.(fbc_list{f}).fbc_type));
-                            switch ind_obj
-                                case 1 % maximise
-                                    fbc_obj_value=-1;
-                                case 2 % minimise
-                                    fbc_obj_value=1;
-                            end
+                            %By FBC definition the fbc_type of an objective
+                            %has to be either "minimize" or maximize"
+                            %As such, we use the first 3 lettters of the
+                            %objective type to define the osenseStr of the
+                            %model.
+                            fbc_obj_value = modelSBML.(fbc_list{f})(1).fbc_type(1:3);                            
                         end
                     else % if the objective function is not specified according to the FBCv2 rules.
                         noObjective=1; % no objective function is defined for the COBRA model.
@@ -632,8 +635,8 @@ else    % in the case of fbc file
     if noObjective==0; % when there is an objective function
         indexObj=findRxnIDs(model,fbc_obj);
         % indexObj=find(strcmp(fbc_obj,model.rxns))
-        model.c(indexObj)=1;
-        model.osense=fbc_obj_value;
+        model.c(indexObj)=1;        
+        model.osenseStr=fbc_obj_value;
     end
     
     if all(cellfun('isempty',fbcMet.fbc_chemicalFormula))~=1  % if all formulas are empty

--- a/src/io/utilities/writeSBML.m
+++ b/src/io/utilities/writeSBML.m
@@ -873,13 +873,22 @@ if isfield(model,'genes')
         end
     end
 end
+
+%Set the objective sense of the FBC objective according to the osenseStr in
+%the model.
+objectiveSense = 'maximize';
+
+if isfield(model,'osenseStr') && strcmp('min',model.osenseStr)
+    objectiveSense = 'minimize'
+end
+
 tmp_fbc_objective=struct('typecode','SBML_FBC_OBJECTIVE',...   % Create templates of new structures defined in the FBCv2 scheme (i.e., field names and default values are initilised)
     'metaid',emptyChar,...
     'notes',emptyChar,...
     'annotation',emptyChar,...
     'sboTerm',defaultSboTerm,...
     'fbc_id','obj',... % define a term (No. 6)
-    'fbc_type', 'maximize',... % define the type (No.7)
+    'fbc_type', objectiveSense,... % define the type (No.7)
     'fbc_fluxObjective',emptyChar,... % is acturally a structure (No.8)
     'level', defaultLevel,...
     'version', defaultVersion,...

--- a/src/optimizeCbModel.m
+++ b/src/optimizeCbModel.m
@@ -124,7 +124,11 @@ if exist('osenseStr', 'var')
         osenseStr = 'max';
     end
 else
-    osenseStr = 'max';
+    if isfield(model, 'osenseStr')
+        osenseStr = model.osenseStr;
+    else        
+        osenseStr = 'max';
+    end
 end
 % Figure out objective sense
 if strcmpi(osenseStr,'max')

--- a/src/optimizeCbModelNLP.m
+++ b/src/optimizeCbModelNLP.m
@@ -30,6 +30,9 @@ function [currentSol,allObjValues,allSolutions] = ...
 
 if (nargin < 2)
     osenseStr = 'max';
+    if isfield(model,'osenseStr')
+        osenseStr = model.osenseStr;
+    end
 end
 if strcmp(osenseStr,'max')
     osense = -1;

--- a/src/optimizeTwoCbModels.m
+++ b/src/optimizeTwoCbModels.m
@@ -64,6 +64,7 @@ else
     tol = 1e-6;
 end
 
+%TODO: Have a look how the model.osenseStr can be incorporated here.
 if (nargin < 3)
     osenseStr = 'max';
 end


### PR DESCRIPTION
*(Note: You may replace [ ] with [X] to check the box)*

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md) document
- [X] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#code-styleguide)
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [X] Written platform-independent code
- [X] Used `pwd` to get the current directory
- [X] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [X] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)
This is a pull request addressing the missing i/o functionality for objective senses as discusses with @rmtfleming . The pr establishes the osenseStr field as a model field being used for optimisation tasks. It also adds this field as a checked field to optimizeCbModel, fluxVariability and other functions that till now needed an explicit definition of the objective sense. The default behaviour is still the same, but if the osenseStr field is set it is used instead.
In addition, I added a List of currently defined fields in the model structure used in the COBRA toolbox to the documentation. 
###  Documentation updates

A List of fields currently used in COBRA models was added to the Documentation.

**I hereby confirm that I have:**

- [X] Documented your code based on the [Documentation styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#documentation-and-comments-styleguide).
- [X] Documented the `Input` and `Output` arguments
- [X] Followed the guidelines to automatically generate the documentation

###  Tests tailored to test the PR

The tests were not adapted, as they should not be influenced by the modifications. An additional check for the model objective should however be added in a future commit.

- [X] Checked that all tests pass
- [X] Tested the code on Linux
