### PR TITLE
Fixed insertion of empty rule blocks

### DIFF
--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -24,6 +24,12 @@ rules(1:n,1) = {''};
 for i = 1:n
     if length(grRules{i}) > 0
         tmp = grRules{i};
+        %The function assumes that there are no spaces between parenthesis
+        %and formulas, or it creates "empty" gene associations. so we
+        %replace all spaces trailing or preceding parenthesis.
+        tmp = regexprep(tmp,'\( *','('); %replace all spaces after opening parenthesis
+        tmp = regexprep(tmp,' *\)',')'); %replace all spaces before closing paranthesis.
+        tmp = regexprep(tmp,' * (and|AND|or|OR|And|Or)  *',' $1 '); %replace all surplus spaces around logical operators
 
         tmp = splitString(tmp,' ');
         tmp = strrep(tmp,' ','');


### PR DESCRIPTION
Fixed an issue with generateRules, where the function originally inserted empty x() into rules statements due to spaces in the rules.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
