### PR TITLE
Fixing typo in documentation

### DIFF
--- a/src/modelAnalysis/deletion/singleRxnDeletion.m
+++ b/src/modelAnalysis/deletion/singleRxnDeletion.m
@@ -3,7 +3,7 @@ function [grRatio, grRateKO, grRateWT, hasEffect, delRxn, fluxSolution] = single
 %
 % USAGE:
 %
-%    [grRatio, grRateKO, grRateWT, hasEffect, delRxns, hasEffect] = singleRxnDeletion(model, method, rxnList, verbFlag)
+%    [grRatio, grRateKO, grRateWT, hasEffect, delRxn, fluxSolution] = singleRxnDeletion(model, method, rxnList, verbFlag)
 %
 % INPUT:
 %    model:           COBRA model structure including reaction names


### PR DESCRIPTION
The documentation had a cut-paste error, which I've fixed now.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
