### PR TITLE
Problem with n_nint

### DIFF
--- a/src/design/createBilevelMILPproblem.m
+++ b/src/design/createBilevelMILPproblem.m
@@ -121,7 +121,7 @@ sel_ic = zeros(length(sel_int),1);
 sel_ic(ind_ic) = 1;
 % Number of inner problem primal varibles with no integers associated with
 % them & not part of the special constraint set
-n_nint = n - n_int - sum(sel_ic);
+% n_nint = n - n_int - sum(sel_ic);
 % Number of reversible rxns with integer
 [n_intr,tmp] = size(rev_int);
 % Number of measured fluxes (count only positive directions)
@@ -177,6 +177,7 @@ c_bl(2*n+2*n_int+m+n_ic+n_m+1:2*n+2*n_int+m+n_ic+2*n_m) = wt_m;
 % Create necessary integer matrices (for SF/n_int sets)
 Iint = selMatrix(sel_int);
 Inint = selMatrix(~sel_int & ~sel_ic);
+n_nint = size(Inint, 1);
 Iic = sparse(n_ic,n);
 for i = 1:length(ind_ic)
     idx_ic = ind_ic(i);


### PR DESCRIPTION
n_nint does not account for reactions that were "selected" for knockout but have special constraints

*(Note: You may replace [ ] with [X] to check the box)*

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [ ] Followed the guidelines in the [contributing](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md) document
- [ ] Followed the [code styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#code-styleguide)
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/opencobra/cobratoolbox/pulls) for the same update/change
- [ ] Written platform-independent code
- [ ] Used `pwd` to get the current directory
- [ ] Used `filesep` for paths (e.g., `['myPath' filesep 'myFile.m']`)
- [x] Made sure that computational results are reproducible

### Errors/fixes (with reference to eventual open issues)

#### Previous output

[*Include here information of the current version of The COBRA Toolbox*]

#### Output of PR-merged version

[*Include here information of modified version of The COBRA Toolbox after your proposed PR is accepted*]

###  Documentation updates

[*Include here information on how the documentation has been updated*]

**I hereby confirm that I have:**

- [ ] Documented your code based on the [Documentation styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#documentation-and-comments-styleguide).
- [ ] Documented the `Input` and `Output` arguments
- [ ] Followed the guidelines to automatically generate the documentation

###  Tests tailored to test the PR

[*Include here information on how new tests and/or how existing tests have been adapted*]

**I hereby confirm that I have:**

- [ ] Written a sensible test according to the [Test styleguide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md#test-styleguide)
- [ ] Tested your PR locally prior to submission
- [ ] Checked that all tests pass
- [ ] Tested the code on Linux
