### PR TITLE
WIP: using the sign of the stoichiometry, rather than the stoichiometry itself

### DIFF
--- a/src/dataIntegration/metabotools/computeFluxSplits.m
+++ b/src/dataIntegration/metabotools/computeFluxSplits.m
@@ -22,7 +22,7 @@ function [P,C,vP,vC] = computeFluxSplits(model,mets,V)
 %
 % .. Author: - Hulda S. Haraldsdottir, December 2, 2016
 
-s = sum([model.S(ismember(model.mets,mets),:); sparse(1,size(model.S,2))],1)'; % net stoichiometry. Zero if model.mets does not contain mets.
+s = sign(sum([model.S(ismember(model.mets,mets),:); sparse(1,size(model.S,2))],1))'; % net stoichiometry. Zero if model.mets does not contain mets.
 W = diag(s)*V; % stoichiometrically weighted flux
 vP = max(W,0); % net production
 vC = -min(W,0); % net consumption


### PR DESCRIPTION
Previously, the flux vector V was being multiplied by the stoichiometry. However, we only want to multiply V by the sign of the stoichiometry, not by the stoichiometry itself. 

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
