### PR TITLE
Updated RetrieveModels to not change the path, and using builtin func…

### DIFF
--- a/test/models/retrieveModels.m
+++ b/test/models/retrieveModels.m
@@ -1,7 +1,7 @@
 % retrieve models required for testing the CI that are published, but released as part of the COBRA Toolbox
 % eventual enhancement with rsync possible
 
-cwd = pwd;
+currentDir = pwd;
 MODELDIR = fileparts(which('retrieveModels.m'));
 cd(MODELDIR);
 
@@ -47,5 +47,5 @@ else
 end
 
 % change back to the root directory
-cd(cwd)
+cd(currentDir)
 

--- a/test/models/retrieveModels.m
+++ b/test/models/retrieveModels.m
@@ -1,8 +1,8 @@
 % retrieve models required for testing the CI that are published, but released as part of the COBRA Toolbox
 % eventual enhancement with rsync possible
 
-pth = which('retrieveModels.m');
-MODELDIR = pth(1:end-(length('retrieveModels.m')+1));
+cwd = pwd;
+MODELDIR = fileparts(which('retrieveModels.m'));
 cd(MODELDIR);
 
 fprintf('\nDownloading models ...\n');
@@ -47,4 +47,5 @@ else
 end
 
 % change back to the root directory
-cd('../../')
+cd(cwd)
+


### PR DESCRIPTION
…tionality to obtain its own path

*(Note: You may replace [ ] with [X] to check the box)*

**I hereby confirm that I have:**

- [X ] Tested my code on my own machine
- [X ] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md) document
- [X ] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#code-styleguide)
- [X ] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [X ] Written platform-independent code
- [X ] Used `pwd` to get the current directory
- [X ] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [X ] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)
retrieveModels no longer switches to the base folder but to the previous working directory

