### PR TITLE
FIX - bounds trouble in converToIrreversible.m

### DIFF
--- a/src/reconstruction/refinement/convertToIrreversible.m
+++ b/src/reconstruction/refinement/convertToIrreversible.m
@@ -94,7 +94,12 @@ for i = 1:nRxns
         modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
         modelIrrev.rev(cnt) = true;
         modelIrrev.lb(cnt) = 0;
-        modelIrrev.ub(cnt) = - model.lb(i);
+        %if original reaction has a positive lb, backwards reaction should have nonnegative upper bound.
+        if model.lb(i)<0
+            modelIrrev.ub(cnt) = - model.lb(i);
+        else
+            modelIrrev.ub(cnt) =  model.lb(i);
+        end
         modelIrrev.c(cnt) = 0;
         rev2irrev{i} = [cnt-1 cnt];
         irrev2rev(cnt) = i;

--- a/src/reconstruction/refinement/convertToIrreversible.m
+++ b/src/reconstruction/refinement/convertToIrreversible.m
@@ -67,15 +67,10 @@ for i = 1:nRxns
         modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
         model.rev(i) = false;
         modelIrrev.rev(cnt) = false;
-    else
-        % Keep positive upper bound
-        modelIrrev.ub(cnt) = model.ub(i);
+    else 
         %if the lb is less than zero, set the forward rxn lb to zero
-        if model.lb(i) < 0
-            modelIrrev.lb(cnt) = 0;
-        else
-            modelIrrev.lb(cnt) = model.lb(i);
-        end
+        modelIrrev.lb(cnt) = max(0, model.lb(i));
+        modelIrrev.ub(cnt) = max(0, model.ub(i));
         modelIrrev.S(:, cnt) = model.S(:, i);
         modelIrrev.c(cnt) = model.c(i);
         modelIrrev.rxns{cnt} = model.rxns{i};
@@ -93,13 +88,9 @@ for i = 1:nRxns
         modelIrrev.S(:, cnt) = - model.S(:, i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
         modelIrrev.rev(cnt) = true;
-        modelIrrev.lb(cnt) = 0;
-        %if original reaction has a positive lb, backwards reaction should have nonnegative upper bound.
-        if model.lb(i)<0
-            modelIrrev.ub(cnt) = - model.lb(i);
-        else
-            modelIrrev.ub(cnt) =  model.lb(i);
-        end
+        modelIrrev.lb(cnt) = max(0, -model.ub(i));
+        %if original reaction has a positive lb, backwards reaction should have nonnegative upper bound.        
+        modelIrrev.ub(cnt) = max(0, -model.lb(i));
         modelIrrev.c(cnt) = 0;
         rev2irrev{i} = [cnt-1 cnt];
         irrev2rev(cnt) = i;


### PR DESCRIPTION
If original reaction has a positive lb, backwards reaction should have nonnegative upper bound