### PR TITLE
Enhancement in fastFVA

### DIFF
--- a/src/base/solvers/configEnvVars.m
+++ b/src/base/solvers/configEnvVars.m
@@ -172,10 +172,7 @@ function configEnvVars(printLevel)
                     % if the solver variable is still empty, then give instructions on how to proceed
                     if isempty(eval(globEnvVar))
                         if printLevel > 0
-                            solversLink = 'https://opencobra.github.io/cobratoolbox/docs/solvers.html';
-                            if usejava('desktop')
-                                solversLink = ['<a href=\"', solversLink, '\">instructions</a>'];
-                            end
+                            solversLink = hyperlink('https://opencobra.github.io/cobratoolbox/docs/solvers.html', 'instructions');
                             fprintf(['   - [', method, '] ', globEnvVar, ' :  --> set this path manually after installing the solver ( see ', solversLink, ' )\n' ]);
                         end
                     else

--- a/src/base/solvers/getCPLEXversion.m
+++ b/src/base/solvers/getCPLEXversion.m
@@ -79,7 +79,8 @@ function cplexVersion = getCPLEXversion(rootPathCPLEX, printLevel)
             fprintf([' > The CPLEX version is ' cplexVersion '\n. Your currently installed version of CPLEX is unsupported or you have multiple versions of CPLEX in the path.']);
         end
     else
-        error('CPLEX is not installed. Please follow the installation instructions here:');
+        error(['CPLEX is not installed. Please follow the installation instructions here: ', ...
+               'https://opencobra.github.io/cobratoolbox/docs/solvers.html']);
     end
 
     % restore the original path

--- a/src/modelAnalysis/sampling/chrrSampler.m
+++ b/src/modelAnalysis/sampling/chrrSampler.m
@@ -38,6 +38,8 @@ function [samples, roundedPolytope, minFlux, maxFlux] = chrrSampler(model, numSk
 % of samples from a single model, you can save `roundedPolytope` from the first round and
 % input it for subsequent rounds.
 
+global SOLVERS
+
 if nargin>=5 && isempty(numSkip)
     numSkip = 8*size(roundedPolytope.A,2)^2;
 end
@@ -73,9 +75,9 @@ if toPreprocess
     fprintf('Checking for width 0 facets...\n');
 
     if toGetWidths
-        %check if we can use fastFVA
-        if exist('fastFVA')==2
-            %check if we can do parallel for fastFVA
+        % check if we can use fastFVA
+        if SOLVERS.ibm_cplex.installed
+            % check if we can do parallel for fastFVA
             v=ver;
             PCT='Parallel Computing Toolbox';
             if  any(strcmp(PCT,{v.Name}))
@@ -84,6 +86,7 @@ if toPreprocess
             end
             [minFlux, maxFlux] = fastFVA(model,100);
         else
+            fprintf('IBM CPLEX is not installed, so `fastFVA` cannot be run. Using `fluxVariability` instead\n');
             [minFlux, maxFlux] = fluxVariability(model);
         end
     end


### PR DESCRIPTION
* better error message when CPLEX is not installed
* if CPLEX is not installed run `fluxVariability` instead of `fastFVA` in sampling.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
