### PR TITLE
Support IBM Cplex parameters in solveCobraMILP and solveCobraQP

### DIFF
--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -396,6 +396,11 @@ switch solver
         cplexlp.Param.simplex.tolerances.feasibility.Cur = solverParams.feasTol;
         % Strict numerical tolerances
         cplexlp.Param.emphasis.numerical.Cur = solverParams.NUMERICALEMPHASIS;
+        
+        % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
+        solverParams = rmfield(solverParams, optParamNames([1:5, 7:12]));
+        cplexlp = setCplexParam(cplexlp, solverParams, printLevel);
+        
         save('MILPProblem','cplexlp')
 
         % Set up callback to print out intermediate solutions
@@ -404,7 +409,10 @@ switch solver
 
         % Solve problem
         Result = cplexlp.solve();
-
+        
+        % Close the output file
+        fclose(outputfile);
+        
         % Get results
         x = Result.x;
         f = osense*Result.objval;
@@ -420,7 +428,7 @@ switch solver
         else
             solStat = 3; % Other problem, but integer solution exists
         end
- 	if exist([pwd filesep 'clone1.log'],'file')
+        if exist([pwd filesep 'clone1.log'],'file')
             delete('clone1.log')
         end
 

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -397,8 +397,9 @@ switch solver
         % Strict numerical tolerances
         cplexlp.Param.emphasis.numerical.Cur = solverParams.NUMERICALEMPHASIS;
         
-        % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
+        % Remove all Cobra solve parameters in solverParams which are not IBM Cplex parameters
         solverParams = rmfield(solverParams, optParamNames([1:5, 7:12]));
+        % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
         cplexlp = setCplexParam(cplexlp, solverParams, printLevel);
         
         save('MILPProblem','cplexlp')

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -178,10 +178,16 @@ switch solver
         CplexQPProblem.Model.Q = F;
 
         %optional parameters
+        if printLevel == 0
+            CplexQPProblem.DisplayFunc=[];
+        end
         CplexQPProblem.Param.output.writelevel.Cur = printLevel;
         CplexQPProblem.Param.qpmethod.Cur = 1;
 
-
+        % Set IBM-Cplex-specific parameters
+        parameters = rmfield(parameters, intersect(fieldnames(parameters), optParamNames));
+        CplexQPProblem = setCplexParam(CplexQPProblem, parameters, printLevel);
+        
         %Save Input if selected
         if ~isempty(saveInput)
             fileName = saveInput;
@@ -193,8 +199,12 @@ switch solver
         end
 
         Result = CplexQPProblem.solve();
-        x = Result.x;
-        f = osense*Result.objval;
+        if isfield(Result,'x')  % Cplex solution may not have x
+            x = Result.x;
+        end
+        if isfield(Result,'objval')  % Cplex solution may not have objval
+            f = osense*Result.objval;
+        end
         origStat = Result.status;
         if (origStat == 1 || origStat == 101)
             stat = 1; % Optimal

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -178,7 +178,7 @@ switch solver
         CplexQPProblem.Model.Q = F;
 
         %optional parameters
-        if printLevel == 0
+        if printLevel == 0  % set display function as empty
             CplexQPProblem.DisplayFunc=[];
         end
         CplexQPProblem.Param.output.writelevel.Cur = printLevel;

--- a/test/verifiedTests/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraMILP.m
@@ -77,15 +77,13 @@ for k = 1:length(solverPkgs)
             assert(all(abs(MILPsolution.int - [0; 31; 46]) < tol))
             assert(abs(MILPsolution.obj - 554) < tol)
             
-            % compare the log file to see whether the parametr changes are implemented
+            % compare the log files to see whether the parameter changes are implemented
             testLog = {''; ''};
             paramsInLog = cell(2, 1);
-            % text that should be found in the first test
-            paramsInLog{1} = {'balance optimality and feasibility'; ...
-                'dynamic search'};
-            % text that should be found in the second test
-            paramsInLog{2} = {'integer feasibility'; ...
-                'branch-and-cut'};
+            % text that should be found during the first test
+            paramsInLog{1} = {'balance optimality and feasibility'; 'dynamic search'};
+            % text that should be found during the second test
+            paramsInLog{2} = {'integer feasibility'; 'branch-and-cut'};
             for jTest = 1:2
                 % read the log files
                 f = fopen(['testIBMcplexMILPparam' num2str(jTest) '.log'], 'r');

--- a/test/verifiedTests/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraMILP.m
@@ -58,6 +58,52 @@ for k = 1:length(solverPkgs)
         % check results with expected answer.
         assert(all(abs(MILPsolution.int - [0; 31; 46]) < tol))
         assert(abs(MILPsolution.obj - 554) < tol)
+        
+        if strcmp(solverPkgs{k}, 'ibm_cplex')
+            % test IBM-Cplex-specific parameters. Solve with the below parameters changed
+            cplexParams = struct();
+            cplexParams.emphasis.mip = 0;  % MIP emphasis: balance optimality and integer feasibility
+            cplexParams.mip.strategy.search = 2;  % MIP search method: dynamic search
+            MILPsolution = solveCobraMILP(MILPproblem, cplexParams, 'logFile', 'testIBMcplexMILPparam1.log');
+            % check expected answer
+            assert(all(abs(MILPsolution.int - [0; 31; 46]) < tol))
+            assert(abs(MILPsolution.obj - 554) < tol)
+            
+            % solve with the parameters changed to other values
+            cplexParams.emphasis.mip = 1;  % MIP emphasis: integer feasibility.
+            cplexParams.mip.strategy.search = 1;  % MIP search method: traditional branch-and-cut search
+            MILPsolution = solveCobraMILP(MILPproblem, cplexParams, 'logFile', 'testIBMcplexMILPparam2.log');
+            % check expected answer
+            assert(all(abs(MILPsolution.int - [0; 31; 46]) < tol))
+            assert(abs(MILPsolution.obj - 554) < tol)
+            
+            % compare the log file to see whether the parametr changes are implemented
+            testLog = {''; ''};
+            paramsInLog = cell(2, 1);
+            % text that should be found in the first test
+            paramsInLog{1} = {'balance optimality and feasibility'; ...
+                'dynamic search'};
+            % text that should be found in the second test
+            paramsInLog{2} = {'integer feasibility'; ...
+                'branch-and-cut'};
+            for jTest = 1:2
+                % read the log files
+                f = fopen(['testIBMcplexMILPparam' num2str(jTest) '.log'], 'r');
+                l = fgets(f);
+                while ~isequal(l, -1)
+                    testLog{jTest} = [testLog{jTest}, l];
+                    l = fgets(f);
+                end
+                fclose(f);
+                % check that the expected parameter values are set, and the unexpected are not set.
+                for p = 1:2
+                    assert(~isempty(strfind(testLog{jTest}, paramsInLog{jTest}{p})));
+                    assert(isempty(strfind(testLog{jTest}, paramsInLog{setdiff(1:2, jTest)}{p})));
+                end
+                % delete the log files
+                delete(['testIBMcplexMILPparam' num2str(jTest) '.log']);
+            end
+        end
     end
 
     % output a success message

--- a/test/verifiedTests/testSolvers/testSolveCobraQP.m
+++ b/test/verifiedTests/testSolvers/testSolveCobraQP.m
@@ -51,6 +51,13 @@ for k = 1:length(solverPkgs)
         % Check QP results with expected answer.
         assert(any(abs(QPsolution.obj + 0.0278)  < tol & abs(QPsolution.full - 0.0556) < [tol; tol]));
 
+        if strcmp(solverPkgs{k}, 'ibm_cplex')
+            % test IBM-Cplex-specific parameters. No good example for testing this. Just test time limit
+            QPsolution = solveCobraQP(QPproblem, struct('timelimit', 0), 'printLevel', 0);
+            % no solution because zero time is given and cplex status = 11
+            assert(isempty(QPsolution.full) & isempty(QPsolution.obj) & QPsolution.origStat == 11)
+        end
+        
         % output a success message
         fprintf('Done.\n');
     end


### PR DESCRIPTION
*Please include a short description of enhancement here*
- Add support for solver-specific parameters for `ibm_cplex` in `solveCobraMILP` and `solveCobraQP`
- Add the corresponding tests in `testSolveCobraMILP` and `testSolveCobraQP`

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
