### PR TITLE
Multiple small corrections

### DIFF
--- a/papers/2016_pairwiseModeling_HumanGutMicrobiota/buildPairwiseModels.m
+++ b/papers/2016_pairwiseModeling_HumanGutMicrobiota/buildPairwiseModels.m
@@ -33,16 +33,14 @@ pairedModelsList{1, 6} = 'Strain2';
 pairedModelsList{1, 7} = 'Biomass2';
 modelList = 2;
 for i = 2:size(InfoFile, 1)
-    load(strcat(InfoFile{i, 1}, '.mat'));
-    % name the first model "model1" by default
-    model1 = model;
+    model1 = readCbModel(strcat(InfoFile{i, 1}, '.mat'));
+    % name the first model "model1" by default    
     % make sure pairs are only generated once ("microbe1_microbe2" and
     % "microbe2_microbe1" are the same pairwise model and thus only one is created)
     % also make sure models aren't paired with themselves
-    for j = i + 1:size(InfoFile, 1)
-         load(strcat(InfoFile{j, 1}, '.mat'));
+    for j = i + 1:size(InfoFile, 1)         
         % name the second model "model2 by default
-        model2 = model;
+        model2 = readCbModel(strcat(InfoFile{j, 1}, '.mat'));
         % script "createMultiSpeciesModel" will join the two microbes
         % need to create file with the two models and two corresponding
         % name tags as input for createMultipleSpeciesModel

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -43,8 +43,8 @@ newFields = {'rxnConfidenceScores', 'metCharges','rxnECNumbers',...
 
 mergefunction = {maxmerge, nanmerge,cellmerge,...
 		cellmerge,cellmerge,cellmerge,...
-		cellmerge,cellmerge,cellmerge};
-
+		cellmerge,cellmerge,cellmerge};    
+    
 for i = 1:numel(oldFields)
     if (isfield(model,oldFields{i}))
         fieldRef = [newFields{i}(1:3) 's'];
@@ -57,6 +57,7 @@ for i = 1:numel(oldFields)
                     merger = strrep(mergefunction{i},'$OLD$',oldFields{i});
                     merger = strrep(merger,'$NEW$',newFields{i});
                     eval(merger);
+                    
                 else
                     warning('Size of %s does not fit to %s. Old field %s exists, but cannot be merged',newFields{i},fieldRef,oldFields{i});
                     continue
@@ -126,6 +127,19 @@ if isfield(model,'rxnConfidenceScores')
 %        model.rxnConfidenceScores = tempScores;
     end
 end
+
+modelfields = fieldnames(model);
+%Some Cell array fields (which all should have '' as default use []
+%instead. we need to fix this, i.e. we will simply replace all non char
+%entries by '' in all cell array fields.
+
+for i = 1: numel(modelfields)
+    if iscell(model.(modelfields{i}))
+        numericpos = cellfun(@(x) isnumeric(x) && isempty(x), model.(modelfields{i}));
+        model.(modelfields{i})(numericpos) = {''};
+    end
+end
+
 
 %reset warnings
 for i = 1:numel(warnstate)

--- a/src/base/io/utilities/restrictModelsToFields.m
+++ b/src/base/io/utilities/restrictModelsToFields.m
@@ -1,0 +1,37 @@
+function restrictedModels = restrictModelsToFields(models, fieldNames)
+% Removes all fields not given as fieldnames from the models
+%
+% USAGE:
+%
+%    restrictedModels = restrictModelsToFields(models, fieldNames)
+%
+% INPUT:
+%    models:           A Cell array of model structs (or single model
+%                      struct that has all fieldNames provided.
+%    fieldNames:       Names of the fields the models will be restricted
+%                      to.
+%
+% OUTPUT:
+%    restrictedModels:    The models with the non names fields removed, or a single struct if its just one model.
+%
+% .. Author: - Thomas Pfau May 2017
+
+
+structin = false;
+if isstruct(models)
+    models = { models};
+    structin = true;
+end
+restrictedModels = cell(size(models));
+for i = 1: numel(models)
+    newModel = struct();
+    cmodel = models{i};
+    for f = 1:numel(fieldNames)
+        newModel.(fieldNames{f}) = cmodel.(fieldNames{f});
+    end
+    restrictedModels{i} = newModel;
+end
+
+if structin
+    restrictedModels = restrictedModels{1};
+end

--- a/src/modelAnalysis/multiSpecies/createMultipleSpeciesModel.m
+++ b/src/modelAnalysis/multiSpecies/createMultipleSpeciesModel.m
@@ -69,6 +69,17 @@ eTag = 'u';
 exTag = 'e';
 % find exchange reactions for models, but leaves demand and sink reactions
 % do this for all models to be added, remove exchange reactions from host while leaving demand and sink reactions
+%First, find the minimal number of fields common to all models.
+presentinallModels = fieldnames(models{1});
+missingFields = {};
+for i = 2:modelNumber
+    cfields = fieldnames(models{i});
+    missingFields = union(missingFields,setxor(cfields,presentinallModels));    
+    presentinallModels = intersect(presentinallModels,cfields);
+end
+fprintf('The following fields are missing in several models, they will not be merged:\n');
+disp(missingFields);
+models = restrictModelsToFields(models,presentinallModels);
 
 for i = 1:modelNumber
     % a new model each turn


### PR DESCRIPTION
CreateMultiSpeciesModel now restricts the multispecies model to those fields present in all individual species models.
convertOldStyleModel now converts all empty numeric entries in cell arrays (default init vlue often present in old models) to ''
buildPairWiseModel now uses readCbModel instead of load (thereby automatically converting old style models)
Added a function to restrict a set of models to a given set of FieldNames (droppping all other fieldNames).


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
