### PR TITLE
Fixed old input parser

### DIFF
--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -57,9 +57,10 @@ if numel(varargin) > 2
         tempargin = varargin(1:2);
         % just replace the input by the options and replace varargin
         % accordingly
-        for i = 3:numel(varargin)
+        for i = 3:numel(varargin)            
             if ~isempty(varargin{i})
-                tempargin = [tempargin, optionalInputs{i - 2}, varargin{i}];
+                tempargin(end+1) = optionalInputs(i-2);
+                tempargin(end+1) = varargin(i);                                
             end
         end
         varargin = tempargin;


### PR DESCRIPTION
Small fix to readCbModel when using old style inputs.
The problem was that the concatenation of cell arrays led to compSymbols/compNames being aded as 2 instead of one additional cell. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
