### PR TITLE
Modified model.rxnGeneMat: rxns x genes

### DIFF
--- a/src/base/io/utilities/buildRxnGeneMat.m
+++ b/src/base/io/utilities/buildRxnGeneMat.m
@@ -12,7 +12,7 @@ function model = buildRxnGeneMat(model)
 % OUTPUT:
 %    model: 	The Model including a rxnGeneMat field. 
 
-model.rxnGeneMat = false(numel(model.genes),numel(model.rxns));
+model.rxnGeneMat = false(numel(model.rxns, numel(model.genes)));
 if isfield(model,'rules')
     for i = 1:numel(model.rxns)
         if ~isempty(model.rules{i})


### PR DESCRIPTION
There was an error in this function, giving rxns x rxns instead of rxns x genes for model.rxnGeneMat


**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
