### PR TITLE
Fix addReaction with 'reactionName' as the 1st name-value argument

### DIFF
--- a/src/reconstruction/refinement/addReaction.m
+++ b/src/reconstruction/refinement/addReaction.m
@@ -25,7 +25,7 @@ function [model, rxnIDexists] = addReaction(model, rxnID, varargin)
 %                         * reversible - Reversibility flag (Default = true)
 %                         * lowerBound - Lower bound (Default = 0 or -vMax`)
 %                         * upperBound - Upper bound (Default = `vMax`)
-%                         * objCoeff - Objective coefficient (Default = 0)
+%                         * objectiveCoef - Objective coefficient (Default = 0)
 %                         * subSystem - Subsystem (Default = '')
 %                         * geneRule - Gene-reaction rule in boolean format (and/or allowed)
 %                           (Default = '');
@@ -65,7 +65,7 @@ function [model, rxnIDexists] = addReaction(model, rxnID, varargin)
 
 optionalParameters = {'reactionName','reactionFormula','metaboliteList','stoichCoeffList',...
     'reversible','lowerBound','upperBound',...
-    'objectiveCoef','subSystem','geneRule','checkDuplicate','printLevel','notes'}; % check for backward compatability
+    'objectiveCoef','subSystem','geneRule','geneNameList','systNameList','checkDuplicate','printLevel','notes'}; % check for backward compatability
 oldOptionalOrder = {'metaboliteList','stoichCoeffList',...
     'reversible','lowerBound','upperBound',...
     'objectiveCoef','subSystem','geneRule','geneNameList','systNameList','checkDuplicate','printLevel'};

--- a/src/reconstruction/refinement/addReaction.m
+++ b/src/reconstruction/refinement/addReaction.m
@@ -12,7 +12,7 @@ function [model, rxnIDexists] = addReaction(model, rxnID, varargin)
 % OPTIONAL INPUTS:
 %    varargin:          Input of additional information as parameter/Value pairs
 %
-%                         * reactonName - a Descriptive name of the reaction
+%                         * reactionName - a Descriptive name of the reaction
 %                           (default ID)
 %                         * metaboliteList - Cell array of metabolite names. Either this
 %                           parameter or reactionFormula are required.
@@ -63,7 +63,7 @@ function [model, rxnIDexists] = addReaction(model, rxnID, varargin)
 %       - Ines Thiele 08/03/2015, made rxnGeneMat optional
 %       - Thomas Pfau May 2017  Change To parameter Value pairs
 
-optionalParameters = {'reactionFormula','metaboliteList','stoichCoeffList',...
+optionalParameters = {'reactionName','reactionFormula','metaboliteList','stoichCoeffList',...
     'reversible','lowerBound','upperBound',...
     'objectiveCoef','subSystem','geneRule','checkDuplicate','printLevel','notes'}; % check for backward compatability
 oldOptionalOrder = {'metaboliteList','stoichCoeffList',...

--- a/test/verifiedTests/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/testModelManipulation/testModelManipulation.m
@@ -175,5 +175,32 @@ for i = 1:numel(fields)
     assert(isequal(val1,val2));
 end
 
+% Test addReaction with name-value argument input
+fprintf('>> Testing addReaction with name-value argument input\n');
+% options available in the input:
+name = {'reactionName', 'reversible', ...
+    'lowerBound', 'upperBound', 'objectiveCoef', 'subSystem', 'geneRule', ...
+    'geneNameList', 'systNameList', 'checkDuplicate', 'printLevel'};
+value = {'TEST', true, ...
+    -1000, 1000, 0, '', '', ...
+    {}, '', true, 1};
+arg = [name; value];
+model2 = addReaction(model, 'TEST', 'reactionFormula', [model.mets{1} ' ->'], arg{:});
+for k = 1:numel(name)
+    % test differet optional name-value argument as the first argument after rxnID
+    model2b = addReaction(model, 'TEST', name{k}, value{k}, 'reactionFormula', [model.mets{1} ' <=>']);
+    assert(isequal(rmfield(model2, 'rev'), rmfield(model2b, 'rev')))  % rev field can be nan, not comparable
+    
+    model2b = addReaction(model, 'TEST', name{k}, value{k}, 'metaboliteList', model.mets(1), 'stoichCoeffList', -1);
+    assert(isequal(rmfield(model2, 'rev'), rmfield(model2b, 'rev')))  % rev field can be nan, not comparable
+    
+    % test differet optional name-value argument as argument after reactionFormula or stoichCoeffList
+    model2b = addReaction(model, 'TEST', 'reactionFormula', [model.mets{1} ' <=>'], name{k}, value{k});
+    assert(isequal(rmfield(model2, 'rev'), rmfield(model2b, 'rev')))  % rev field can be nan, not comparable
+    
+    model2b = addReaction(model, 'TEST', 'metaboliteList', model.mets(1), 'stoichCoeffList', -1, name{k}, value{k});
+    assert(isequal(rmfield(model2, 'rev'), rmfield(model2b, 'rev')))  % rev field can be nan, not comparable
+end
+
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
[*Please include a short description of enhancement here*]
As I tried:
```
load('iAF1260.mat')
addReaction(iAF1260, 'test', 'reactionName', 'test', 'reactionFormula', 'glc__D_c ->');
```
It returns the error:
```
Error using addReaction (line 170)
The value of 'metaboliteList' is invalid. It must satisfy the function: iscell. 
```
It is because 'reactionName' was not in `optionalParameters` in line 66. So it treats it as the old style. Adding it back resolves the error. 
Where is the test for `addReaction` located? Does this need to be added into a test?

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
