### PR TITLE
Using matlabroot/toolbox/local/pathdef.m if write access

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -44,8 +44,24 @@ function initCobraToolbox()
     WAITBAR_TYPE = 1;
 
     % Linux only - default save path location
-    defaultSavePathLocation = '~/pathdef.m';
-
+    %Check if we can write in the root folder
+    rootpathdef = [matlabroot filesep 'toolbox' filesep 'local' filesep 'pathdef.m' ];
+    %Try to read/write the file, if both works, we can write to the
+    %directory, else we need to use the home folder.
+    [status,~] = copyfile(rootpathdef, 'pathdef_cobra.m');    
+    if status == 1
+        [status,~] = copyfile('pathdef_cobra.m',rootpathdef);
+        if status == 1
+            defaultSavePathLocation = rootpathdef;            
+        else
+            defaultSavePathLocation = '~/pathdef.m';
+        end
+        %if we copied it, we also need to clean it again
+        delete('pathdef_cobra.m')
+    else
+        defaultSavePathLocation = '~/pathdef.m';
+    end
+    
     % initialize the cell of solvers
     SOLVERS = {};
 


### PR DESCRIPTION
Changed the default save location for the pathdef.m if write access to the matlab folder is available. 
The home folder location can interfere with different matlab installations.


**I hereby confirm that I have:**

- [X] Selected `develop` as a target branch (top left drop-down menu)
- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://github.com/opencobra/cobratoolbox/blob/master/.github/CONTRIBUTING.md)

*(Note: You may replace [ ] with [X] to check the box)*
