### PR TITLE
turned off default printing of solver iterations on linux

### DIFF
--- a/src/solvers/solveCobraLPCPLEX.m
+++ b/src/solvers/solveCobraLPCPLEX.m
@@ -117,7 +117,10 @@ end
 if ~exist('minNorm','var')
     minNorm=0;
 end
-
+if ~printLevel && isunix
+    %turn off solver iterations that is on by default in Linux
+    cpxControl.SCRIND = 0;
+end
 if basisReuse
     if isfield(LPProblem,'LPBasis')
         basis=LPProblem.LPBasis;

--- a/src/solvers/solveCobraLPCPLEX.m
+++ b/src/solvers/solveCobraLPCPLEX.m
@@ -117,7 +117,7 @@ end
 if ~exist('minNorm','var')
     minNorm=0;
 end
-if ~printLevel && isunix
+if printLevel==0
     %turn off solver iterations that is on by default in Linux
     cpxControl.SCRIND = 0;
 end


### PR DESCRIPTION
*(Note: You may replace [ ] with [X] to check the box)*

**I hereby confirm that I have:**

- [ ] Tested my code on my own machine
- [ ] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md) document
- [ ] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#code-styleguide)
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [ ] Written platform-independent code
- [ ] Used `pwd` to get the current directory
- [ ] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [ ] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)

Turned off CPX_PARAM_SCRIND when verbose is 0 in unix platforms.
In Windows, the parameter is turned off by default.

Parameter log from CPLEX doc 
https://www.ibm.com/support/knowledgecenter/SSSA5P_12.6.3/ilog.odms.studio.help/pdf/paramcplex.pdf

messages to screen switch
Decides whether or not results are displayed on screen in an application of the C API.
Purpose
Messages to screen switch

Description
Decides whether or not results are displayed on screen.
In an application of the Callable Library (C API), this parameter works by adding
or removing stdout to or from the result, warning, and error channels.
Consequently, good practice dictates that your Callable Library application must
not manage stdout in those channels directly at the same time as your application
uses this parameter. Indeed, if your application uses this parameter as well as
stdout on the result, warning, or error channels at the same time, undefined
behavior can occur.
To turn off output to the screen, in a C++ application, where cplex is an instance
of the class IloCplex and env is an instance of the class IloEnv , the environment,
use cplex.setOut(env.getNullStream()) .
In a Java application, use cplex.setOut(null).

#### Previous output

[*Include here information of the current version of The COBRA Toolbox*]

#### Output of PR-merged version

[*Include here information of modified version of The COBRA Toolbox after your proposed PR is accepted*]

###  Documentation updates

[*Include here information on how the documentation has been updated*]

**I hereby confirm that I have:**

- [ ] Documented your code based on the [Documentation styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#documentation-and-comments-styleguide).
- [ ] Documented the `Input` and `Output` arguments
- [ ] Followed the guidelines to automatically generate the documentation

###  Tests tailored to test the PR

[*Include here information on how new tests and/or how existing tests have been adapted*]

**I hereby confirm that I have:**

- [ ] Written a sensible test according to the [Test styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#test-styleguide)
- [ ] Tested your PR locally prior to submission
- [ ] Checked that all tests pass
- [ ] Tested the code on Linux