### PR TITLE
installDevTools function

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ How to contribute
 <img src="https://raw.githubusercontent.com/opencobra/MATLAB.devTools/develop/assets/devTools_logo.png" height="120px"/>
 </p>
 
+You can install the [MATLAB.devTools](https://github.com/opencobra/MATLAB.devTools) from within MATLAB by typing:
+```Matlab
+>> installDevTools()
+```
+
 <img src="https://prince.lcsb.uni.lu/jenkins/userContent/bulb.png" height="20px" alt="bulb"> **Check out the [MATLAB.devTools](https://github.com/opencobra/MATLAB.devTools) - and contribute the smart way!**
 
 - Please follow the [Style Guide](https://opencobra.github.io/cobratoolbox/docs/styleGuide.html).

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -14,14 +14,15 @@ function installDevTools()
     currentDir = pwd;
 
     % change to the local directory
-    cd([CBTDIR filesep '..']);
+    localDir = [CBTDIR filesep '..'];
+    cd(localDir);
 
     installFlag = false;
-    localDir = '';
 
     if exist([CBTDIR filesep '..' filesep 'MATLAB.devTools'], 'dir') == 7
 
-        reply = input([' > There is already a copy of the MATLAB.devTools installe in the default location.\n   Do you want to enter another location to install the MATLAB.devTools? Y/N [Y]: '], 's');
+        reply = input([' > There is already a copy of the MATLAB.devTools installed in the default location.\n   Do you want to enter another location to install the MATLAB.devTools? Y/N [Y]: '], 's');
+        localDir = '';
 
         if isempty(reply) || strcmpi(reply, 'y') || strcmpi(reply, 'yes')
         % enter another location for the MATLAB.devTools
@@ -47,8 +48,10 @@ function installDevTools()
             installFlag = true;
         else
             installFlag = false;
-            error('You cannot install the MATLAB.devTools. Please delete the folder ');
+            fprintf(' > You cannot install the MATLAB.devTools. Please delete the folder %s\n', [CBTDIR filesep '..' filesep 'MATLAB.devTools']);
         end
+    else
+        installFlag = true;
     end
 
     if installFlag

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -1,0 +1,87 @@
+function installDevTools()
+
+    global ENV_VARS
+    global CBTDIR
+
+    % make sure that The COBRA Toolbox is properly installed;
+    % git and curl are tested here
+    if isempty(ENV_VARS)
+        ENV_VARS.printLevel = false;
+        initCobraToolbox;
+        ENV_VARS.printLevel = true;
+    end
+
+    currentDir = pwd;
+
+    % change to the local directory
+    cd([CBTDIR filesep '..']);
+
+    installFlag = false;
+    localDir = '';
+
+    if exist([CBTDIR filesep '..' filesep 'MATLAB.devTools'], 'dir') == 7
+
+        reply = input([' > There is already a copy of the MATLAB.devTools installe in the default location.\n   Do you want to enter another location to install the MATLAB.devTools? Y/N [Y]: '], 's');
+
+        if isempty(reply) || strcmpi(reply, 'y') || strcmpi(reply, 'yes')
+        % enter another location for the MATLAB.devTools
+
+            dirReply = '';
+            while isempty(dirReply)
+                dirReply = input(['\n -> Please define the installation path of the MATLAB.devTools\n    Enter the path: '], 's');
+
+                if exist([dirReply filesep 'MATLAB.devTools'], 'dir') == 7
+                    fprintf('\n   The directory ', [dirReply filesep 'MATLAB.devTools'], ' already exists. Please enter a different directory.\n');
+                    dirReply = '';
+                end
+
+                if ~isempty(dirReply) && exist(dirReply, 'dir') == 7
+                    localDir = dirReply;
+                    break;
+                else
+                    fprintf('\n   -> The directory does not exist. Please try again.\n');
+                    dirReply = '';
+                end
+            end
+
+            installFlag = true;
+        else
+            installFlag = false;
+            error('You cannot install the MATLAB.devTools. Please delete the folder ');
+        end
+    end
+
+    if installFlag
+
+        % changing to the local directory
+        cd(localDir);
+
+        % install the devTools properly speaking
+        fprintf('\n > Installing the MATLAB.devTools (might take some time) ... ');
+
+        [status_gitClone, result_gitClone] = system(['git clone -c http.sslVerify=false git@github.com:opencobra/MATLAB.devTools.git']);
+
+        if status_gitClone == 0
+
+            if ~isempty(localDir)
+                indexDir = strfind(CBTDIR, filesep);
+                devToolsDir = [CBTDIR(1:indexDir(end)), 'MATLAB.devTools'];
+            else
+                devToolsDir = dirReply;
+            end
+
+            fprintf(['Done.\n > The MATLAB.devTools have been installed into: ', devToolsDir, '\n\n']);
+
+            % add the path to the devTools
+            addpath(genpath(devToolsDir));
+
+            fprintf([' > In order to start contributing, you can now run: >> contribute\n\n']);
+        else
+            fprintf(result_gitClone);
+            error(['The MATLAB.devTools could not be cloned. Please make sure that your SSH key is configured correctly.']);
+        end
+    end
+
+    % change back to the current directory
+    cd(currentDir);
+end

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -1,4 +1,11 @@
-function installDevTools()
+function [] = installDevTools()
+% checks if the MATLAB.devTools already are present and
+% installs the MATLAB.devTools next to the cloned folder cobratoolbox if not
+%
+% USAGE:
+%    installDevTools()
+%
+% .. Author: Laurent Heirendt, June 2017
 
     global ENV_VARS
     global CBTDIR
@@ -19,6 +26,7 @@ function installDevTools()
 
     installFlag = false;
 
+    % check if the devTools already exist
     if exist([CBTDIR filesep '..' filesep 'MATLAB.devTools'], 'dir') == 7
 
         reply = input([' > There is already a copy of the MATLAB.devTools installed in the default location.\n   Do you want to enter another location to install the MATLAB.devTools? Y/N [Y]: '], 's');
@@ -54,6 +62,7 @@ function installDevTools()
         installFlag = true;
     end
 
+    % install a new copy of the MATLAB.devTools
     if installFlag
 
         % changing to the local directory

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -1,9 +1,15 @@
 function [] = installDevTools()
-% checks if the MATLAB.devTools already are present and
+% checks if the MATLAB.devTools are already present.
 % installs the MATLAB.devTools next to the cloned folder cobratoolbox if not
 %
 % USAGE:
 %    installDevTools()
+%
+% NOTE:
+%    In order to install the devTools, please make sure that the SSH key is
+%    configured properly as explained `here`_.
+%
+% .. _here: https://opencobra.github.io/cobratoolbox/docs/solvers.html
 %
 % .. Author: Laurent Heirendt, June 2017
 

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -88,12 +88,15 @@ function [] = installDevTools()
                 devToolsDir = dirReply;
             end
 
-            fprintf(['Done.\n > The MATLAB.devTools have been installed into: ', strrep(devToolsDir, '\', '\\'), '\n\n']);
+            fprintf(['Done.\n > Location of the MATLAB.devTools: ', strrep(devToolsDir, '\', '\\'), '\n\n']);
 
             % add the path to the devTools
             addpath(genpath(devToolsDir));
 
-            fprintf([' > In order to start contributing, you can now run: >> contribute\n\n']);
+            % removing .git folder
+            rmpath(genpath([devToolsDir filesep '.git']));
+
+            fprintf([' > In order to start contributing, you can now run:\n\n >> contribute\n\n']);
         else
             fprintf(result_gitClone);
             error(['The MATLAB.devTools could not be cloned. Please make sure that your SSH key is configured correctly.']);

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -1,6 +1,6 @@
 function [] = installDevTools()
-% checks if the MATLAB.devTools are already present.
-% installs the MATLAB.devTools next to the cloned folder cobratoolbox if not
+% checks if the MATLAB.devTools are already present and installs the
+% MATLAB.devTools next to the cloned folder cobratoolbox (if not present yet)
 %
 % USAGE:
 %    installDevTools()

--- a/src/base/installDevTools.m
+++ b/src/base/installDevTools.m
@@ -73,7 +73,7 @@ function installDevTools()
                 devToolsDir = dirReply;
             end
 
-            fprintf(['Done.\n > The MATLAB.devTools have been installed into: ', devToolsDir, '\n\n']);
+            fprintf(['Done.\n > The MATLAB.devTools have been installed into: ', strrep(devToolsDir, '\', '\\'), '\n\n']);
 
             % add the path to the devTools
             addpath(genpath(devToolsDir));


### PR DESCRIPTION
- `installDevTools()` function to install the MATLAB.devTools from within MATLAB.
- updated documentation and `README` instructions

*Note:* Tested on `Windows`, `macOS` and `Linux`. CI test to be added at a later point.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)