### PR TITLE
Fix get model fields

### DIFF
--- a/src/reconstruction/fastGapFill/submitFastGapFill.m
+++ b/src/reconstruction/fastGapFill/submitFastGapFill.m
@@ -118,7 +118,7 @@ else
         model = readCbModel(modelFile);
         % If subSystems is empty, create a dummy subSystems for mergeTwoModels
         if ~exist('model.subSystems') || length(model.subSystems) ~= length(model.rxnNames)
-            model.subSystems = repmat({''},length(model.rxns));
+            model.subSystems = repmat({''},length(model.rxns),1);
         end
         if ~exist('model.genes')
             model.genes = repmat({'no_gene'},1);
@@ -127,7 +127,7 @@ else
             model.rxnGeneMat = zeros(length(model.rxns),1);
         end
         if ~exist('model.grRules')
-            model.grRules = repmat({''},length(model.rxns));
+            model.grRules = repmat({''},length(model.rxns),1);
         end
     end
 

--- a/src/reconstruction/refinement/removeFieldEntriesForType.m
+++ b/src/reconstruction/refinement/removeFieldEntriesForType.m
@@ -117,21 +117,40 @@ if strcmp(type,'genes')
 end
 
 
-fields = getModelFieldsForType(model, type, fieldSize);
-
-fields = setdiff(fields,excludeFields);
+[fields,dimensions] = getModelFieldsForType(model, type, fieldSize);
 
 for i = 1:numel(fields)
+    if any(ismember(fields{i},excludeFields))
+        continue
+    end
     %Lets assume, that we only have 2 dimensional fields.
-    if size(model.(fields{i}),1) == fieldSize
-        model.(fields{i}) = model.(fields{i})(~indicesToRemove,:);
-    end
-    if size(model.(fields{i}),2) == fieldSize
-        model.(fields{i}) = model.(fields{i})(:,~indicesToRemove);
-    end
+    model.(fields{i}) = removeIndicesInDimenion(model.(fields{i}),dimensions(i),~indicesToRemove);  
 end
 
 
+function removed = removeIndicesInDimenion(input,dimension,indices)
+% Remove the indices in a specified field in the given dimension
+% USAGE:
+%    removed = removeIndicesInDimenion(input, dimension, indices)
+%
+% INPUTS:
+%
+%    input:              The input matrix or array
+%    dimension:          The dimension from which to remove the indices
+%    indices:            The indices to remove
+%
+% OUTPUT:
+%
+%    removed:          The array/matrix with the given indices removed.
+%
+% .. Authors: 
+%                   - Thomas Pfau Sept 2017, adapted to merge all fields.
+
+inputDimensions = ndims(input);
+S.subs = repmat({':'},1,inputDimensions);
+S.subs{dimension} = indices;
+S.type = '()';
+removed = subsref(input,S);
 
         
 function model = normalizeRules(model)


### PR DESCRIPTION
Addressing #844.
Empty Fields are now checked against and updated correctly, also fields with  two matching dimensions are now correctly identified. 
The fix in fastGapFil is necessary as otherwise the test would fail since grRules would be created with the wrong dimensions or potentially completely removed and thus would lead to later steps failing. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
