### PR TITLE
changeCobraSolver printLevel fix

### DIFF
--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -146,9 +146,14 @@ global GUROBI_PATH;
 global MINOS_PATH;
 global ILOG_CPLEX_PATH;
 
+if nargin < 3
+    printLevel = 1;
+end
+
 if ~exist('unchecked' , 'var')
     unchecked = 0;
 end
+
 if unchecked
     switch solverType
         case 'LP'
@@ -164,7 +169,6 @@ if unchecked
     end
     return
 end
-
 
 if isempty(SOLVERS) || isempty(OPT_PROB_TYPES)
     ENV_VARS.printLevel = false;
@@ -230,10 +234,6 @@ if nargin < 2
     solverType = 'LP';
 else
     solverType = upper(solverType);
-end
-
-if nargin < 3
-    printLevel = 1;
 end
 
 % print an error message if the solver is not supported


### PR DESCRIPTION
in changeCobraSolver.m, moving assignment statement for default value of printLevel to avoid "Not enough input arguments" error


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
