### PR TITLE
ctype field needs to be a row vector in cplex.

### DIFF
--- a/src/solvers/solveCobraMILP.m
+++ b/src/solvers/solveCobraMILP.m
@@ -380,7 +380,7 @@ switch solver
         if size(vartype,1) > size(vartype,2)
             vartype = vartype';
         end
-        cplexlp.Model.ctype = vartype';
+        cplexlp.Model.ctype = vartype;
         cplexlp.Start.x = x0;
         cplexlp.Param.mip.tolerances.mipgap.Cur =  solverParams.relMipGapTol;
         cplexlp.Param.mip.tolerances.integrality.Cur =  solverParams.intTol;

--- a/src/solvers/solveCobraMILP.m
+++ b/src/solvers/solveCobraMILP.m
@@ -375,6 +375,11 @@ switch solver
         cplexlp.Model.lb = lb;
         cplexlp.Model.obj = osense * c;
         cplexlp.Model.name = 'CobraMILP';
+        %Make sure, that the vartype is in the correct orientation, cplex
+        %is quite picky here..
+        if size(vartype,1) > size(vartype,2)
+            vartype = vartype';
+        end
         cplexlp.Model.ctype = vartype';
         cplexlp.Start.x = x0;
         cplexlp.Param.mip.tolerances.mipgap.Cur =  solverParams.relMipGapTol;

--- a/test/testSolvers/testSolvers.m
+++ b/test/testSolvers/testSolvers.m
@@ -14,46 +14,6 @@ x=1;
 %[solverOK, invalidConstraints, invalidVars, objective] = verifyCobraProblem(LPproblem, LPsolution.full);
 
 
-%MILP Solver test.
-%http://www.chemeng.ed.ac.uk/~jwp/MSO/section5/milp.html
-
-% 1. Set up MILP problem.
-MILPproblem.c = [20; 6; 8];
-MILPproblem.A = [0.8, 0.2, 0.3;
-    0.4, 0.3, 0;
-    0.2, 0, 0.1];
-MILPproblem.b = [20; 10; 5];
-MILPproblem.lb = [0; 0; 0];
-MILPproblem.ub = [1000; 1000; 1000];
-MILPproblem.osense = -1;
-MILPproblem.csense = ['L'; 'L'; 'L'];
-MILPproblem.vartype = ['I'; 'I'; 'I'];
-MILPproblem.x0 = [0, 0, 0];
-pass = 1;
-
-% 2. Solve MILP problem.
-try
-    %Solve MILP problem setting the relative MIP gap tolerance and
-    %integrality tolerance to 1e-12 using parameters structure.
-    parameters.relMipGapTol = 1e-12;
-    parameters.intTol = 1e-12;
-    MILPsolution = solveCobraMILP(MILPproblem, parameters);
-    %[solverOK, invalidConstraints, invalidVars, objective] = verifyCobraProblem(MILPproblem, MILPsolution.full);
-catch
-    disp('Error in MILP test');
-    x=0;
-    pass = 0;
-end
-
-% 3. Check results with expected answer.
-if pass == 1
-    if all(abs(MILPsolution.int - [0;31;46]) < tol) && abs(MILPsolution.obj - 554) < tol
-        display('MILP Test Passed');
-    else
-        display('MILP Test Not Passed');
-        x=0;
-    end
-end
 %QP Solver test.
 % http://tomopt.com/docs/quickguide/quickguide005.php
 

--- a/test/verifiedTests/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraLP.m
@@ -61,8 +61,7 @@ for k = 1:length(solverPkgs)
                 fprintf('   Running %s with solveCobraLP using %s ... ', testSuite{p}, solverPkgs{k});
 
                 if p == 1
-                    % 2. Solve LP problem.
-                    %solve LP problem printing summary information
+                    % solve LP problem printing summary information
                     for printLevel = 0:3
                         LPsolution = solveCobraLP(LPproblem, 'printLevel', printLevel);
                     end
@@ -89,6 +88,7 @@ for k = 1:length(solverPkgs)
                     assert(isequal(solution_solveCobraLP.dual, solution_optimizeCbModel.y))
                     assert(solution_solveCobraLP.stat == solution_optimizeCbModel.stat)
                 end
+
                 % output a success message
                 fprintf('Done.\n');
             end
@@ -104,3 +104,6 @@ for k = 1:length(solverPkgs)
         rmpath(genpath(path_GUROBI));
     end
 end
+
+% change the directory
+cd(CBTDIR)

--- a/test/verifiedTests/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraLP.m
@@ -21,9 +21,9 @@ CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSolvers']);
 
 % Dummy Model
-%http://www2.isye.gatech.edu/~spyros/LP/node2.html
+% http://www2.isye.gatech.edu/~spyros/LP/node2.html
 LPproblem.c = [200; 400];
-LPproblem.A = [1/40, 1/60; 1/50, 1/50];
+LPproblem.A = [1 / 40, 1 / 60; 1 / 50, 1 / 50];
 LPproblem.b = [1; 1];
 LPproblem.lb = [0; 0];
 LPproblem.ub = [1; 1];
@@ -33,7 +33,7 @@ LPproblem.csense = ['L'; 'L'];
 % set the tolerance
 tol = 1e-4;
 
-%test solver packages
+% test solver packages
 solverPkgs = {'cplex_direct', 'tomlab_cplex', 'gurobi6', 'glpk'};
 
 % list of tests
@@ -50,8 +50,8 @@ for k = 1:length(solverPkgs)
         addpath(genpath(path_GUROBI));
     end
 
-    if ~verLessThan('matlab', '8') && strcmp(solverPkgs{k}, 'cplex_direct') %2015
-        fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k},' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
+    if ~verLessThan('matlab', '8') && strcmp(solverPkgs{k}, 'cplex_direct')  % 2015
+        fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k}, ' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
     else
         % change the COBRA solver (LP)
         solverOK = changeCobraSolver(solverPkgs{k});
@@ -78,7 +78,7 @@ for k = 1:length(solverPkgs)
                     % solveCobraLP
                     solution_solveCobraLP = solveCobraLP(model);
 
-                    %optimizeCbModel
+                    % optimizeCbModel
                     solution_optimizeCbModel = optimizeCbModel(model);
 
                     % compare both solution objects

--- a/test/verifiedTests/testSolvers/testSolveCobraLPCPLEX.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraLPCPLEX.m
@@ -62,6 +62,9 @@ for k = 1:length(solverPkgs)
         %test basis reuse
         [solTest] = solveCobraLPCPLEX(basis, 0, 1, 0, [], 0, solverPkgs{k});
         assert(any(abs(solTest.obj - sol.obj) < tol));
+
+        % output a success message
+        fprintf('Done.\n');
     end
 
     % remove the solver paths (temporary addition for CI)

--- a/test/verifiedTests/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraMILP.m
@@ -1,0 +1,99 @@
+% The COBRAToolbox: testSolveCobraMILP.m
+%
+% Purpose:
+%     - testSolveCobraMILP tests the SolveCobraMILP function and its different methods
+%
+% Author:
+%     - Original file: Joseph Kang 11/16/09
+%     - CI integration: Laurent Heirendt, March 2017
+%
+% Note:
+%       test is performed on objective as solution can vary between machines, solver version etc..
+
+% define global paths
+global path_TOMLAB
+global path_ILOG_CPLEX
+global path_GUROBI
+global CBT_MILP_SOLVER
+
+% define the path to The COBRAToolbox
+pth = which('initCobraToolbox.m');
+CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
+
+initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSolvers']);
+
+%test solver packages
+solverPkgs = {'cplex_direct', 'tomlab_cplex', 'gurobi6', 'glpk'};
+
+% set the tolerance
+tol = 1e-8;
+
+for k = 1:length(solverPkgs)
+
+    % add the solver paths (temporary addition for CI)
+    if strcmp(solverPkgs{k}, 'tomlab_cplex')
+        addpath(genpath(path_TOMLAB));
+    elseif strcmp(solverPkgs{k}, 'cplex_direct')
+        addpath(genpath(path_ILOG_CPLEX));
+    elseif strcmp(solverPkgs{k}, 'gurobi6')
+        addpath(genpath(path_GUROBI));
+    end
+
+    if ~verLessThan('matlab', '8') && strcmp(solverPkgs{k}, 'cplex_direct') %2015
+        fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k},' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
+    else
+        fprintf('   Running solveCobraLPCPLEX using %s ... ', solverPkgs{k});
+
+        % change the COBRA solver (LP)
+        solverOK = changeCobraSolver(solverPkgs{k});
+
+        % set the global solver name
+        CBT_MILP_SOLVER = solverPkgs{k};
+
+        if solverOK
+            %MILP Solver test: chemeng.ed.ac.uk/~jwp/MSO/section5/milp.html
+
+            % set up MILP problem.
+            MILPproblem.c = [20; 6; 8];
+            MILPproblem.A = [0.8, 0.2, 0.3;
+                             0.4, 0.3, 0;
+                             0.2, 0, 0.1];
+            MILPproblem.b = [20; 10; 5];
+            MILPproblem.lb = [0; 0; 0];
+            MILPproblem.ub = [1000; 1000; 1000];
+            MILPproblem.osense = -1;
+            MILPproblem.csense = ['L'; 'L'; 'L'];
+            MILPproblem.vartype = ['I'; 'I'; 'I'];
+            MILPproblem.x0 = [0, 0, 0];
+            pass = 1;
+
+            % solve MILP problem setting the relative MIP gap tolerance and integrality tolerance to 1e-12 using parameters structure.
+            if strcmp(solverPkgs{k}, 'cplex_direct') || strcmp(solverPkgs{k}, 'tomlab_cplex')
+                parameters.relMipGapTol = 1e-12;
+                parameters.intTol = 1e-12;
+                MILPsolution = solveCobraMILP(MILPproblem, parameters);
+            else
+                MILPsolution = solveCobraMILP(MILPproblem);
+            end
+
+            % check results with expected answer.
+            assert(all(abs(MILPsolution.int - [0; 31; 46]) < tol))
+            assert(abs(MILPsolution.obj - 554) < tol)
+        end
+
+        % output a success message
+        fprintf('Done.\n');
+    end
+
+    % remove the solver paths (temporary addition for CI)
+    if strcmp(solverPkgs{k}, 'tomlab_cplex')
+        rmpath(genpath(path_TOMLAB));
+    elseif strcmp(solverPkgs{k}, 'cplex_direct')
+        rmpath(genpath(path_ILOG_CPLEX));
+    elseif strcmp(solverPkgs{k}, 'gurobi6')
+        rmpath(genpath(path_GUROBI));
+    end
+end
+
+% change the directory
+cd(CBTDIR)

--- a/test/verifiedTests/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraMILP.m
@@ -22,7 +22,7 @@ CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 
 initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSolvers']);
 
-%test solver packages
+% test solver packages
 solverPkgs = {'cplex_direct', 'ibm_cplex', 'tomlab_cplex', 'gurobi6', 'glpk'};
 
 % set the tolerance
@@ -40,7 +40,7 @@ for k = 1:length(solverPkgs)
     end
 
     if (~verLessThan('matlab', '8.4') && strcmp(solverPkgs{k}, 'cplex_direct')) || (~verLessThan('matlab', '9') && strcmp(solverPkgs{k}, 'ibm_cplex'))
-        fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k},' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
+        fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k}, ' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
     else
         fprintf('   Running solveCobraLPCPLEX using %s ... ', solverPkgs{k});
 
@@ -51,7 +51,7 @@ for k = 1:length(solverPkgs)
         CBT_MILP_SOLVER = solverPkgs{k};
 
         if solverOK
-            %MILP Solver test: chemeng.ed.ac.uk/~jwp/MSO/section5/milp.html
+            % MILP Solver test: chemeng.ed.ac.uk/~jwp/MSO/section5/milp.html
 
             % set up MILP problem.
             MILPproblem.c = [20; 6; 8];

--- a/test/verifiedTests/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraMILP.m
@@ -23,7 +23,7 @@ CBTDIR = pth(1:end - (length('initCobraToolbox.m') + 1));
 initTest([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSolvers']);
 
 %test solver packages
-solverPkgs = {'cplex_direct', 'tomlab_cplex', 'gurobi6', 'glpk'};
+solverPkgs = {'cplex_direct', 'ibm_cplex', 'tomlab_cplex', 'gurobi6', 'glpk'};
 
 % set the tolerance
 tol = 1e-8;
@@ -33,13 +33,13 @@ for k = 1:length(solverPkgs)
     % add the solver paths (temporary addition for CI)
     if strcmp(solverPkgs{k}, 'tomlab_cplex')
         addpath(genpath(path_TOMLAB));
-    elseif strcmp(solverPkgs{k}, 'cplex_direct')
+    elseif strcmp(solverPkgs{k}, 'cplex_direct') || strcmp(solverPkgs{k}, 'ibm_cplex')
         addpath(genpath(path_ILOG_CPLEX));
     elseif strcmp(solverPkgs{k}, 'gurobi6')
         addpath(genpath(path_GUROBI));
     end
 
-    if ~verLessThan('matlab', '8') && strcmp(solverPkgs{k}, 'cplex_direct') %2015
+    if (~verLessThan('matlab', '8.4') && strcmp(solverPkgs{k}, 'cplex_direct')) || (~verLessThan('matlab', '9') && strcmp(solverPkgs{k}, 'ibm_cplex'))
         fprintf(['\n IBM ILOG CPLEX - ', solverPkgs{k},' - is incompatible with this version of MATLAB, please downgrade or change solver\n'])
     else
         fprintf('   Running solveCobraLPCPLEX using %s ... ', solverPkgs{k});
@@ -88,11 +88,17 @@ for k = 1:length(solverPkgs)
     % remove the solver paths (temporary addition for CI)
     if strcmp(solverPkgs{k}, 'tomlab_cplex')
         rmpath(genpath(path_TOMLAB));
-    elseif strcmp(solverPkgs{k}, 'cplex_direct')
+    elseif strcmp(solverPkgs{k}, 'cplex_direct') || strcmp(solverPkgs{k}, 'ibm_cplex')
         rmpath(genpath(path_ILOG_CPLEX));
     elseif strcmp(solverPkgs{k}, 'gurobi6')
         rmpath(genpath(path_GUROBI));
     end
+end
+
+% remove the generated file
+fullFileNamePath = [CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'testSolvers', filesep, 'MILPProblem.mat'];
+if exist(fullFileNamePath, 'file') == 2
+    system(['rm ', fullFileNamePath]);
 end
 
 % change the directory


### PR DESCRIPTION
**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md) document
- [X] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#code-styleguide)
- [X] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [X] Written platform-independent code
- [X] Used `pwd` to get the current directory
- [X] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [X] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)

e.g. OptKnock produced a row vector for the vartype, which was previously transposed in the cplex setup. The current code ensures, that transposition only happens if the ctype vector would otherwise have the wrong orientation.

###  Tests tailored to test the PR

No specific test for this PR.
