### PR TITLE
Fix bug in generateRules and speedup

### DIFF
--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -13,60 +13,18 @@ function [model2] = generateRules(model)
 %    model2:    same model but with model.rules added
 %
 % .. Author: -  Aarash Bordar 11/17/2010
+%          :    Uri David Akavia 6-Aug-2017, bug fixes and speedup
 
 grRules = model.grRules;
 genes = model.genes;
-
-[m,n] = size(model.S);
-
-rules(1:n,1) = {''};
-
-for i = 1:n
-    if length(grRules{i}) > 0
-        tmp = grRules{i};
-        %The function assumes that there are no spaces between parenthesis
-        %and formulas, or it creates "empty" gene associations. so we
-        %replace all spaces trailing or preceding parenthesis.
-        tmp = regexprep(tmp,'\( *','('); %replace all spaces after opening parenthesis
-        tmp = regexprep(tmp,' *\)',')'); %replace all spaces before closing paranthesis.
-        tmp = regexprep(tmp,' * (and|AND|or|OR|And|Or)  *',' $1 '); %replace all surplus spaces around logical operators
-
-        tmp = splitString(tmp,' ');
-        tmp = strrep(tmp,' ','');
-
-        tmp2 = [];
-        for j = 1:length(tmp)
-            if strcmp(tmp{j},'or')
-                tmp2 = [tmp2,'| '];
-            elseif strcmp(tmp{j},'and')
-                tmp2 = [tmp2,'& '];
-            elseif strcmp(tmp{j}(1),'(') & strcmp(tmp{j}(end),')')
-                tmp{j} = strrep(tmp{j},'(','');
-                tmp{j} = strrep(tmp{j},')','');
-                loc = strmatch(tmp{j},genes,'exact');
-                tmp2 = [tmp2,'(x(',num2str(loc),')) '];
-            elseif strcmp(tmp{j}(1),'(')
-                tmp{j} = strrep(tmp{j},'(','');
-                tmp{j} = strrep(tmp{j},')','');
-                loc = strmatch(tmp{j},genes,'exact');
-                tmp2 = [tmp2,'(x(',num2str(loc),') '];
-            elseif strcmp(tmp{j}(end),')')
-                tmp{j} = strrep(tmp{j},'(','');
-                tmp{j} = strrep(tmp{j},')','');
-                loc = strmatch(tmp{j},genes,'exact');
-                tmp2 = [tmp2,'x(',num2str(loc),')) '];
-            else
-                loc = strmatch(tmp{j},genes,'exact');
-                tmp2 = [tmp2,'x(',num2str(loc),') '];
-            end
-        end
-
-        tmp2 = tmp2(1:end-1);
-        rules{i} = tmp2;
-
-    end
-end
-
+convertGenes = @(x) sprintf('%d', find(strcmp(x, genes)));
+tmp = regexprep(grRules,'\( *','('); %replace all spaces after opening parenthesis
+tmp = regexprep(tmp,' *\)',')'); %replace all spaces before closing paranthesis.
+tmp = regexprep(tmp, ' * (?i)(and) *', ' & ');
+tmp = regexprep(tmp, ' * (?i)(or) *', ' | ');
+rules = regexprep(tmp, '([^\(\)\|\&\ ]+)', 'x(${convertGenes($0)})');
 
 model2 = model;
 model2.rules = rules;
+
+end

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -13,7 +13,7 @@ function [model2] = generateRules(model)
 %    model2:    same model but with model.rules added
 %
 % .. Author: -  Aarash Bordar 11/17/2010
-%          :    Uri David Akavia 6-Aug-2017, bug fixes and speedup
+%            -  Uri David Akavia 6-Aug-2017, bug fixes and speedup
 
 grRules = model.grRules;
 genes = model.genes;

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -20,11 +20,11 @@ modelsToTry = {'Acidaminococcus_intestini_RyC_MR95.mat', 'Acidaminococcus_sp_D21
 
 for i=1:length(modelsToTry)
     model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep modelsToTry{i}]);
-    fprintf('Beginning model %s\n', fileList(i).name);
+    fprintf('Beginning model %s\n', modelsToTry{i});
     model2 = generateRules(model);
     model.rules = strrep(model.rules, '  ', ' ');
     model.rules = strrep(model.rules, ' )', ')');
     model.rules = strrep(model.rules, '( ', '(');
     assert(all(strcmp(model.rules, model2.rules)));
-    fprintf('Succesfully completed model %s\n', fileList(i).name);
+    fprintf('Succesfully completed model %s\n', modelsToTry{i});
 end

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -1,0 +1,30 @@
+% The COBRAToolbox: testGenerateRules.m
+%
+% Purpose:
+%     - testGenerateRules tests generateRules
+%
+% Authors:
+%     - Initial Version: Uri David Akavia - August 2017
+
+global CBTDIR
+
+% save the current path
+currentDir = pwd;
+
+% initialize the test
+fileDir = fileparts(which('testGenerateRules'));
+cd(fileDir);
+
+modelsToTry = {'Acidaminococcus_intestini_RyC_MR95.mat', 'Acidaminococcus_sp_D21.mat', 'Recon1.0model.mat', 'ecoli_core_model.mat', 'modelReg.mat'};
+%fileList = dir([CBTDIR filesep 'test' filesep 'models' filesep '*.mat']);
+
+for i=1:length(modelsToTry)
+    model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep modelsToTry{i}]);
+    fprintf('Beginning model %s\n', fileList(i).name);
+    model2 = generateRules(model);
+    model.rules = strrep(model.rules, '  ', ' ');
+    model.rules = strrep(model.rules, ' )', ')');
+    model.rules = strrep(model.rules, '( ', '(');
+    assert(all(strcmp(model.rules, model2.rules2)));
+    fprintf('Succesfully completed model %s\n', fileList(i).name);
+end

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -25,6 +25,6 @@ for i=1:length(modelsToTry)
     model.rules = strrep(model.rules, '  ', ' ');
     model.rules = strrep(model.rules, ' )', ')');
     model.rules = strrep(model.rules, '( ', '(');
-    assert(all(strcmp(model.rules, model2.rules2)));
+    assert(all(strcmp(model.rules, model2.rules)));
     fprintf('Succesfully completed model %s\n', fileList(i).name);
 end


### PR DESCRIPTION
I was looking at generateRules in an attempt to speed it up, and I discovered a bug.
it doesn’t necessarily add the correct number of parentheses (lines 48-57 have a fixed number)
Lines 47-52 replace an opening parenthesis with two opening parentheses
Lines 53-57 replace a closing parenthesis with two closing parentheses

However, if there are more than one, they are still only replaced with two, which can lead to a wrong number of parenthesis overall.

For an example, look at Abiotrophia_defectiva_ATCC_49176.mat, rxn #74 ('AACOAT')
This reaction has the gene rule (bold and italics indicate matching parens, space inserted to make sure markdown works)
**(** Unknown and _(_ 592010.4.peg.1070 or 592010.4.peg.907 or 592010.4.peg.584 _)_ **)**

the rule should be (and my function generates)
**(** x(16) &  _(_ x(17) | x(18) | x(19) _)_ **)**

The rule as generated by the current function is
**(** x(16) & _(_ x(17) | x(18) | x(19) _)_

The outermost paren is missing.
For other examples, see mismatch between grRules and rules in
Acinetobacter_calcoaceticus_PHEA_2.mat, rxn 887
Recon2.0model.mat, rxns 2089, 2240, 2265, 2543, 2750, 2940, 3133
Recon2.v04.mat, rxns  2240, 2543, 2750,  2940, 3133
iAF1260.mat, rxns 377, 1065, 1103, 1831, 1909, 2126, 2127, 2128, 2129, 2130, 2131, 2132, 2133
iJO1366.mat, rxns 750, 1174, 1215, 1978, 2067, 2300, 2301, 2302, 2303, 2304, 2305, 2306, 2307

There are additional bugs in the models
Abiotrophia_defectiva_ATCC_49176.mat
Abiotrophia_defectiva_ATCC_49176.mat
Acidaminococcus_fermentans_DSM_20731.mat

But I will open a bug request.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)