### PR TITLE
:bug: Adjusted comparisons to assignments and assigned values

### DIFF
--- a/updateCobraToolbox.m
+++ b/updateCobraToolbox.m
@@ -35,8 +35,8 @@ function updateCobraToolbox(fetchAndCheckOnly)
             result_gitCountMaster = char(result_gitCountMaster);
             result_gitCountMaster = result_gitCountMaster(1:end-1);
         else
-            status_gitCountMaster == 0;
-            result_gitCountMaster == '';
+            status_gitCountMaster = 0;
+            result_gitCountMaster = '0';
         end
 
         % check if develop branch exists
@@ -48,8 +48,8 @@ function updateCobraToolbox(fetchAndCheckOnly)
             result_gitCountDevelop = char(result_gitCountDevelop);
             result_gitCountDevelop = result_gitCountDevelop(1:end-1);
         else
-            status_gitCountDevelop == 0;
-            result_gitCountDevelop == '';
+            status_gitCountDevelop = 0;
+            result_gitCountDevelop = '0';
         end
 
         if status_gitCountMaster == 0 && status_gitCountDevelop == 0


### PR DESCRIPTION
In updateCobraToolbox two comparisons were made instead of assignments, and the assigned values were unusable ('' evaluates to [] in str2num, while 0 was desired)

**I hereby confirm that I have:**

- [X] Selected `develop` as a target branch (top left drop-down menu)
- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md)

*(Note: You may replace [ ] with [X] to check the box)*
