### PR TITLE
Updated 'all' behaviour

### DIFF
--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -264,22 +264,15 @@ if ~any(strcmp(supportedSolversNames, solverName))
 end
 
 % Attempt to set the user provided solver for all optimization problem types
-if strcmpi(solverType, 'all')
-    for i = 1:length(OPT_PROB_TYPES)
-        try
-            solverOk = changeCobraSolver(solverName, OPT_PROB_TYPES{i});            
-            if printLevel > 0
-                if (solverOk)
-                    fprintf([' > CBT_', OPT_PROB_TYPES{i}, '_SOLVER has been set to ', solverName, '.\n']);
-                else
-                    warning('Solver %s is not supported for for problems of type %s. Keeping old setting', solverName, OPT_PROB_TYPES{i});
-                end
-            end
-        catch ME
-            if printLevel > 0
-                warning([ME.message sprintf('\n') solverName ' not set to solve ' OPT_PROB_TYPES{i} ' problems']);
-            end
-        end                            
+if strcmpi(solverType, 'all')    
+    solvedProblems = SOLVERS.(solverName).type;    
+    for i = 1:length(solvedProblems)
+        changeCobraSolver(solverName, solvedProblems{i});            
+        fprintf([' > Solver for ', solvedProblems{i}, 'problems has been set to ', solverName, '.\n']);        
+    end
+    notsupportedProblems = setdiff(OPT_PROB_TYPES,solvedProblems);
+    for i = 1:length(notsupportedProblems)
+        fprintf(' > Solver %s not supported for problems of type %s \n', solverName, notsupportedProblems{i});        
     end
     return
 end

--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -272,7 +272,13 @@ if strcmpi(solverType, 'all')
     end
     notsupportedProblems = setdiff(OPT_PROB_TYPES,solvedProblems);
     for i = 1:length(notsupportedProblems)
-        fprintf(' > Solver %s not supported for problems of type %s \n', solverName, notsupportedProblems{i});        
+        solverUsed = eval(['CBT_' notsupportedProblems{i} '_SOLVER']);
+        if isempty(solverUsed)
+            infoString = 'No solver set for this problemtype';
+        else
+            infoString = sprintf('Currently used: %s',solverUsed);
+        end
+        fprintf(' > Solver %s not supported for problems of type %s. %s \n', solverName, notsupportedProblems{i},infoString);        
     end
     return
 end

--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -266,8 +266,20 @@ end
 % Attempt to set the user provided solver for all optimization problem types
 if strcmpi(solverType, 'all')
     for i = 1:length(OPT_PROB_TYPES)
-        changeCobraSolver(solverName, OPT_PROB_TYPES{i}, 0);
-        fprintf([' > CBT_', OPT_PROB_TYPES{i}, '_SOLVER has been set to ', solverName, '.\n']);
+        try
+            solverOk = changeCobraSolver(solverName, OPT_PROB_TYPES{i});            
+            if printLevel > 0
+                if (solverOk)
+                    fprintf([' > CBT_', OPT_PROB_TYPES{i}, '_SOLVER has been set to ', solverName, '.\n']);
+                else
+                    warning('Solver %s is not supported for for problems of type %s. Keeping old setting', solverName, OPT_PROB_TYPES{i});
+                end
+            end
+        catch ME
+            if printLevel > 0
+                warning([ME.message sprintf('\n') solverName ' not set to solve ' OPT_PROB_TYPES{i} ' problems']);
+            end
+        end                            
     end
     return
 end


### PR DESCRIPTION
At the moment, `changeCobraSolver('glpk','all')` will lead to statements indicating that all solvers have been set to GLPK, which is wrong, as only e.g. LP and MILP will have been set to GLPK. 
However, the user is not made aware of this, and also not of the reason why this is happening.

This pr introduces feedback during the `changeCobraSolver(solver,'all')` call in accordance with the actual changed settings, and return the appropriate error messages (as text).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
