### PR TITLE
option added to convertToIrreversible.m 

### DIFF
--- a/convertToIrreversible.m
+++ b/convertToIrreversible.m
@@ -1,10 +1,15 @@
-function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model)
-%convertToIrreversible Convert model to irreversible format
+function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model, sRxns)
+%convertToIrreversible Convert model to irreversible format, either for the
+%entire model or for a defined list of reversible reactions.
 %
-% [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model)
+% [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model, sRxns)
 %
 %INPUT
 % model         COBRA model structure
+%
+%OPTIONAL INPUTS
+% sRxns         List of specific reversible reactions to convert to
+%               irreversible (Default = model.rxns)
 %
 %OUTPUTS
 % modelIrrev    Model in irreversible format
@@ -17,13 +22,17 @@ function [modelIrrev,matchRev,rev2irrev,irrev2rev] = convertToIrreversible(model
 % reactions separated into forward and backward reactions.  Separated
 % reactions are appended with '_f' and '_b' and the reversible list tracks
 % these changes with a '1' corresponding to separated forward reactions.
-% Reactions entirely in the negative direction will be reversed and
-% appended with '_r'.
+% By default, reactions entirely in the negative direction will be reversed
+% and appended with '_r'.
 %
 % written by Gregory Hannum 7/9/05
 %
 % Modified by Markus Herrgard 7/25/05
 % Modified by Jan Schellenberger 9/9/09 for speed.
+% Modified by Diana El Assal & Fatima Monteiro 2/6/2017 allow to optionally
+% only split a specific list of reversible reactions to irreversible,
+% without appending '_r'. In this case, model.rev = false (forward) and
+% model.rev = true (reversible).
 
 %declare variables
 modelIrrev.S = spalloc(size(model.S,1),0,2*nnz(model.S));
@@ -40,84 +49,162 @@ irrev2rev = zeros(2*length(model.rxns),1);
 %loop through each column/rxn in the S matrix building the irreversible
 %model
 cnt = 0;
-for i = 1:nRxns
-    cnt = cnt + 1;
-    
-    %expand the new model (same for both irrev & rev rxns  
-    modelIrrev.rev(cnt) = model.rev(i);
-    irrev2rev(cnt) = i;
 
-    % Check if reaction is declared as irreversible, but bounds suggest
-    % reversible (i.e., having both positive and negative bounds
-    if (model.ub(i) > 0 && model.lb(i) < 0) && model.rev(i) == false
-        model.rev(i) = true;
-        warning(cat(2,'Reaction: ',model.rxns{i},' is classified as irreversible, but bounds are positive and negative!'))
-
-    end
-   
-    % Reaction entirely in the negative direction
-    if (model.ub(i) <= 0 && model.lb(i) < 0)
-        % Retain original bounds but reversed
-        modelIrrev.ub(cnt) = -model.lb(i);
-        modelIrrev.lb(cnt) = -model.ub(i);
-        % Reverse sign
-        modelIrrev.S(:,cnt) = -model.S(:,i);
-        modelIrrev.c(cnt) = -model.c(i);
-        modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
-        model.rev(i) = false;
-        modelIrrev.rev(cnt) = false;
-    else
-        % Keep positive upper bound
-        modelIrrev.ub(cnt) = model.ub(i);
-        %if the lb is less than zero, set the forward rxn lb to zero 
-        if model.lb(i) < 0
-            modelIrrev.lb(cnt) = 0;
-        else
-            modelIrrev.lb(cnt) = model.lb(i);
-        end
-        modelIrrev.S(:,cnt) = model.S(:,i);
-        modelIrrev.c(cnt) = model.c(i);
-        modelIrrev.rxns{cnt} = model.rxns{i};
-
-    end
-
-   
-    %if the reaction is reversible, add a new rxn to the irrev model and
-    %update the names of the reactions with '_f' and '_b'
-    if model.rev(i) == true
-        cnt = cnt + 1;
-        matchRev(cnt) = cnt - 1;
-        matchRev(cnt-1) = cnt;
-        modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
-        modelIrrev.S(:,cnt) = -model.S(:,i);
-        modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
-        modelIrrev.rev(cnt) = true;
-        modelIrrev.lb(cnt) = 0;
-        modelIrrev.ub(cnt) = -model.lb(i);
-        modelIrrev.c(cnt) = 0;
-        rev2irrev{i} = [cnt-1 cnt];
-        irrev2rev(cnt) = i;
-    else
-        matchRev(cnt) = 0;
-        rev2irrev{i} = cnt;
-    end
+if nargin< 2
+    sRxns = [];
 end
 
-rev2irrev = columnVector(rev2irrev);
-irrev2rev = irrev2rev(1:cnt);
-irrev2rev = columnVector(irrev2rev);
-
-% Build final structure
-modelIrrev.S = modelIrrev.S(:,1:cnt);
-modelIrrev.ub = columnVector(modelIrrev.ub(1:cnt));
-modelIrrev.lb = columnVector(modelIrrev.lb(1:cnt));
-modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
-modelIrrev.rev = modelIrrev.rev(1:cnt);
-modelIrrev.rev = columnVector(modelIrrev.rev == 1);
-modelIrrev.rxns = columnVector(modelIrrev.rxns); 
-modelIrrev.mets = model.mets;
-matchRev = columnVector(matchRev(1:cnt));
-modelIrrev.match = matchRev;
+%Convert only a specific list of reactions to irreversible
+if ~isempty(sRxns)
+    model.revSpecific = zeros(length(model.rxns), 1);
+    ind = findRxnIDs(model, sRxns);
+    model.revSpecific(ind) = 1;
+    for i = 1:nRxns
+        cnt = cnt + 1;
+        
+        %expand the new model (same for both irrev & rev rxns
+        modelIrrev.rev(cnt) = modelIrrev.rev(i);
+        irrev2rev(cnt) = i;
+        
+        % Check if reaction is declared as irreversible, but bounds suggest
+        % reversible (i.e., having both positive and negative bounds
+        if model.ub(i) > 0 && model.lb(i) < 0 && modelIrrev.rev(i) == false
+            model.rev(i) = true;
+            warning(cat(2, 'Reaction: ', model.rxns{i}, ' is classified as irreversible, but bounds are positive and negative!'))
+        elseif (sign(model.ub(i)) == sign(model.lb(i)) || sign(model.ub(i)) * sign(model.lb(i)) == 0) && model.rev(i) == true
+            model.rev(i) = false;
+        end
+        
+        % Retain original bounds
+        modelIrrev.ub(cnt) = model.ub(i);
+        modelIrrev.lb(cnt) = model.lb(i);
+        modelIrrev.S(:, cnt) = model.S(:, i);
+        modelIrrev.c(cnt) = model.c(i);
+        modelIrrev.rxns{cnt} = model.rxns{i};
+        modelIrrev.rev(cnt) = model.rev(i);
+        
+        %if the reaction is reversible, add a new rxn to the irrev model and
+        %update the names of the reactions with '_f' and '_b'
+        if model.revSpecific(i) == true
+            cnt = cnt + 1;
+            matchRev(cnt) = cnt - 1;
+            matchRev(cnt-1) = cnt;
+            modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
+            modelIrrev.S(:, cnt) = - model.S(:, i);
+            modelIrrev.S(:, cnt-1) = model.S(:, i);
+            modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
+            modelIrrev.rev(cnt) = false;
+            modelIrrev.lb(cnt) = 0;
+            modelIrrev.lb(cnt-1) = 0;
+            modelIrrev.ub(cnt) =  - model.lb(i);
+            modelIrrev.ub(cnt - 1) = - model.lb(i);
+            modelIrrev.c(cnt) = 0;
+            rev2irrev{i} = [cnt-1 cnt];
+            irrev2rev(cnt) = i;
+        else
+            matchRev(cnt) = 0;
+            rev2irrev{i} = cnt;
+        end
+    end
+    
+    rev2irrev = columnVector(rev2irrev);
+    irrev2rev = irrev2rev(1:cnt);
+    irrev2rev = columnVector(irrev2rev);
+    
+    % Build final structure
+    modelIrrev.S = modelIrrev.S(:,1:cnt);
+    modelIrrev.ub = columnVector(modelIrrev.ub(1:cnt));
+    modelIrrev.lb = columnVector(modelIrrev.lb(1:cnt));
+    modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
+    modelIrrev.rev = modelIrrev.rev(1:cnt);
+    modelIrrev.rev = columnVector(modelIrrev.rev == 1);
+    modelIrrev.rxns = columnVector(modelIrrev.rxns);
+    modelIrrev.mets = model.mets;
+    matchRev = columnVector(matchRev(1:cnt));
+    modelIrrev.match = matchRev;
+    modelIrrev.rev = zeros(length(modelIrrev.rxns),1);
+    modelIrrev.rev(find(modelIrrev.lb<0))=1;
+    
+    %By default, convert the entire model:
+else
+    for i = 1:nRxns;
+        cnt = cnt + 1;
+        
+        %expand the new model (same for both irrev & rev rxns
+        modelIrrev.rev(cnt) = model.rev(i);
+        irrev2rev(cnt) = i;
+        
+        % Check if reaction is declared as irreversible, but bounds suggest
+        % reversible (i.e., having both positive and negative bounds
+        if (model.ub(i) > 0 && model.lb(i) < 0) && model.rev(i) == false
+            model.rev(i) = true;
+            warning(cat(2,'Reaction: ',model.rxns{i},' is classified as irreversible, but bounds are positive and negative!'))
+            
+        end
+        
+        % Reaction entirely in the negative direction
+        if (model.ub(i) <= 0 && model.lb(i) < 0)
+            % Retain original bounds but reversed
+            modelIrrev.ub(cnt) = -model.lb(i);
+            modelIrrev.lb(cnt) = -model.ub(i);
+            % Reverse sign
+            modelIrrev.S(:,cnt) = -model.S(:,i);
+            modelIrrev.c(cnt) = -model.c(i);
+            modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
+            model.rev(i) = false;
+            modelIrrev.rev(cnt) = false;
+        else
+            % Keep positive upper bound
+            modelIrrev.ub(cnt) = model.ub(i);
+            %if the lb is less than zero, set the forward rxn lb to zero
+            if model.lb(i) < 0
+                modelIrrev.lb(cnt) = 0;
+            else
+                modelIrrev.lb(cnt) = model.lb(i);
+            end
+            modelIrrev.S(:,cnt) = model.S(:,i);
+            modelIrrev.c(cnt) = model.c(i);
+            modelIrrev.rxns{cnt} = model.rxns{i};
+            
+        end
+        
+        %if the reaction is reversible, add a new rxn to the irrev model and
+        %update the names of the reactions with '_f' and '_b'
+        if model.rev(i) == true
+            cnt = cnt + 1;
+            matchRev(cnt) = cnt - 1;
+            matchRev(cnt-1) = cnt;
+            modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
+            modelIrrev.S(:,cnt) = -model.S(:,i);
+            modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
+            modelIrrev.rev(cnt) = true;
+            modelIrrev.lb(cnt) = 0;
+            modelIrrev.ub(cnt) = -model.lb(i);
+            modelIrrev.c(cnt) = 0;
+            rev2irrev{i} = [cnt-1 cnt];
+            irrev2rev(cnt) = i;
+        else
+            matchRev(cnt) = 0;
+            rev2irrev{i} = cnt;
+        end
+    end
+    
+    rev2irrev = columnVector(rev2irrev);
+    irrev2rev = irrev2rev(1:cnt);
+    irrev2rev = columnVector(irrev2rev);
+    
+    % Build final structure
+    modelIrrev.S = modelIrrev.S(:,1:cnt);
+    modelIrrev.ub = columnVector(modelIrrev.ub(1:cnt));
+    modelIrrev.lb = columnVector(modelIrrev.lb(1:cnt));
+    modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
+    modelIrrev.rev = modelIrrev.rev(1:cnt);
+    modelIrrev.rev = columnVector(modelIrrev.rev == 1);
+    modelIrrev.rxns = columnVector(modelIrrev.rxns);
+    modelIrrev.mets = model.mets;
+    matchRev = columnVector(matchRev(1:cnt));
+    modelIrrev.match = matchRev;
+end
 if (isfield(model,'b'))
     modelIrrev.b = model.b;
 end

--- a/findMetFromCompartment.m
+++ b/findMetFromCompartment.m
@@ -1,0 +1,31 @@
+function [compartmentMetabolites] = findMetFromCompartment(model,compartment);
+%findMetFromCompartment finds the metabolites and its IDs in a
+%compartment of interest
+%
+% [compartmentMetabolites] = findMetFromCompartment(model,Compartment)
+%
+%INPUTS
+% model         COBRA model strcture
+% compartment   compartment of interest (e.g.: '[m]', '[n]', '[e]', etc.)
+%
+%OUTPUT
+% compartmentMetabolites  List of metabolites in the compartment of interest
+%
+% Diana El Assal 27/10/2015
+
+%Form a matrix with the metabolites and its identifiers
+[metabolites]=[model.mets];
+
+%Find the metabolites in the compartment of interest (e.g. '[m], '[n]')
+compartmentMets=strfind(model.mets, compartment);
+index=find(~cellfun(@isempty, compartmentMets));
+compartmentMets=model.mets(index);
+
+%Find all metabolite identifiers
+for i=1:size(compartmentMets,1);
+    num=find(ismember(metabolites(:,1),compartmentMets{i,1}));
+    if ~isempty(num);
+        compartmentMetabolites(i,:)=metabolites(num,:);
+    end
+end
+

--- a/findRxnFromCompartment.m
+++ b/findRxnFromCompartment.m
@@ -1,0 +1,30 @@
+function [compartmentReactions] = findRxnFromCompartment(model,compartment);
+%findRxnFromCompartment finds the reaction and its IDs in a
+%compartment of interest
+%
+% [compartmentReactions] = findRxnFromCompartment(model,Compartment)
+%
+%INPUTS
+% model         COBRA model strcture
+% compartment   compartment of interest (e.g.: '[m]', '[n]', '[e]', etc.)
+%
+%OUTPUT
+% compartmentMetabolites  List of reactions in the compartment of interest
+%
+% Diana El Assal 01/06/2016
+
+%Form a matrix with the metabolites and its identifiers
+[reactions]=[model.rxns, printRxnFormula(model, model.rxns)];
+
+%Find the reactions in the compartment of interest (e.g. '[m], '[n]')
+compartmentRxns=strfind(reactions(:,2), compartment);
+index=find(~cellfun(@isempty, compartmentRxns));
+compartmentRxns=unique(reactions(index,1));
+
+%Find all reaction identifiers
+for i=1:size(compartmentRxns,1);
+    num=find(ismember(reactions(:,1),compartmentRxns{i,1}));
+    if ~isempty(num);
+        compartmentReactions(i,:)=reactions(num,:);
+    end
+end

--- a/splitRevRxns.m
+++ b/splitRevRxns.m
@@ -69,23 +69,19 @@ for i = 1:nRxns
     % Reaction entirely in the negative direction
     if model.ub(i) <= 0 && model.lb(i) < 0
         % Retain original bounds but reversed
-        modelIrrev.ub(cnt) = -model.lb(i);
-        modelIrrev.lb(cnt) = -model.ub(i);
+        modelIrrev.ub(cnt) = model.lb(i);
+        modelIrrev.lb(cnt) = model.ub(i);
         % Reverse sign
-        modelIrrev.S(:, cnt) = -model.S(:, i);
-        modelIrrev.c(cnt) = -model.c(i);
-        modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
+        modelIrrev.S(:, cnt) = model.S(:, i);
+        modelIrrev.c(cnt) = model.c(i);
+        modelIrrev.rxns{cnt} = model.rxns{i};
         model.rev(i) = false;
         modelIrrev.rev(cnt) = false;
     else
         % Keep positive upper bound
         modelIrrev.ub(cnt) = model.ub(i);
         %if the lb is less than zero, set the forward rxn lb to zero
-        if model.lb(i) < 0
-            modelIrrev.lb(cnt) = 0;
-        else
-            modelIrrev.lb(cnt) = model.lb(i);
-        end
+        modelIrrev.lb(cnt) = model.lb(i);
         modelIrrev.S(:, cnt) = model.S(:, i);
         modelIrrev.c(cnt) = model.c(i);
         modelIrrev.rxns{cnt} = model.rxns{i};
@@ -101,10 +97,13 @@ for i = 1:nRxns
         matchRev(cnt-1) = cnt;
         modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
         modelIrrev.S(:, cnt) = - model.S(:, i);
+        modelIrrev.S(:, cnt-1) = model.S(:, i);
         modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
-        modelIrrev.rev(cnt) = true;
+        modelIrrev.rev(cnt) = false;
         modelIrrev.lb(cnt) = 0;
-        modelIrrev.ub(cnt) = - model.lb(i);
+        modelIrrev.lb(cnt-1) = 0;
+        modelIrrev.ub(cnt) =  - model.lb(i);
+        modelIrrev.ub(cnt - 1) = - model.lb(i);
         modelIrrev.c(cnt) = 0;
         rev2irrev{i} = [cnt-1 cnt];
         irrev2rev(cnt) = i;
@@ -149,4 +148,6 @@ if isfield(model,'genes')
     modelIrrev.rules = model.rules(irrev2rev);
     modelIrrev.grRules = model.grRules(irrev2rev); %added to allow model reduction 18/02/2016 Agnieszka
 end
+modelIrrev.rev = zeros(length(modelIrrev.rxns),1); 
+modelIrrev.rev(find(modelIrrev.lb<0))=1;
 modelIrrev.reversibleModel = false;

--- a/splitRevRxns.m
+++ b/splitRevRxns.m
@@ -1,0 +1,152 @@
+function [modelIrrev,matchRev,rev2irrev,irrev2rev] = splitRevRxns(model, sRxns)
+%splitRevRxns Convert model to irreversible format for a specific
+%list of reactions. This function is based on convertToIrreversible
+%
+% [modelIrrev,matchRev,rev2irrev,irrev2rev] = splitRevRxns(model, sRxns)
+%
+%INPUT
+% model         COBRA model structure
+% sRxns         List of specific reversible reactions to convert to irreversible
+%
+% 
+%
+%OUTPUTS
+% modelIrrev    Model in irreversible format
+% matchRev      Matching of forward and backward reactions of a reversible
+%               reaction
+% rev2irrev     Matching from reversible to irreversible reactions
+% irrev2rev     Matching from irreversible to reversible reactions
+%
+% Uses the reversible list to construct a new model with reversible
+% reactions separated into forward and backward reactions.  Separated
+% reactions are appended with '_f' and '_b' and the reversible list tracks
+% these changes with a '1' corresponding to separated forward reactions.
+% Reactions entirely in the negative direction will be reversed and
+% appended with '_r'.
+%
+% written by Gregory Hannum 7/9/05
+%
+% Modified by Markus Herrgard 7/25/05
+% Modified by Jan Schellenberger 9/9/09 for speed.
+% Modified by Diana El Assal & Fatima Monteiro 2/6/2017 allow to only split
+% a specific list of reversible reactions to irreversible 
+
+%declare variables
+modelIrrev.S = spalloc(size(model.S, 1), 0, 2 * nnz(model.S));
+modelIrrev.rxns = [];
+modelIrrev.rev = zeros(2 * length(model.rxns), 1);
+modelIrrev.lb = zeros(2 * length(model.rxns), 1);
+modelIrrev.ub = zeros(2 * length(model.rxns), 1);
+modelIrrev.c = zeros(2 * length(model.rxns), 1);
+matchRev = zeros(2 * length(model.rxns), 1);
+
+model.revSpecific = zeros(length(model.rxns), 1);
+ind = findRxnIDs(model, sRxns);
+model.revSpecific(ind) = 1;
+
+nRxns = size(model.S, 2);
+irrev2rev = zeros(2 * length(model.rxns), 1);
+
+%loop through each column/rxn in the S matrix building the irreversible
+%model
+cnt = 0;
+for i = 1:nRxns
+    cnt = cnt + 1;
+
+    %expand the new model (same for both irrev & rev rxns
+    modelIrrev.rev(cnt) = modelIrrev.rev(i);
+    irrev2rev(cnt) = i;
+
+    % Check if reaction is declared as irreversible, but bounds suggest
+    % reversible (i.e., having both positive and negative bounds
+    if model.ub(i) > 0 && model.lb(i) < 0 && modelIrrev.rev(i) == false
+        model.rev(i) = true;
+        warning(cat(2, 'Reaction: ', model.rxns{i}, ' is classified as irreversible, but bounds are positive and negative!'))
+    elseif (sign(model.ub(i)) == sign(model.lb(i)) || sign(model.ub(i)) * sign(model.lb(i)) == 0) && model.rev(i) == true
+        model.rev(i) = false;
+    end
+
+    % Reaction entirely in the negative direction
+    if model.ub(i) <= 0 && model.lb(i) < 0
+        % Retain original bounds but reversed
+        modelIrrev.ub(cnt) = -model.lb(i);
+        modelIrrev.lb(cnt) = -model.ub(i);
+        % Reverse sign
+        modelIrrev.S(:, cnt) = -model.S(:, i);
+        modelIrrev.c(cnt) = -model.c(i);
+        modelIrrev.rxns{cnt} = [model.rxns{i} '_r'];
+        model.rev(i) = false;
+        modelIrrev.rev(cnt) = false;
+    else
+        % Keep positive upper bound
+        modelIrrev.ub(cnt) = model.ub(i);
+        %if the lb is less than zero, set the forward rxn lb to zero
+        if model.lb(i) < 0
+            modelIrrev.lb(cnt) = 0;
+        else
+            modelIrrev.lb(cnt) = model.lb(i);
+        end
+        modelIrrev.S(:, cnt) = model.S(:, i);
+        modelIrrev.c(cnt) = model.c(i);
+        modelIrrev.rxns{cnt} = model.rxns{i};
+
+    end
+
+
+    %if the reaction is reversible, add a new rxn to the irrev model and
+    %update the names of the reactions with '_f' and '_b'
+    if model.revSpecific(i) == true
+        cnt = cnt + 1;
+        matchRev(cnt) = cnt - 1;
+        matchRev(cnt-1) = cnt;
+        modelIrrev.rxns{cnt-1} = [model.rxns{i} '_f'];
+        modelIrrev.S(:, cnt) = - model.S(:, i);
+        modelIrrev.rxns{cnt} = [model.rxns{i} '_b'];
+        modelIrrev.rev(cnt) = true;
+        modelIrrev.lb(cnt) = 0;
+        modelIrrev.ub(cnt) = - model.lb(i);
+        modelIrrev.c(cnt) = 0;
+        rev2irrev{i} = [cnt-1 cnt];
+        irrev2rev(cnt) = i;
+    else
+        matchRev(cnt) = 0;
+        rev2irrev{i} = cnt;
+    end
+end
+
+rev2irrev = columnVector(rev2irrev);
+irrev2rev = irrev2rev(1:cnt);
+irrev2rev = columnVector(irrev2rev);
+
+% Build final structure
+modelIrrev.S = modelIrrev.S(:,1:cnt);
+modelIrrev.ub = columnVector(modelIrrev.ub(1:cnt));
+modelIrrev.lb = columnVector(modelIrrev.lb(1:cnt));
+modelIrrev.c = columnVector(modelIrrev.c(1:cnt));
+modelIrrev.rev = modelIrrev.rev(1:cnt);
+modelIrrev.rev = columnVector(modelIrrev.rev == 1);
+modelIrrev.rxns = columnVector(modelIrrev.rxns);
+modelIrrev.mets = model.mets;
+matchRev = columnVector(matchRev(1:cnt));
+modelIrrev.match = matchRev;
+
+if isfield(model,'b')
+    modelIrrev.b = model.b;
+end
+if isfield(model,'csense')
+    modelIrrev.csense = model.csense;
+end
+if isfield(model,'description')
+    modelIrrev.description = [model.description ' irreversible'];
+end
+if isfield(model,'subSystems')
+    modelIrrev.subSystems = model.subSystems(irrev2rev);
+end
+if isfield(model,'genes')
+    modelIrrev.genes = model.genes;
+    genemtxtranspose = model.rxnGeneMat';
+    modelIrrev.rxnGeneMat = genemtxtranspose(:, irrev2rev)';
+    modelIrrev.rules = model.rules(irrev2rev);
+    modelIrrev.grRules = model.grRules(irrev2rev); %added to allow model reduction 18/02/2016 Agnieszka
+end
+modelIrrev.reversibleModel = false;


### PR DESCRIPTION
An option has been added to convertToIrreversible.m to allow the user to only split a selected list of reversible reactions, rather than the entire model reactions. Additional functions have been added to find reactions or metabolites from a given compartment. 


**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
