### PR TITLE
scripts to test a list of metabolic tasks

### DIFF
--- a/docs/source/modules/MetabolicTask.rst
+++ b/docs/source/modules/MetabolicTask.rst
@@ -1,0 +1,9 @@
+
+.. _MetabolicTask:
+
+
+MetabolicTask
+-----
+.. automodule:: src.dataIntegration.transcriptomics.MetabolicTask
+   :members:
+

--- a/docs/source/modules/transcriptomics.rst
+++ b/docs/source/modules/transcriptomics.rst
@@ -6,6 +6,7 @@ Transcriptomics
 .. toctree::
 
    FASTCORE
+   MetabolicTask
 
 .. automodule:: src.dataIntegration.transcriptomics
    :members:

--- a/src/dataIntegration/transcriptomics/MetabolicTask/checkMetabolicTasks.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/checkMetabolicTasks.m
@@ -1,20 +1,23 @@
 function [taskReport essentialRxns taskStructure]=checkMetabolicTasks(model,inputFile,printOutput,printOnlyFailed,getEssential,taskStructure)
 % checkMetabolicTasks performs a set of simulations as defined in a task file
 % to check if the model is able to pass a list of metabolic tasks.
-%  A metabolic task is defined as the capacity of producing a list of
-% "outputs" products when ONLY a defined list of "inputs" substrates are
+% A metabolic task is defined as the capacity of producing a list of
+% output products when ONLY a defined list of inputs substrates are
 % available. In other words, a model successfuly pass a metabolic task if it is
 % still a solvable LP problem when ONLY exchange reactions related to 
 % the inputs substrates and outputs products are allowed to carry fluxes 
 %
-% INPUTS
+% USAGE : [taskReport essentialReactions taskStructure]=checkMetabolicTasks(model,inputFile,...
+%           printOutput,printOnlyFailed,getEssential,taskStructure)
+%
+% INPUTS :
 %
 %   model           a model structure
 %   inputFile       a task list in Excel format. See the function
 %                   parseTaskList for details (opt if taskStructure is
 %                   supplied)
 %
-%OPTIONAL INPUTS
+% OPTIONAL INPUTS :
 %   printOutput     true if the results of the test should be displayed
 %                   (default - true)
 %   printOnlyFailed true if only tasks that failed should be displayed
@@ -25,7 +28,7 @@ function [taskReport essentialRxns taskStructure]=checkMetabolicTasks(model,inpu
 %   taskStructure   structure with the tasks, as from parseTaskList. If
 %                   this is supplied then inputFile is ignored
 %
-% OUTPUTS
+% OUTPUTS :
 %
 %   taskReport          structure with the results
 %       firstcolumn     id              cell array with the id of the task
@@ -38,20 +41,9 @@ function [taskReport essentialRxns taskStructure]=checkMetabolicTasks(model,inpu
 %
 %   taskStructure   structure with the tasks, as from parseTaskList.
 %
-%   This function is used for defining a set of tasks for a model to
-%   perform. The tasks are defined by defining constraints on the model,
-%   and if the problem is feasible, then the task is considered successful.
-%   In general, each row can contain one constraint on uptakes and one 
-%   constraint on outputs. 
-%
-%   Usage: [taskReport essentialReactions taskStructure]=checkMetabolicTasks(model,inputFile,...
-%           printOutput,printOnlyFailed,getEssential,taskStructure)
-%
-%   Originally written for RAVEN toolbox by
-%   Rasmus Agren, 2013-11-17
-%   Adapted for cobratoolbox and modified to rely only on flux constraints by
-%   Richelle Anne, 2017-05-18
-%
+% .. Author : Originally written for RAVEN toolbox by Rasmus Agren, 2013-11-17
+% Adapted for cobratoolbox and modified to rely only on flux constraints by
+% Richelle Anne, 2017-05-18
 
 if nargin < 3 || isempty(printOutput)
     printOutput=true;

--- a/src/dataIntegration/transcriptomics/MetabolicTask/checkMetabolicTasks.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/checkMetabolicTasks.m
@@ -1,0 +1,430 @@
+function [taskReport essentialRxns taskStructure]=checkMetabolicTasks(model,inputFile,printOutput,printOnlyFailed,getEssential,taskStructure)
+% checkMetabolicTasks performs a set of simulations as defined in a task file
+% to check if the model is able to pass a list of metabolic tasks.
+%  A metabolic task is defined as the capacity of producing a list of
+% "outputs" products when ONLY a defined list of "inputs" substrates are
+% available. In other words, a model successfuly pass a metabolic task if it is
+% still a solvable LP problem when ONLY exchange reactions related to 
+% the inputs substrates and outputs products are allowed to carry fluxes 
+%
+% INPUTS
+%
+%   model           a model structure
+%   inputFile       a task list in Excel format. See the function
+%                   parseTaskList for details (opt if taskStructure is
+%                   supplied)
+%
+%OPTIONAL INPUTS
+%   printOutput     true if the results of the test should be displayed
+%                   (default - true)
+%   printOnlyFailed true if only tasks that failed should be displayed
+%                   (default - false)
+%   getEssential    true if the minimal number of reactions that need to be
+%                   active to pass the task need to be computed
+%                   (default - false)
+%   taskStructure   structure with the tasks, as from parseTaskList. If
+%                   this is supplied then inputFile is ignored
+%
+% OUTPUTS
+%
+%   taskReport          structure with the results
+%       firstcolumn     id              cell array with the id of the task
+%       secondcolumn    description     cell array with the description of the task
+%       thirdcolumn     ok              boolean array with true if the task
+%       was successful
+%
+%   essentialRxns   cell array containing the essential reactions required
+%                   to pass a task
+%
+%   taskStructure   structure with the tasks, as from parseTaskList.
+%
+%   This function is used for defining a set of tasks for a model to
+%   perform. The tasks are defined by defining constraints on the model,
+%   and if the problem is feasible, then the task is considered successful.
+%   In general, each row can contain one constraint on uptakes and one 
+%   constraint on outputs. 
+%
+%   Usage: [taskReport essentialReactions taskStructure]=checkMetabolicTasks(model,inputFile,...
+%           printOutput,printOnlyFailed,getEssential,taskStructure)
+%
+%   Originally written for RAVEN toolbox by
+%   Rasmus Agren, 2013-11-17
+%   Adapted for cobratoolbox and modified to rely only on flux constraints by
+%   Richelle Anne, 2017-05-18
+%
+
+if nargin < 3 || isempty(printOutput)
+    printOutput=true;
+end
+if nargin < 4 || isempty(printOnlyFailed)
+    printOnlyFailed=false;
+end
+if nargin < 5 || isempty(getEssential)
+    getEssential=false;
+end
+% Generate a task structure from a list of task in excell format
+if nargin < 6 || isempty(taskStructure)
+  taskStructure=generateTaskStructure(inputFile); 
+end
+
+
+%CHECK the format of the model
+if size(model.rxns,2)>size(model.rxns,1)
+    model.rxns=model.rxns';
+end
+if size(model.rxnNames,2)>size(model.rxnNames,1)
+    model.rxnNames=model.rxnNames';
+end
+if size(model.rules,2)>size(model.rules,1)
+    model.rules=model.rules';
+end
+if size(model.grRules,2)>size(model.grRules,1)
+    model.grRules=model.grRules';
+end
+
+%Find all exchange/demand/sink reactions
+Exchange = {};
+for k=1:length(model.rxns)
+    if sum(abs(model.S(:,k))) == 1  
+        Exchange(end+1) = model.rxns(k);
+    end
+end
+Exchange=unique(Exchange);
+
+%Close all exchange reactions
+model.lb(findRxnIDs(model,Exchange))=0;
+model.ub(findRxnIDs(model,Exchange))=0;
+
+
+score=0;
+totalTask=0;
+notPresent=0;
+taskReport={numel(taskStructure),3};
+essentialRxns={numel(taskStructure)};
+for i=1:numel(taskStructure)
+
+    clear tModel
+    tModel=model;
+    modelMets=upper(tModel.mets);
+    
+    %%SETUP of the input model
+    %suppress objective function if any
+    tModel.c(tModel.c==1)=0;
+    tModel.csense(1:length(model.b),1) = 'E';
+
+    taskReport{i,1}=taskStructure(i).id;
+    taskReport{i,2}=taskStructure(i).description;
+    
+    %Set the inputs
+    if ~isempty(taskStructure(i).inputs)
+        
+        rxn_Subs={};
+        for n=1:length(taskStructure(i).inputs)
+            INPUT=taskStructure(i).inputs(n);
+            INPUT=INPUT{1};
+            match_INPUTS = strncmpi(INPUT,modelMets,length(INPUT(1:end-3)));
+            match_INPUTS = modelMets(match_INPUTS==1);
+                        
+            compSymbol={};
+            for k=1:length(match_INPUTS)
+                [tokens] = regexp(match_INPUTS{k},'(.+)\[(.+)\]','tokens');
+                Symb = tokens{1}{2};
+                compSymbol{end+1} = Symb;
+            end
+            
+            % Set the exchange reactions for the inputs
+            % If the metabolites already exist extracellularly
+            AddExchange=0;
+            if ismember('E',compSymbol)==1
+                Tsp_ID=findRxnIDs(tModel,findRxnsFromMets(tModel,INPUT));
+                Tsp_rxn = full(tModel.S(:,Tsp_ID));
+                Nb_React=sum(abs(Tsp_rxn),1);
+                
+                % If an exchange reaction already exist
+                if isempty(Nb_React==1)==0
+                    ID_exc=find(Nb_React==1);
+                    % Remove the existing exchange reaction
+                    tModel=removeRxns(tModel,tModel.rxns(Tsp_ID(ID_exc)));
+                    AddExchange=1;
+                else 
+                    AddExchange=1;
+                end
+            else
+            	AddExchange=1;
+            end
+            
+            % Add a temporary exchange reaction that allows the import of
+            % the metabolite 
+            if AddExchange==1
+                % If the input is also member of the outputs, let the exchange reversible
+                warning off
+                if ismember(INPUT,taskStructure(i).outputs)==1
+                	[tModel]=addReaction(tModel,['temporary_exchange_',INPUT(1:end-3)],[' <=> ',INPUT],[],[],-1000,1000,[], [], [], [], [], [],0);
+                else
+                	[tModel]=addReaction(tModel,['temporary_exchange_',INPUT(1:end-3)],[' => ',INPUT],[],[],taskStructure(i).LBin(n),taskStructure(i).UBin(n),[], [], [], [], [], [],0);  
+                end
+                warning on
+                rxn_Subs(end+1) = {['temporary_exchange_',INPUT(1:end-3)]};
+            end
+            
+            % Definition of the compartment for the transport reaction
+            if ischar(taskStructure(i).COMP)==1
+                comp_used=taskStructure(i).COMP;
+                if strcmpi(comp_used,'[e]')==1
+                    continue
+                end
+            elseif ismember('C',compSymbol)==1
+                comp_used='[c]';
+            elseif ismember('M',compSymbol)==1
+                comp_used='[m]';
+            elseif ismember('N',compSymbol)==1
+                comp_used='[n]';
+            elseif ismember('X',compSymbol)==1
+                comp_used='[x]';
+            elseif ismember('L',compSymbol)==1
+                comp_used='[l]';
+            elseif ismember('R',compSymbol)==1
+                comp_used='[R]';
+            end
+            
+            % Set the transport reactions for the inputs
+            % Find existing transporters associated with the input
+            AddTransport=0;
+            Tsp_ID=findRxnIDs(tModel,findRxnsFromMets(tModel,INPUT));
+            Tsp_rxn = full(tModel.S(:,Tsp_ID));
+            Nb_React=sum(abs(Tsp_rxn),1);
+            
+            % If free diffusion exist
+            if isempty(Nb_React==2)==0
+                Tsp_ID2=Tsp_ID(Nb_React==2);
+            
+                % Choose the transport reaction related to the defined
+                % compartment (comp_used)
+                Tsp_ID=Tsp_ID2(tModel.S((strcmpi(tModel.mets,([INPUT(1:end-3),comp_used]))==1),Tsp_ID2)~=0);
+                if isempty(Tsp_ID)==0
+                    % Remove the existing transport reaction
+                    tModel=removeRxns(tModel,tModel.rxns(Tsp_ID)); 
+                    AddTransport=1;
+                else
+                    AddTransport=1;
+                end
+            else 
+                AddTransport=1;
+            end
+            
+            %Create a transport reaction
+            if AddTransport==1
+                warning off
+                if ismember(INPUT,taskStructure(i).outputs)==1
+                        %if the input is also output make the reaction
+                        %reversible
+                        [tModel]=addReaction(tModel,['temporary_trsp_',INPUT(1:end-3)],[INPUT,' <=> ',INPUT(1:end-3),comp_used],[],[],-1000,1000,[], [], [], [], [], [],0);   
+                else
+                        [tModel]=addReaction(tModel,['temporary_trsp_',INPUT(1:end-3)],[INPUT,' => ',INPUT(1:end-3),comp_used],[],[],taskStructure(i).LBin(n),taskStructure(i).UBin(n),[], [], [], [], [], [],0);  
+
+                end
+                warning on
+                rxn_Subs(end+1) = {['temporary_trsp_',INPUT(1:end-3)]};
+            end
+            
+        end
+    end
+
+    modelMets=upper(tModel.mets);
+    [I J]=ismember(upper(taskStructure(i).inputs),modelMets);
+    J=J(I);
+    %Check that all metabolites are either real metabolites 
+    if ~all(I)
+        fprintf(['ERROR: Could not find all inputs in "[' taskStructure(i).id '] ' taskStructure(i).description '"\n']);
+    	taskReport{i,3}='Could not find all inputs';
+    	notPresent=notPresent+1;
+    end
+    if numel(J)~=numel(unique(J))
+    	dispEM(['The constraints on some input(s) in "[' taskStructure(i).id '] ' taskStructure(i).description '" are defined more than one time']);  
+    end
+
+    %Set the outputs
+    if ~isempty(taskStructure(i).outputs)
+
+        rxn_Prod={};
+        for n=1:length(taskStructure(i).outputs)
+            OUTPUT=taskStructure(i).outputs(n);
+        	OUTPUT=OUTPUT{1};
+
+        	%skip the setup if output is also input as it has already been
+        	%setup
+            if ismember(upper(OUTPUT),upper(taskStructure(i).inputs))==1
+            	continue
+            end
+
+            match_OUTPUTS = strncmpi(OUTPUT,modelMets,length(OUTPUT(1:end-3)));
+            match_OUTPUTS = modelMets(match_OUTPUTS==1);
+            compSymbol={};
+            for k=1:length(match_OUTPUTS)
+                [tokens] = regexp(match_OUTPUTS{k},'(.+)\[(.+)\]','tokens');
+            	Symb = tokens{1}{2};
+            	compSymbol{end+1} = Symb;
+            end
+
+            % Set the exchange reactions for the outputs
+            % If the metabolites already exist extracellularly
+            AddExchange=0;
+            if ismember('E',compSymbol)==1
+            	Tsp_ID=findRxnIDs(tModel,findRxnsFromMets(tModel,OUTPUT));
+                Tsp_rxn = full(tModel.S(:,Tsp_ID));
+                Nb_React=sum(abs(Tsp_rxn),1);
+                % If an exchange reaction already exist
+                if isempty(Nb_React==1)==0
+                	ID_exc=find(Nb_React==1);
+                    % Remove the existing exchange reaction
+                    tModel=removeRxns(tModel,tModel.rxns(Tsp_ID(ID_exc)));
+                    AddExchange=1;
+                else
+                    AddExchange=1;
+                end
+            else
+                AddExchange=1;
+            end
+
+            % Add a temporary exchange reaction that allows the export of
+            % the metabolite 
+            if AddExchange==1
+                warning off
+            	[tModel]=addReaction(tModel,['temporary_exchange_',OUTPUT(1:end-3)],[OUTPUT,' => '],[],[],taskStructure(i).LBout(n),taskStructure(i).UBout(n),[], [], [], [], [], [],0);  
+                warning on
+                rxn_Prod(end+1) = {['temporary_exchange_',OUTPUT(1:end-3)]};
+            end
+
+            % Definition of the compartment for the transport reaction
+            if ischar(taskStructure(i).COMP)==1
+            	comp_used=taskStructure(i).COMP;
+                if strcmpi(comp_used,'[e]')==1
+                	continue
+                end
+            elseif ismember('C',compSymbol)==1
+            	comp_used='[c]';
+            elseif ismember('M',compSymbol)==1
+            	comp_used='[m]';
+            elseif ismember('N',compSymbol)==1
+            	comp_used='[n]';
+           	elseif ismember('X',compSymbol)==1
+                comp_used='[x]';
+            elseif ismember('L',compSymbol)==1
+             	comp_used='[l]';
+            elseif ismember('R',compSymbol)==1
+                comp_used='[R]';
+            end
+
+            % Set the transport reactions for the outputs
+            % Find existing transporters associated with the ouput
+            AddTransport=0;
+            Tsp_ID=findRxnIDs(tModel,findRxnsFromMets(tModel,OUTPUT));
+            Tsp_rxn = full(tModel.S(:,Tsp_ID));
+            Nb_React=sum(abs(Tsp_rxn),1);
+
+            % If free diffusion exist
+            if isempty(Nb_React==2)==0
+                Tsp_ID2=Tsp_ID(Nb_React==2);
+
+                % Choose the transport reaction related to the defined
+                % compartment (comp_used)
+                Tsp_ID=Tsp_ID2(tModel.S((strcmpi(tModel.mets,([OUTPUT(1:end-3),comp_used]))==1),Tsp_ID2)~=0);
+                if isempty(Tsp_ID)==0
+                    % Remove the existing transport reaction
+                    tModel=removeRxns(tModel,tModel.rxns(Tsp_ID));
+                    AddTransport=1;
+                else 
+                    AddTransport=1;
+                end
+            else 
+                AddTransport=1;
+            end
+
+            %Create a transport reaction
+            if AddTransport==1
+                warning off
+            	[tModel]=addReaction(tModel,['temporary_trsp_',OUTPUT(1:end-3)],[OUTPUT(1:end-3),comp_used,' => ',OUTPUT],[],[],taskStructure(i).LBout(n),taskStructure(i).UBout(n),[], [], [], [], [], [],0);
+                warning on
+                rxn_Prod(end+1) = {['temporary_trsp_',OUTPUT(1:end-3)]};
+            end
+        end
+    end
+
+    modelMets=upper(tModel.mets);
+    [I J]=ismember(upper(taskStructure(i).outputs),modelMets);
+    J=J(I);
+
+    %Check that all metabolites are either real metabolites
+    if ~all(I)
+        fprintf(['ERROR: Could not find all outputs in "[' taskStructure(i).id '] ' taskStructure(i).description '"\n']);
+        taskReport{i,3}='Could not find all outputs';
+        notPresent=notPresent+1;
+    end
+    if numel(J)~=numel(unique(J))
+        dispEM(['The constraints on some output(s) in "[' taskStructure(i).id '] ' taskStructure(i).description '" are defined more than one time']);  
+    end
+
+    
+	%Solve the constrained problem
+	tModel.csense(1:length(tModel.mets),1) = 'E';
+	tModel.osense = -1;
+	tModel.A=tModel.S;
+	sol=solveCobraLP(tModel);
+       
+    if ~isempty(sol.full)
+        if sum(abs(sol.full))~=0
+            if taskStructure(i).shouldFail==0
+                taskReport{i,3}='true';
+                if printOnlyFailed==false && printOutput==true
+                    fprintf(['PASS: [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+                    score=score+1;
+                end
+                %Calculate the minimal number of reactions to pass the task
+                if getEssential==true
+                    [Rxns_taskEssential]=essentialRxnsTasks(tModel);
+                    essentialRxns{i}= Rxns_taskEssential';
+                    
+                end  
+            else
+                taskReport{i,3}='PASS (should fail)';
+                if printOutput==true
+                    fprintf(['PASS (should fail): [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+                end
+            end
+        else
+            if taskStructure(i).shouldFail==0
+                taskReport{i,3}='FAIL (should NOT fail)';
+                if printOutput==true
+                    fprintf(['FAIL: [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+                end
+            else
+                taskReport{i,3}='FAIL (should fail)';
+                if printOnlyFailed==false && printOutput==true
+                    fprintf(['FAIL (should fail): [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+                    score=score+1;
+                end
+            end
+        end            
+    else
+        if taskStructure(i).shouldFail==0
+            taskReport{i,3}='FAIL (should NOT fail)';
+            if printOutput==true
+                fprintf(['FAIL: [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+            end
+        else
+            taskReport{i,3}='FAIL (should fail)';
+            if printOnlyFailed==false && printOutput==true
+                fprintf(['FAIL (should fail): [' taskStructure(i).id '] ' taskStructure(i).description '\n']);
+                score=score+1;
+            end
+        end
+    end
+totalTask=totalTask+1;
+end
+
+fprintf(['Pass ',num2str(score),' over ',num2str(totalTask),' metabolic tasks tested','\n']);
+fprintf([num2str(notPresent),' failed metabolic task are due to absence of metabolites in the model','\n']);
+taskReport{end+1,1}='Final Score';
+taskReport{end,3}=[num2str(score),'/',num2str(i)];
+taskReport{end+1,1}='Not present in the model';
+taskReport{end,3}=num2str(notPresent);

--- a/src/dataIntegration/transcriptomics/MetabolicTask/essentialRxnsTasks.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/essentialRxnsTasks.m
@@ -1,0 +1,84 @@
+function [essentialRxns]=essentialRxnsTasks(model)
+%   Calculate the minimal number of reactions needed to be active for each
+%   task using Parsimoneous enzyme usage Flux Balance Analysis
+%
+%   model                   a model structure
+%
+%   essentialRxns           cell array with the names of the essential
+%                           reactions for the task
+%   
+%
+%   Essential reactions are those which, when constrained to 0, result in an
+%   infeasible problem.
+%
+%   Usage: [essentialRxns]=essentialRxnsTasks(model)
+%
+%   Originally written for RAVEN toolbox by
+%   Rasmus Agren, 2013-11-17
+%   Adapted for cobratoolbox and modified to rely on pFBA by
+%   Richelle Anne, 2017-05-18
+
+    %Compute the minimal set of reactions
+	[solMin modelIrrevFM]= minimizeModelFlux_local(model);
+	modelIrrevFM = changeRxnBounds(modelIrrevFM,'netFlux',solMin.f,'b');
+    
+    %Define the list of reactions to test
+	rxnsToCheck=modelIrrevFM.rxns(abs(solMin.x)>10^-6);
+
+    % Loop that set to 0 each reaction to test and check if the problem
+    % still has a solution
+	essentialRxns={};
+    for i=1:numel(rxnsToCheck)
+        modelIrrevFM.lb(findRxnIDs(modelIrrevFM,rxnsToCheck(i)))=0;
+        modelIrrevFM.ub(findRxnIDs(modelIrrevFM,rxnsToCheck(i)))=0;
+        modelIrrevFM.csense(1:length(modelIrrevFM.mets),1) = 'E';
+        modelIrrevFM.osense = -1;
+        modelIrrevFM.A=modelIrrevFM.S;
+        sol=solveCobraLP(modelIrrevFM);
+
+       if sol.stat==0 || isempty(sol.full)
+           essentialRxns=[essentialRxns;rxnsToCheck(i)];
+       end
+    end
+
+    rxns_kept=unique(essentialRxns);        
+    rxns_final={};
+    
+    %% Analysis part
+    for i=1: length(rxns_kept)
+        string=rxns_kept{i};
+        if strcmp('_f', string(end-1:end))==1
+            rxns_final{i}= string(1:end-2);
+        elseif strcmp('_b', string(end-1:end))==1
+            rxns_final{i}= string(1:end-2);
+        elseif strcmp('_r', string(end-1:end))==1
+            rxns_final{i}= string(1:end-2);
+        else
+            rxns_final{i}=string;
+        end
+    end
+    essentialRxns=unique(rxns_final);
+end
+
+function [ MinimizedFlux modelIrrev]= minimizeModelFlux_local(model)
+% This function finds the minimum flux through the network and returns the
+% minimized flux and an irreversible model
+    % Convert the model to amodel with only irreversible reactions
+    modelIrrev = convertToIrreversible(model);
+
+    % Add a pseudo-metabolite to measure flux through network
+    modelIrrev.S(end+1,:) = ones(size(modelIrrev.S(1,:)));
+    modelIrrev.b(end+1) = 0;
+    modelIrrev.mets{end+1} = 'fluxMeasure';
+    
+    % Add a pseudo reaction that measures the flux through the network
+    modelIrrev = addReaction(modelIrrev,'netFlux',{'fluxMeasure'},[-1],false,0,inf,0,'','');
+    
+    % Set the flux measuring demand as the objective
+    modelIrrev.c = zeros(length(modelIrrev.rxns),1);
+    modelIrrev = changeObjective(modelIrrev, 'netFlux');
+    
+    % Minimize the flux measuring demand (netFlux)
+    MinimizedFlux = optimizeCbModel(modelIrrev,'min');
+
+end

--- a/src/dataIntegration/transcriptomics/MetabolicTask/essentialRxnsTasks.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/essentialRxnsTasks.m
@@ -1,27 +1,30 @@
-function [essentialRxns]=essentialRxnsTasks(model)
-%   Calculate the minimal number of reactions needed to be active for each
-%   task using Parsimoneous enzyme usage Flux Balance Analysis
+function [essentialRxns] = essentialRxnsTasks(model)
+% Calculates the minimal number of reactions needed to be active for each
+% task using Parsimoneous enzyme usage Flux Balance Analysis
 %
-%   model                   a model structure
+% USAGE:
 %
-%   essentialRxns           cell array with the names of the essential
-%                           reactions for the task
-%   
+%    [essentialRxns] = essentialRxnsTasks(model)
 %
-%   Essential reactions are those which, when constrained to 0, result in an
-%   infeasible problem.
+% INPUT:
+%    model:            a model structure
 %
-%   Usage: [essentialRxns]=essentialRxnsTasks(model)
+% OUTPUT:
+%    essentialRxns:    cell array with the names of the essential
+%                      reactions for the task
 %
-%   Originally written for RAVEN toolbox by
-%   Rasmus Agren, 2013-11-17
-%   Adapted for cobratoolbox and modified to rely on pFBA by
-%   Richelle Anne, 2017-05-18
+% NOTE:
+%
+%    Essential reactions are those which, when constrained to 0, result in an
+%    infeasible problem.
+%
+% .. Authors:
+%   		- Originally written for RAVEN toolbox by Rasmus Agren, 2013-11-17
+%   		- Adapted for cobratoolbox and modified to rely on pFBA by Richelle Anne, 2017-05-18
 
-    %Compute the minimal set of reactions
-	[solMin modelIrrevFM]= minimizeModelFlux_local(model);
+	[solMin modelIrrevFM]= minimizeModelFlux_local(model); %Compute the minimal set of reactions
 	modelIrrevFM = changeRxnBounds(modelIrrevFM,'netFlux',solMin.f,'b');
-    
+
     %Define the list of reactions to test
 	rxnsToCheck=modelIrrevFM.rxns(abs(solMin.x)>10^-6);
 
@@ -41,9 +44,9 @@ function [essentialRxns]=essentialRxnsTasks(model)
        end
     end
 
-    rxns_kept=unique(essentialRxns);        
+    rxns_kept=unique(essentialRxns);
     rxns_final={};
-    
+
     %% Analysis part
     for i=1: length(rxns_kept)
         string=rxns_kept{i};
@@ -70,14 +73,14 @@ function [ MinimizedFlux modelIrrev]= minimizeModelFlux_local(model)
     modelIrrev.S(end+1,:) = ones(size(modelIrrev.S(1,:)));
     modelIrrev.b(end+1) = 0;
     modelIrrev.mets{end+1} = 'fluxMeasure';
-    
+
     % Add a pseudo reaction that measures the flux through the network
     modelIrrev = addReaction(modelIrrev,'netFlux',{'fluxMeasure'},[-1],false,0,inf,0,'','');
-    
+
     % Set the flux measuring demand as the objective
     modelIrrev.c = zeros(length(modelIrrev.rxns),1);
     modelIrrev = changeObjective(modelIrrev, 'netFlux');
-    
+
     % Minimize the flux measuring demand (netFlux)
     MinimizedFlux = optimizeCbModel(modelIrrev,'min');
 

--- a/src/dataIntegration/transcriptomics/MetabolicTask/generateTaskStructure.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/generateTaskStructure.m
@@ -1,86 +1,79 @@
-function taskStruct=generateTaskStructure(inputFile)
-% Generate a task structure from a Excell sheet containing a list of tasks
+function taskStruct = generateTaskStructure(inputFile)
+% Generates a task structure from a Excell sheet containing a list of tasks
 %
-%   inputFile       a task list in Excel format. The file must contain a
-%                   sheet named TASKS, which in turn may contain the
+% USAGE:
+%
+%    taskStruct = generateTaskStructure(inputFile)
+%
+% INPUT:
+%    inputFile:     a task list in Excel format. The file must contain a sheet
+%                   named TASKS, which in turn may contain the
 %                   following column headers (note, all rows starting with
 %                   a non-empty cell are removed. The first row after that
 %                   is considered the headers):
-%                   ID 
-%                       the only required header. Each task must have a
+%
+%                     * ID - the only required header. Each task must have a
 %                       unique id (string or numeric). Tasks can span multiple
 %                       rows, only the first row in each task should have
 %                       an id
-%                   SYSTEM
-%                       definition of the system associated to the task
-%                   SUBSYSTEM
-%                       definition of the subsystem associated to the task
-%                   DESCRIPTION
-%                       description of the task
-%                   IN
-%                       allowed input(s) for the task. Metabolite names
+%                     * SYSTEM - definition of the system associated to the task
+%                     * SUBSYSTEM - definition of the subsystem associated to the task
+%                     * DESCRIPTION - description of the task
+%                     * IN - allowed input(s) for the task. Metabolite names
 %                       should be on the form
 %                       "model.metName[model.comps]". Several inputs
 %                       can be delimited by ";". If so, then the same
 %                       bounds are used for all inputs. If that is not
 %                       wanted, then use several rows for the task
-%                   IN LB
-%                       lower bound for the uptake of the metabolites in
+%                     * IN LB - lower bound for the uptake of the metabolites in
 %                       the row (opt, (opt, default 1e-04 which force the directionality
 %                       of the fluxes associated to the inputs)
-%                   IN UB
-%                       upper bound for the uptake of the metabolites in
+%                     * IN UB - upper bound for the uptake of the metabolites in
 %                       the row (opt, default 1000 which corresponds to a
 %                       maximal uptake of 1000 units)
-%                   OUT
-%                       allowed output(s) for the task (see IN)
-%                   OUT LB
-%                       lower bound for the production of the metabolites in
+%                     * OUT - allowed output(s) for the task (see IN)
+%                     * OUT LB - lower bound for the production of the metabolites in
 %                       the row (opt, default 1e-04 which force the directionality
 %                       of the fluxes associated to the outputs)
-%                   OUT UB
-%                       upper bound for the production of the metabolites in
+%                     * OUT UB - upper bound for the production of the metabolites in
 %                       the row (opt, default 1000 which corresponds to a
 %                       maximal production of 1000 units)
-%                   SHOULD FAIL
-%                       1 if the correct behavior of the model is to
+%                     * SHOULD FAIL - 1 if the correct behavior of the model is to
 %                       not have a feasible solution given the constraints
 %                       (opt, default 0)
-%                   COMP
-%                       specify the compartment where occurs the task
+%                     * COMP - specify the compartment where occurs the task
 %                       (defaut [c], cytosol)
 %
-%   taskStruct      array of structures with the following fields
-%       .id          the id of the task
-%       .description the description of the task
-%       .system      definition of the system associated to the task
-%       .subsystem   definition of the subsystem associated to the task
-%       .shouldFail  true if the task should fail
-%       .inputs      cell array with input metabolites (in the form metName[comps]) 
-%       .LBin        array with lower bounds on inputs (default, 1e-04)
-%       .UBin        array with upper bounds on inputs (default, 1000)
-%       .outputs     cell array with output metabolites (in the form metName[comps])
-%       .LBout       array with lower bounds on outputs (default, 1e-04)
-%       .UBout       array with upper bounds on outputs (default, 1000)
-%       .COMP        compartment where occurs the task (default [c], cytosol)
+% OUTPUT:
+%    taskStruct:    array of structures with the following fields:
 %
-%   This function is used for defining a set of tasks for a model to
-%   perform. The tasks are defined by defining constraints on the exchange 
-%   and transport reaction fluxes associated with the inputs and the outputs,
-%   and if the problem is feasible, then the task is considered successful.
-%   In general, each row can contain one constraint on uptakes, one 
-%   constraint on outputs. 
+%                     * .id - the id of the task
+%                     * .description - the description of the task
+%                     * .system - definition of the system associated to the task
+%                     * .subsystem - definition of the subsystem associated to the task
+%                     * .shouldFail - true if the task should fail
+%                     * .inputs - cell array with input metabolites (in the form metName[comps])
+%                     * .LBin - array with lower bounds on inputs (default, 1e-04)
+%                     * .UBin - array with upper bounds on inputs (default, 1000)
+%                     * .outputs - cell array with output metabolites (in the form metName[comps])
+%                     * .LBout - array with lower bounds on outputs (default, 1e-04)
+%                     * .UBout - array with upper bounds on outputs (default, 1000)
+%                     * .COMP - compartment where occurs the task (default [c], cytosol)
 %
-%   Usage: taskStruct=generateTaskStructure(inputFile)
+% NOTE:
 %
-%   Originally written for RAVEN toolbox by
-%   Rasmus Agren, 2013-08-01
-%   Adapted for cobratoolbox and modified to rely only on flux constraints
-%   by
-%   Richelle Anne, 2017-04-18
+%    This function is used for defining a set of tasks for a model to
+%    perform. The tasks are defined by defining constraints on the exchange
+%    and transport reaction fluxes associated with the inputs and the outputs,
+%    and if the problem is feasible, then the task is considered successful.
+%    In general, each row can contain one constraint on uptakes, one
+%    constraint on outputs.
+%
+% .. Authors:
+%    - Originally written for RAVEN toolbox by Rasmus Agren, 2013-08-01
+%    - Adapted for cobratoolbox and modified to rely only on flux constraints by Richelle Anne, 2017-04-18
 
-%Load the tasks file
-[crap,crap,raw]=xlsread(inputFile,'TASKS');
+[crap,crap,raw]=xlsread(inputFile,'TASKS'); %Load the tasks file
 
 %Captions of the column in the excell file
 columns={'ID';'DESCRIPTION';'IN';'IN LB';'IN UB';'OUT';'OUT LB';'OUT UB';'SHOULD FAIL';'COMP';'SYSTEM';'SUBSYSTEM'};
@@ -105,7 +98,7 @@ for i=1:numel(colI)
         else
              raw(I,colI(i))={1e-04};
         end
-    end    
+    end
 end
 
 %Create an empty task structure
@@ -156,11 +149,11 @@ for i=2:size(raw,1)
 
     %Check if it should add more constraints
     if i<size(raw,1)
-        if isnan(raw{i+1,colI(1)})   
+        if isnan(raw{i+1,colI(1)})
             continue;
         end
     end
-    
+
     taskStruct=[taskStruct;task];
     task=eTask;
     if i<size(raw,1)
@@ -183,11 +176,11 @@ function I=isBad(x)
     I=false;
     if ischar(x)
         if numel(x)==0 || all(isstrprop(x, 'wspace'))
-           I=true; 
+           I=true;
         end
     else
        if isnan(x)
-          I=true; 
+          I=true;
        end
     end
     if isempty(x)

--- a/src/dataIntegration/transcriptomics/MetabolicTask/generateTaskStructure.m
+++ b/src/dataIntegration/transcriptomics/MetabolicTask/generateTaskStructure.m
@@ -1,0 +1,196 @@
+function taskStruct=generateTaskStructure(inputFile)
+% Generate a task structure from a Excell sheet containing a list of tasks
+%
+%   inputFile       a task list in Excel format. The file must contain a
+%                   sheet named TASKS, which in turn may contain the
+%                   following column headers (note, all rows starting with
+%                   a non-empty cell are removed. The first row after that
+%                   is considered the headers):
+%                   ID 
+%                       the only required header. Each task must have a
+%                       unique id (string or numeric). Tasks can span multiple
+%                       rows, only the first row in each task should have
+%                       an id
+%                   SYSTEM
+%                       definition of the system associated to the task
+%                   SUBSYSTEM
+%                       definition of the subsystem associated to the task
+%                   DESCRIPTION
+%                       description of the task
+%                   IN
+%                       allowed input(s) for the task. Metabolite names
+%                       should be on the form
+%                       "model.metName[model.comps]". Several inputs
+%                       can be delimited by ";". If so, then the same
+%                       bounds are used for all inputs. If that is not
+%                       wanted, then use several rows for the task
+%                   IN LB
+%                       lower bound for the uptake of the metabolites in
+%                       the row (opt, (opt, default 1e-04 which force the directionality
+%                       of the fluxes associated to the inputs)
+%                   IN UB
+%                       upper bound for the uptake of the metabolites in
+%                       the row (opt, default 1000 which corresponds to a
+%                       maximal uptake of 1000 units)
+%                   OUT
+%                       allowed output(s) for the task (see IN)
+%                   OUT LB
+%                       lower bound for the production of the metabolites in
+%                       the row (opt, default 1e-04 which force the directionality
+%                       of the fluxes associated to the outputs)
+%                   OUT UB
+%                       upper bound for the production of the metabolites in
+%                       the row (opt, default 1000 which corresponds to a
+%                       maximal production of 1000 units)
+%                   SHOULD FAIL
+%                       1 if the correct behavior of the model is to
+%                       not have a feasible solution given the constraints
+%                       (opt, default 0)
+%                   COMP
+%                       specify the compartment where occurs the task
+%                       (defaut [c], cytosol)
+%
+%   taskStruct      array of structures with the following fields
+%       .id          the id of the task
+%       .description the description of the task
+%       .system      definition of the system associated to the task
+%       .subsystem   definition of the subsystem associated to the task
+%       .shouldFail  true if the task should fail
+%       .inputs      cell array with input metabolites (in the form metName[comps]) 
+%       .LBin        array with lower bounds on inputs (default, 1e-04)
+%       .UBin        array with upper bounds on inputs (default, 1000)
+%       .outputs     cell array with output metabolites (in the form metName[comps])
+%       .LBout       array with lower bounds on outputs (default, 1e-04)
+%       .UBout       array with upper bounds on outputs (default, 1000)
+%       .COMP        compartment where occurs the task (default [c], cytosol)
+%
+%   This function is used for defining a set of tasks for a model to
+%   perform. The tasks are defined by defining constraints on the exchange 
+%   and transport reaction fluxes associated with the inputs and the outputs,
+%   and if the problem is feasible, then the task is considered successful.
+%   In general, each row can contain one constraint on uptakes, one 
+%   constraint on outputs. 
+%
+%   Usage: taskStruct=generateTaskStructure(inputFile)
+%
+%   Originally written for RAVEN toolbox by
+%   Rasmus Agren, 2013-08-01
+%   Adapted for cobratoolbox and modified to rely only on flux constraints
+%   by
+%   Richelle Anne, 2017-04-18
+
+%Load the tasks file
+[crap,crap,raw]=xlsread(inputFile,'TASKS');
+
+%Captions of the column in the excell file
+columns={'ID';'DESCRIPTION';'IN';'IN LB';'IN UB';'OUT';'OUT LB';'OUT UB';'SHOULD FAIL';'COMP';'SYSTEM';'SUBSYSTEM'};
+
+[I colI]=ismember(columns,raw(1,1:end));
+colI=colI;
+
+%Check that the ID field is present
+if I(1)==0
+    dispEM('The TASKS sheet must have a column named ID');
+end
+
+%Prepare the input file a little. Put NaN for missing strings and default
+%bounds where needed
+for i=1:numel(colI)
+    I=cellfun(@isBad,raw(:,colI(i)));
+    if ~ismember(i,[4 5 7 8])
+        raw(I,colI(i))={NaN};
+    else
+        if i==5 || i==8
+            raw(I,colI(i))={1000};
+        else
+             raw(I,colI(i))={1e-04};
+        end
+    end    
+end
+
+%Create an empty task structure
+eTask.id='';
+eTask.description='';
+eTask.system='';
+eTask.subsystem='';
+
+%eTask.shouldFail=false;
+eTask.shouldFail=[];
+eTask.inputs={};
+eTask.LBin=[];
+eTask.UBin=[];
+eTask.outputs={};
+eTask.LBout=[];
+eTask.UBout=[];
+eTask.COMP='';
+
+%Main loop
+taskStruct=[];
+task=eTask;
+if isnumeric(raw{2,colI(1)})
+    task.id=num2str(raw{2,colI(1)});
+else
+    task.id=raw{2,colI(1)};
+end
+task.description=raw{2,colI(2)};
+task.shouldFail=raw{2,colI(9)};
+task.COMP=raw{2,colI(10)};
+task.system=raw{2,colI(11)};
+task.subsystem=raw{2,colI(12)};
+
+for i=2:size(raw,1)
+    %Set the inputs
+    if ischar(raw{i,colI(3)})
+        inputs=regexp(raw{i,colI(3)},';','split');
+        task.inputs=[task.inputs;inputs(:)];
+        task.LBin=[task.LBin;ones(numel(inputs),1)*raw{i,colI(4)}];
+        task.UBin=[task.UBin;ones(numel(inputs),1)*raw{i,colI(5)}];
+    end
+    %Set the outputs
+    if ischar(raw{i,colI(6)})
+        outputs=regexp(raw{i,colI(6)},';','split');
+        task.outputs=[task.outputs;outputs(:)];
+        task.LBout=[task.LBout;ones(numel(outputs),1)*raw{i,colI(7)}];
+        task.UBout=[task.UBout;ones(numel(outputs),1)*raw{i,colI(8)}];
+    end
+
+    %Check if it should add more constraints
+    if i<size(raw,1)
+        if isnan(raw{i+1,colI(1)})   
+            continue;
+        end
+    end
+    
+    taskStruct=[taskStruct;task];
+    task=eTask;
+    if i<size(raw,1)
+        if isnumeric(raw{i+1,colI(1)})
+            task.id=num2str(raw{i+1,colI(1)});
+        else
+            task.id=raw{i+1,colI(1)};
+        end
+        task.description=raw{i+1,colI(2)};
+        task.shouldFail=raw{i+1,colI(9)};
+        task.COMP=raw{i+1,colI(10)};
+        task.system=raw{i+1,colI(11)};
+        task.subsystem=raw{i+1,colI(12)};
+
+    end
+end
+
+end
+function I=isBad(x)
+    I=false;
+    if ischar(x)
+        if numel(x)==0 || all(isstrprop(x, 'wspace'))
+           I=true; 
+        end
+    else
+       if isnan(x)
+          I=true; 
+       end
+    end
+    if isempty(x)
+        I=true;
+    end
+end


### PR DESCRIPTION
This PR contains the scripts used to test a list of metabolic task. These codes are inspired from the checkTasks.m from the RAVEN toolbox. I've adapted them to be compatible with the cobratoolbox but I've also modify the way to define the task itself as now it only rely on the management of constraints on flux related to a list of input substrates and output products and not anymore on the relaxation of pseudo-stationary assumption.

These scripts could be very useful to test if the extracted model keep the same list of metabolic functionalities as the original one. We are currently working on this kind of analysis with @nel3 . Any comments/suggestions for improvement are welcome.

