### PR TITLE
Fix writeLPPproblem for problems with csense 'G'

### DIFF
--- a/src/base/io/writeLPProblem.m
+++ b/src/base/io/writeLPProblem.m
@@ -171,8 +171,8 @@ switch outputFormat
             MPSfilename = fileName;
         end
         % split A matrix for L and E csense
-        Ale = A((csense == 'L') | (csense == 'G'), :);
-        ble = b((csense == 'L') | (csense == 'G'));
+        Ale = [A(csense == 'L', :); -A(csense == 'G', :)];
+        ble = [b(csense == 'L'); -b(csense == 'G')];
         Aeq = A(csense == 'E', :);
         beq = b(csense == 'E');
 

--- a/test/verifiedTests/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraLP.m
@@ -127,6 +127,20 @@ params.pdco_zsize = 1e-12;
 [~, all_obj] = runLPvariousSolvers(model, solverPkgs, params);
 assert(abs(min(all_obj) - max(all_obj)) < tol)
 
+clear model
+% test constraints with csense 'G'
+% max x 
+% s.t. -x >= -1,  
+%      0 <= x <= 100
+model.S = -1;
+model.b = -1;
+model.csense = 'G';
+model.lb = 0;
+model.ub = 100;
+model.c = 1;
+model.osense = -1;
+[~, all_obj] = runLPvariousSolvers(model, solverPkgs, params);
+assert(abs(min(all_obj) - 1) < tol & abs(max(all_obj) - 1) < tol)
 
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
[*Please include a short description of enhancement here*]
`writeLPPproblem` for writing MPS file seems to handle constraints with csense 'G' incorrectly.
Since the solver dqqMinos calls writeLPPproblem, I used it as a test:

```
LP = struct();
% constraint: x >= 1
LP.A = 1;
LP.b = 1;
LP.csense = 'G';

LP.lb = 0;
LP.ub = 100;
LP.c = 1;
LP.osense = 1;

changeCobraSolver('gurobi', 'LP');
solRef = solveCobraLP(LP);
fprintf('Solution from gurobi: x = %.4f\n', solRef.full);

changeCobraSolver('dqqMinos', 'LP');
sol = solveCobraLP(LP);
fprintf('Solution from dqqMinos: x = %.4f\n', sol.full);
```
Before making the changes, I got:

> Solution from gurobi: x = 1.0000
> Solution from dqqMinos: x = 0.0000

After making the changes, I got
> Solution from gurobi: x = 1.0000
> Solution from dqqMinos: x = 1.0000

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
