### PR TITLE
adding test for new option of computeFluxSplits

### DIFF
--- a/src/dataIntegration/metabotools/computeFluxSplits.m
+++ b/src/dataIntegration/metabotools/computeFluxSplits.m
@@ -4,7 +4,7 @@ function [P,C,vP,vC,s] = computeFluxSplits(model,mets,V, coeffSign)
 %
 % USAGE:
 %
-%    [P, C, vP, vC] = computeFluxSplits(model, mets, V);
+%    [P, C, vP, vC, s] = computeFluxSplits(model, mets, V, 0);
 %
 % INPUTS:
 %    model:     a COBRA model structure with required fields
@@ -25,7 +25,7 @@ function [P,C,vP,vC,s] = computeFluxSplits(model,mets,V, coeffSign)
 %    vC:    an `n` x `k` matrix of net consuming fluxes
 %    s:     net stoichiometry of reactions containing metabolites 
 %
-% Example: [P,C,vP,vC] = computeFluxSplits(model,mets,V,1);
+% Example: [P,C,vP,vC,s] = computeFluxSplits(model,mets,V,1);
 %
 % .. Author: - Hulda S. Haraldsdottir, December 2, 2016
 %            - Modified by Diana El Assal 22/7/2017

--- a/src/dataIntegration/metabotools/computeFluxSplits.m
+++ b/src/dataIntegration/metabotools/computeFluxSplits.m
@@ -1,4 +1,4 @@
-function [P,C,vP,vC] = computeFluxSplits(model,mets,V)
+function [P,C,vP,vC,s] = computeFluxSplits(model,mets,V, coeffSign)
 % Compute relative contributions of fluxes (`V`) to the net production (`P`)
 % and consumption (`C`) of a set of metabolites (`mets`)
 %
@@ -14,18 +14,34 @@ function [P,C,vP,vC] = computeFluxSplits(model,mets,V)
 %    mets:      a list of metabolite identifiers from model.mets
 %    V:         an `n` x `k` matrix of `k` flux distributions
 %
+% OPTIONAL INPUT:
+%    coeffSign: only use the sign of the stoichiometric coefficient
+%               (i.e. +1 or -1, Default = false)
+%
 % OUTPUTS:
 %    P:     an `n` x `k` matrix of relative contributions to the production of mets
 %    C:     an `n` x `k` matrix of relative contributions to the consumption of mets
 %    vP:    an `n` x `k` matrix of net producing fluxes
 %    vC:    an `n` x `k` matrix of net consuming fluxes
+%    s:     net stoichiometry of reactions containing metabolites 
+%
+% Example: [P,C,vP,vC] = computeFluxSplits(model,mets,V,1);
 %
 % .. Author: - Hulda S. Haraldsdottir, December 2, 2016
+%            - Modified by Diana El Assal 22/7/2017
 
-s = sum([model.S(ismember(model.mets,mets),:); sparse(1,size(model.S,2))],1)'; % net stoichiometry. Zero if model.mets does not contain mets.
+if nargin <4;
+    coeffSign = false; %default
+end
+
+if coeffSign
+    s = sign(sum([model.S(ismember(model.mets,mets),:); sparse(1,size(model.S,2))],1))';
+else
+    s = sum([model.S(ismember(model.mets,mets),:); sparse(1,size(model.S,2))],1)'; % net stoichiometry. Zero if model.mets does not contain mets.
+end
+
 W = diag(s)*V; % stoichiometrically weighted flux
 vP = max(W,0); % net production
 vC = -min(W,0); % net consumption
 P = vP*diag(1./sum(vP)); % relative production
 C = vC*diag(1./sum(vC)); % relative consumption
-

--- a/test/verifiedTests/analysis/testComputeFluxSplits/testcomputeFluxSplits.m
+++ b/test/verifiedTests/analysis/testComputeFluxSplits/testcomputeFluxSplits.m
@@ -1,0 +1,72 @@
+% The COBRAToolbox: testcomputeFluxSplits.m
+%
+% Purpose:
+%     - tests the basic functionality of computeFluxSplits
+%       Tests 1 optional input with 3 possibilities: coeffSign=[] or 0 or 1
+%       returns 1 if all tests were completed succesfully, 0 if not
+%
+% Authors:
+%     - Original file: Diana El Assal 03/08/2017
+%
+
+% % save the current path
+currentDir = pwd;
+
+% % initialize the test
+fileDir = fileparts(which('testComputeFluxSplits'));
+cd(fileDir);
+global CBTDIR
+
+% define the solver packages to be used to run this test
+solverPkgs = {'gurobi6', 'tomlab_cplex', 'glpk'};
+
+% load the model 
+load([CBTDIR filesep 'test' filesep 'models' filesep 'Recon2.0model.mat'])
+model = Recon2model;
+
+% define the metabolites of interest
+mets = {'atp[c]','atp[m]', 'atp[e]'};
+
+% obtain a flux vector using e.g. FBA or uniform sampling
+model = changeObjective(model, 'DM_atp_c_');
+FBAsolution = optimizeCbModel(model, 'max');
+V = FBAsolution.x;
+
+for k = 1:length(solverPkgs);
+    
+    % change the COBRA solver (LP)
+    solverOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
+    
+    if solverOK == 1
+        fprintf('   Testing compute flux splits using %s ... ', solverPkgs{k});
+        
+        % check the function without optional input
+        fprintf('\n>> without optional input\n');
+        [P,C,vP,vC,s] = computeFluxSplits(model,mets,V,[]);        
+        assert(isequal(sum([model.S(ismember(model.mets,mets),:);...
+            sparse(1,size(model.S,2))],1)',s));
+        
+        % check the optional input of coeffSign = 0
+        fprintf('\n>> with coeffSign = false (stoichiometric coefficient)\n');
+        [P,C,vP,vC,s] = computeFluxSplits(model,mets,V,0);
+        assert(isequal(sum([model.S(ismember(model.mets,mets),:);...
+            sparse(1,size(model.S,2))],1)',s));
+        
+        % check the optional input of coeffSign = 1
+        fprintf('\n>> with coeffSign = true (sign of stoichiometric coefficient)\n');
+        [P,C,vP,vC,s] = computeFluxSplits(model,mets,V,1);
+        sInd = find(s);
+        for i = length(sInd);
+            j = sInd(i);
+            assert(s(j) == 1 || s(j) == -1);
+        end
+        
+        % output a success message
+        fprintf('Done.\n');
+    end
+end
+
+clear i j
+
+% change the directory
+cd(currentDir)


### PR DESCRIPTION
Previously, the flux vector V was being multiplied by the stoichiometry. However, we only want to multiply V by the sign of the stoichiometry, not by the stoichiometry itself.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
