### PR TITLE
Complete support for IBM Cplex parameters in solveCobraLP

### DIFF
--- a/src/base/solvers/setCplexParam.m
+++ b/src/base/solvers/setCplexParam.m
@@ -18,58 +18,87 @@ end
 if isempty(fieldnames(solverParams))
     return
 end
+% get all the end parameters and their paths from LP.Param
+%(e.g., LP.Param.simplex.display will have 'display' in paramList and 'LP.Param.simplex' in paramPath)
 [paramList, paramPath] = getParamList(LP.Param, 0);
-[paramUserList, paramUserPath] = getParamList(solverParams, 1);
+% similarly get all parameters and paths from the user-supplied parameter structure
+% (but not going to the bottom level. User-supplied parameter structure no
+% need to have *.Cur field after every parameter. But still supported if there is .Cur)
+[paramUserList, paramUserPath, addCur] = getParamList(solverParams, 1);
+% whether an user-supplied parameter can be matched to LP.Param
 paramIden = false(numel(paramUserList), 1);
 for p = 1:numel(paramUserList)
     f = strcmpi(paramList,paramUserList{p});
     if sum(f) == 1
+        % uniquely matched
         paramIden(p) = true;
-        str = ['LP.Param.' paramPath{f} '.Cur = solverParams.' paramUserPath{p} ';'];
+        str = ['LP.Param.' paramPath{f} '.Cur = solverParams.' paramUserPath{p}];
+        if addCur(p)  % add back .Cur if in the user-supplied parameters
+            str = [str '.Cur'];
+        end
+        str = [str ';'];
         eval(str);
     elseif sum(f) > 1
-        if ismember(lower(paramUserPath{p}), paramPath);
+        % not uniquely matched (for parameters end with 'display' etc.)
+        % compare the path then
+        if ismember(lower(paramUserPath{p}), paramPath)
             paramIden(p) = true;
-            str = ['LP.Param.' lower(paramUserPath{p}) '.Cur = solverParams.' paramUserPath{p} ';'];
+            str = ['LP.Param.' lower(paramUserPath{p}) '.Cur = solverParams.' paramUserPath{p}];
+            if addCur(p)  % add back .Cur if in the user-supplied parameters
+                str = [str '.Cur'];
+            end
+            str = [str ';'];
             eval(str);
         else
             if verbFlag
-                fprintf('*.%s cannot be uniquely identified as a valid cplex parameter. Ignore.\n', paramUserPath{p});
+                warning('*.%s cannot be uniquely identified as a valid cplex parameter. Ignore.', paramUserPath{p});
             end
         end
     else
+        % not matched at all
         if verbFlag
-            fprintf('*.%s cannot be identified as a valid cplex parameter. Ignore.\n', paramUserPath{p});
+            warning('*.%s cannot be identified as a valid cplex parameter. Ignore.', paramUserPath{p});
         end
     end
 end
 end
 
-function [paramList, paramPath] = getParamList(param, bottomFlag)
-%for matching CPLEX parameters appropriately
-structCur = param;
-lv = 1;
+function [paramList, paramPath, addCur] = getParamList(param, bottomFlag)
+% Get all the end parameters and their paths for matching CPLEX parameters appropriately
+% (e.g., if param.simplex.display is a parameter, then we will have 'display' 
+% in paramList and 'param.simplex' in paramPath)
+structCur = param;  % current structure
+lv = 1;  % current level of the structure
+% use a stack structure to store the found parameters
 lvFieldN = zeros(10,1);
-lvFieldN(1) = 1;
+lvFieldN(1) = 1;  % the number of fields being checked at the current level
 lvField = cell(10, 1);
-lvField{lv} = fieldnames(structCur);
+lvField{lv} = fieldnames(structCur);  % all fields in the current level
 paramPath = {};
 paramList = {};
+addCur = [];
 while lv > 0
-    if isstruct(structCur.(lvField{lv}{lvFieldN(lv)})) 
+    if isstruct(structCur.(lvField{lv}{lvFieldN(lv)}))
+        % if the current level is still a structure
         if ~isempty(fieldnames(structCur.(lvField{lv}{lvFieldN(lv)})))
+            % if it is not an empty structure, go into that structure
             structCur = structCur.(lvField{lv}{lvFieldN(lv)});
-            lv = lv + 1;
-            lvFieldN(lv) = 1;
+            lv = lv + 1;  % level + 1
+            % start checking from the first field in the next level of structure
+            lvFieldN(lv) = 1;  
+            % get all fields for the next structure
             lvField{lv} = fieldnames(structCur);
         else
+            % an empty structure, go back to the closest level with any unchecked structures
             while lvFieldN(lv) == numel(lvField{lv})
                 lv = lv - 1;
                 if lv == 0
+                    % finish if level = 0
                     break
                 end
             end
             if lv > 0
+                % check the next structure in the current level
                 lvFieldN(lv) = lvFieldN(lv) + 1;
                 structCur = param;
                 for j = 1:lv-1
@@ -78,23 +107,44 @@ while lv > 0
             end
         end
     else
-        if ~bottomFlag
+        addCurLv = false;
+        if ~bottomFlag || strcmpi(lvField{lv}{lvFieldN(lv)}, 'Cur')
+            % if the current level is not a structure, with the bottomFlag off 
+            % (not going to the bottom level, for LP.Param), or if the current level 
+            % is named 'Cur' (may happen in the user-supplied parameter structure),
+            % decrease one level since the bottom level of all parameters is either 
+            % 'Min', 'Max', 'Cur', 'Def', 'Name', 'Help' containing the information 
+            % for the parameter, which is the name for the structure immediately on 
+            % top of the current level
             lv = lv - 1;
+            if bottomFlag  % 'Cur' at the bottom level in the user-supplied parameters
+                addCurLv = true;
+            end
         end
         if lv > 0
+            % get the path for the current parameter
             c = {};
             for j = 1:lv
                 c = [c lvField{j}(lvFieldN(j))];
             end
             paramPath = [paramPath; strjoin(c,'.')];
+            % whether or not need to add back .Cur to the path for user-supplied parameters
+            if addCurLv
+                addCur = [addCur; true];
+            else
+                addCur = [addCur; false];
+            end
             paramList = [paramList; c(end)];
+            % go back to the closest level with any unchecked structures
             while lvFieldN(lv) == numel(lvField{lv})
                 lv = lv - 1;
                 if lv == 0
+                    % finish if level = 0
                     break
                 end
             end
             if lv > 0
+                % check the next structure in the current level
                 lvFieldN(lv) = lvFieldN(lv) + 1;
                 structCur = param;
                 for j = 1:lv-1
@@ -102,6 +152,7 @@ while lv > 0
                 end
             end
         else
+            % if lv = 0 because of bottomFlag, continue at lv = 1 
             lv = 1;
             if lvFieldN(lv) == numel(lvField{lv})
                 break

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -1202,14 +1202,26 @@ switch solver
             % 6 Concurrent Dual, Barrier and Primal
             % Default: 0
 
-            % TODO assign all parameters
-            if isfield(solverParams,'lpmethod')
-                if isfield(solverParams.lpmethod,'Cur')
-                    ILOGcplex.Param.lpmethod.Cur=solverParams.lpmethod.Cur;
-                end
-            else
-                % automatically chooses algorithm
-                ILOGcplex.Param.lpmethod.Cur=0;
+            % Assign all parameters
+            % solverParams in this case can be e.g.:
+            % solverParams = struct();
+            % [solverParams.simplex.display, solverParams.tune.display, solverParams.barrier.display,...
+            %      solverParams.sifting.display, solverParams.conflict.display] = deal(0);
+            % [solverParams.simplex.tolerances.optimality, solverParams.simplex.tolerances.feasibility] = deal(1e-9);
+            % See Cplex().Param for all possible parameters
+            ILOGcplex = setCplexParam(ILOGcplex, solverParams, printLevel);
+            % use the feasTol and optTol from Cobra toolbox if exist
+            if exist('feasTol', 'var')
+                ILOGcplex.Param.simplex.tolerances.feasibility.Cur = feasTol;
+            end
+            if exist('optTol', 'var')
+                ILOGcplex.Param.simplex.tolerances.optimality.Cur = optTol;
+            end
+            
+            if ~isfield(solverParams, 'lpmethod')
+                % automatically chooses algorithm if not set in solverParams
+                % (should already be the default value in ILOGcplex.Param.lpmethod.Cur)
+                ILOGcplex.Param.lpmethod.Cur = 0;
             end
 
             % set the print level

--- a/test/verifiedTests/testSolvers/testChangeIBMCplexParams.m
+++ b/test/verifiedTests/testSolvers/testChangeIBMCplexParams.m
@@ -1,0 +1,102 @@
+% The COBRAToolbox: testChangeIBMCplexParams.m
+%
+% Purpose:
+%    This script tests whether input parameters for the IBM ILOG Cplex solver
+%    are in effect when calling solveCobraLP.m, and also tests directly the function 
+%    setCplexParam used to change the IBM ILOG Cplex parameters in solveCobraLP.m
+
+% save the current path
+currentDir = pwd;
+
+% initialize the test
+fileDir = fileparts(which('testChangeIBMCplexParams'));
+cd(fileDir);
+
+try
+    ibm_cplex = changeCobraSolver('ibm_cplex', 'LP');
+catch
+    ibm_cplex = false;
+end
+if ibm_cplex
+    LP = struct();
+    LP.A = 1;
+    LP.b = 1;
+    LP.lb = -1000;
+    LP.ub = 1000;
+    LP.c = 1;
+    LP.osense = -1;
+    LP.csense = 'L';
+    sol = solveCobraLP(LP);
+    assert(sol.full == 1)
+    % change the time limite for the solver
+    CplexParam = struct('timelimit', 0);
+    sol = solveCobraLP(LP, CplexParam);
+    % no solution because of time limit
+    assert(isempty(sol.full) & sol.origStat == 11)
+    
+    % print parameters not recognized by Cplex
+    CplexParam.notexist = 1;
+    diary('testChangeIBMCplexParams.txt');
+    sol = solveCobraLP(LP, CplexParam, 'printLevel', 1);
+    diary off
+    fid = fopen('testChangeIBMCplexParams.txt', 'r');
+    text1 = '';
+    line = fgetl(fid);
+    while ~isequal(line, -1)
+        text1 = [strtrim(text1), ' ', line];
+        line = fgetl(fid);
+    end
+    fclose(fid);
+    % check if the warning is printed
+    assert(~isempty(strfind(text1, 'Warning: *.notexist cannot be identified as a valid cplex parameter. Ignore.')))
+    delete('testChangeIBMCplexParams.txt');
+    
+    % print parameters that cannot be uniquely identified
+    CplexParam = struct('timelimit', 0, 'feasibility', 1e-8);
+    diary('testChangeIBMCplexParams.txt');
+    sol = solveCobraLP(LP, CplexParam, 'printLevel', 1);
+    diary off
+    fid = fopen('testChangeIBMCplexParams.txt', 'r');
+    text1 = '';
+    line = fgetl(fid);
+    while ~isequal(line, -1)
+        text1 = [strtrim(text1), ' ', line];
+        line = fgetl(fid);
+    end
+    fclose(fid);
+    % check if the warning is printed
+    assert(~isempty(strfind(text1, 'Warning: *.feasibility cannot be uniquely identified as a valid cplex parameter. Ignore.')))
+    delete('testChangeIBMCplexParams.txt');
+    
+    % test changing other Cplex parameters
+    LP = Cplex('test setCplexParam');
+    CplexParam = struct();
+    [CplexParam.simplex.display, CplexParam.tune.display] = deal(0);
+    [CplexParam.simplex.tolerances.optimality, CplexParam.simplex.tolerances.feasibility] = deal(1e-9, 1e-8);
+    % change parameters using setCplexParam
+    LP = setCplexParam(LP, CplexParam);
+    % Cplex internal method for getting all changed parameters
+    ChangedParams = LP.getChgParam;
+    
+    % test also with .Cur at the end of the input struct
+    LP = Cplex('test setCplexParam');
+    CplexParam = struct();
+    [CplexParam.simplex.display.Cur, CplexParam.tune.display.Cur] = deal(0);
+    [CplexParam.simplex.tolerances.optimality.Cur, CplexParam.simplex.tolerances.feasibility.Cur] = deal(1e-9, 1e-8);
+    % change parameters using setCplexParam
+    LP = setCplexParam(LP, CplexParam);
+    % Cplex internal method for getting all changed parameters
+    ChangedParams2 = LP.getChgParam;
+    
+    % the changed parameters should be the same using either input structures
+    assert(isequal(ChangedParams, ChangedParams2))
+    % check if the parameters are really changed
+    assert(isfield(ChangedParams, 'simplex') && isfield(ChangedParams.simplex, 'display') ...
+        && ChangedParams.simplex.display.Cur == 0 && isfield(ChangedParams.simplex, 'tolerances') ...
+        && isfield(ChangedParams.simplex.tolerances, 'optimality') && ChangedParams.simplex.tolerances.optimality.Cur == 1e-9 ...
+        && isfield(ChangedParams.simplex.tolerances, 'feasibility') && ChangedParams.simplex.tolerances.feasibility.Cur == 1e-8 ...
+        && isfield(ChangedParams, 'tune') && isfield(ChangedParams.tune, 'display') && ChangedParams.tune.display.Cur == 0)
+end
+
+% change the directory
+cd(currentDir)


### PR DESCRIPTION
*Please include a short description of enhancement here*
In `solveCobraLP`, the optional parameter support for the `ibm_cplex` solver is still in the TODO list. The following changes are made accordingly:
- Modify `setCplexParam` and add in-line comments
- Add complete support for IBM ILOG Cplex parameter structure when calling `solveCobraLP` using `setCplexParam`
- Add `testChangeIBMCplexParams` for testing the relevant functionalities in `solveCobraLP` and `setCplexParam`.
If the code for `solveCobraLP` looks good, it can be used in `solveCobraQP` and `solveCobraMILP` in a similar fashion.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
