### PR TITLE
Added the definition of Basic FBA fields 

### DIFF
--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -1,40 +1,40 @@
-Model Field	Xdim	Ydim	Evaluator	databaseid	qualifier	referenced Field	Default Value	DBPatterns	Property Description	Field Description
-S	mets	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	The stoichiometric matrix containing the model structure (for large models a sparse format is suggested)
-mets	mets	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['M' num2str(i)]		Column Cell Array of Strings	Identifiers of the metabolites
-b	mets	1	isnumeric(x)				0		Column Vector of Doubles	The coefficients of the constraints of the metabolites.
-csense	mets	1	ischar(x)				E		Column Vector of Chars	The sense of the constraints represented by b, each row is either E (equality), L(less than) or G(greater than)
-rxns	rxns	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['R' num2str(i)]		Column Cell Array of Strings	Identifiers for the reactions.
-lb	rxns	1	isnumeric(x)				-1000		Column Vector of Doubles	The lower bounds for fluxes through the reactions.
-ub	rxns	1	isnumeric(x)				1000		Column Vector of Doubles	The upper bounds for fluxes through the reactions.
-c	rxns	1	isnumeric(x)				0		Column Vector of Doubles	The objective coefficient of the reactions.
-osense	1	1	isnumeric(x)				-1		Double	The objective sense either -1 for maximisation or 1 for minimisation
-genes	genes	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['G' num2str(i)]		Column Cell Array of Strings	Identifiers of the genes in the model
-rules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	GPR rules in evaluateable format for each reaction ( e.g. "x(1) &#124; x(2) & x(3)", would indicate the first gene or both the second and third gene are necessary for the respective reaction to carry flux
-geneNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))		is	genes	model.genes{i}		Column Cell Array of Strings	Full names of each corresponding genes.
-compNames	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.comps{i}		Column Cell Array of Strings	Descriptions of the Compartments (compNames(m) is associated with comps(m))
-comps	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['C' num2str{i}]		Column Cell Array of Strings	Symbols for compartments, can include Tissue information
-proteinNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.proteins{i}		Column Cell Array of Strings	Full Name for each Protein
-proteins	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['COBRAProtein' num2str(i)]		Column Cell Array of Strings	Proteins associated with each gene.
-metCharges	mets	1	isnumeric(x)				NaN		Column Vector of Double	The charge of the respective metabolite (NaN if unknown)
-metFormulas	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Elemental formula for each metabolite.
-metSmiles	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Formula for each metabolite in SMILES Format
-metNames	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.mets{i}		Column Cell Array of Strings	Full name of each corresponding metabolite.
-metNotes	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Additional Notes for the respective metabolite.
-metHMDBID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	hmdb	is	mets	''	^HMDB\d{5}$	Column Cell Array of Strings	HMDB ID of the metabolite.
-metInChIString	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	inchi	is	mets	''	^InChI\=1S?\/[A-Za-z0-9]+(\+[0-9]+)?(\/[cnpqbtmsih][A-Za-z0-9\-\+\(\)\,\/]+)*$	Column Cell Array of Strings	Formula for each metabolite in the InCHI strings format.
-metKEGGID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.compound;kegg	is	mets	''	^C\d+$	Column Cell Array of Strings	KEGG ID of the metabolite.
-metChEBIID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	chebi;obo.chebi	is	mets	''	^CHEBI:\d+$	Column Cell Array of Strings	ChEBI ID of the metabolite.
-metPubChemID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubchem.compound	is	mets	''	^\d+$	Column Cell Array of Strings	PubChem ID of each metabolite
-metMetaNetXID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.chemical	is	mets	''	^MNXM\d+$	Column Cell Array of Strings	MetaNetX identifier of the metabolite
-description	NaN	NaN	ischar(x) || isstruct(x)				struct()		String or Struct	Name of a file the model is loaded from.
-modelVersion	NaN	NaN	isstruct(x)				struct()		Struct	Information on the model version
-geneEntrezID	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ncbigene	is;isEncodedBy	genes	''	^\d+$	Column Cell Array of Strings	Entrez IDs of genes
-grRules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	A string representation of the GPR rules defined in a readable format.
-rxnGeneMat	rxns	genes	issparse(x) || isnumeric(x) || islogical(x)				0		Sparse or Full Matrix of Double or Boolean	Matrix with rows corresponding to reactions and columns corresponding to genes.
-rxnConfidenceScores	rxns	1	isnumeric(x) || iscell(x) && isnumeric(cellfun(str2num,x))				0		Column Vector of double	Confidence scores for reaction presence (0-5, with 5 being the highest confidence)
-rxnNames	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.rxns{i}		Column Cell Array of Strings	Full name of each corresponding reaction.
-rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Description of each corresponding reaction.
-rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.
-rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.
-rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.
-subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	subSystem assignment for each reaction
+Model Field	Xdim	Ydim	Evaluator	databaseid	qualifier	referenced Field	Default Value	DBPatterns	Property Description	Field Description	FBABasicField
+S	mets	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	The stoichiometric matrix containing the model structure (for large models a sparse format is suggested)	'true(1)'
+mets	mets	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['M' num2str(i)]		Column Cell Array of Strings	Identifiers of the metabolites	'true(1)'
+b	mets	1	isnumeric(x)				0		Column Vector of Doubles	The coefficients of the constraints of the metabolites.	'true(1)'
+csense	mets	1	ischar(x)				E		Column Vector of Chars	The sense of the constraints represented by b, each row is either E (equality), L(less than) or G(greater than)	'true(1)'
+rxns	rxns	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['R' num2str(i)]		Column Cell Array of Strings	Identifiers for the reactions.	'true(1)'
+lb	rxns	1	isnumeric(x)				-1000		Column Vector of Doubles	The lower bounds for fluxes through the reactions.	'true(1)'
+ub	rxns	1	isnumeric(x)				1000		Column Vector of Doubles	The upper bounds for fluxes through the reactions.	'true(1)'
+c	rxns	1	isnumeric(x)				0		Column Vector of Doubles	The objective coefficient of the reactions.	'true(1)'
+osense	1	1	isnumeric(x)				-1		Double	The objective sense either -1 for maximisation or 1 for minimisation	'true(1)'
+genes	genes	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['G' num2str(i)]		Column Cell Array of Strings	Identifiers of the genes in the model	'true(1)'
+rules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	GPR rules in evaluateable format for each reaction ( e.g. "x(1) &#124; x(2) & x(3)", would indicate the first gene or both the second and third gene are necessary for the respective reaction to carry flux	'true(1)'
+geneNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))		is	genes	model.genes{i}		Column Cell Array of Strings	Full names of each corresponding genes.	'false(1)'
+compNames	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.comps{i}		Column Cell Array of Strings	Descriptions of the Compartments (compNames(m) is associated with comps(m))	'false(1)'
+comps	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['C' num2str{i}]		Column Cell Array of Strings	Symbols for compartments, can include Tissue information	'false(1)'
+proteinNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.proteins{i}		Column Cell Array of Strings	Full Name for each Protein	'false(1)'
+proteins	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['COBRAProtein' num2str(i)]		Column Cell Array of Strings	Proteins associated with each gene.	'false(1)'
+metCharges	mets	1	isnumeric(x)				NaN		Column Vector of Double	The charge of the respective metabolite (NaN if unknown)	'false(1)'
+metFormulas	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Elemental formula for each metabolite.	'false(1)'
+metSmiles	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Formula for each metabolite in SMILES Format	'false(1)'
+metNames	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.mets{i}		Column Cell Array of Strings	Full name of each corresponding metabolite.	'false(1)'
+metNotes	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Additional Notes for the respective metabolite.	'false(1)'
+metHMDBID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	hmdb	is	mets	''	^HMDB\d{5}$	Column Cell Array of Strings	HMDB ID of the metabolite.	'false(1)'
+metInChIString	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	inchi	is	mets	''	^InChI\=1S?\/[A-Za-z0-9]+(\+[0-9]+)?(\/[cnpqbtmsih][A-Za-z0-9\-\+\(\)\,\/]+)*$	Column Cell Array of Strings	Formula for each metabolite in the InCHI strings format.	'false(1)'
+metKEGGID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.compound;kegg	is	mets	''	^C\d+$	Column Cell Array of Strings	KEGG ID of the metabolite.	'false(1)'
+metChEBIID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	chebi;obo.chebi	is	mets	''	^CHEBI:\d+$	Column Cell Array of Strings	ChEBI ID of the metabolite.	'false(1)'
+metPubChemID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubchem.compound	is	mets	''	^\d+$	Column Cell Array of Strings	PubChem ID of each metabolite	'false(1)'
+metMetaNetXID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.chemical	is	mets	''	^MNXM\d+$	Column Cell Array of Strings	MetaNetX identifier of the metabolite	'false(1)'
+description	NaN	NaN	ischar(x) || isstruct(x)				struct()		String or Struct	Name of a file the model is loaded from.	'false(1)'
+modelVersion	NaN	NaN	isstruct(x)				struct()		Struct	Information on the model version	'false(1)'
+geneEntrezID	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ncbigene	is;isEncodedBy	genes	''	^\d+$	Column Cell Array of Strings	Entrez IDs of genes	'false(1)'
+grRules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	A string representation of the GPR rules defined in a readable format.	'false(1)'
+rxnGeneMat	rxns	genes	issparse(x) || isnumeric(x) || islogical(x)				0		Sparse or Full Matrix of Double or Boolean	Matrix with rows corresponding to reactions and columns corresponding to genes.	'false(1)'
+rxnConfidenceScores	rxns	1	isnumeric(x) || iscell(x) && isnumeric(cellfun(str2num,x))				0		Column Vector of double	Confidence scores for reaction presence (0-5, with 5 being the highest confidence)	'false(1)'
+rxnNames	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.rxns{i}		Column Cell Array of Strings	Full name of each corresponding reaction.	'false(1)'
+rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Description of each corresponding reaction.	'false(1)'
+rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.	'false(1)'
+rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.	'false(1)'
+rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'
+subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	subSystem assignment for each reaction	'false(1)'

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -37,7 +37,7 @@ function model = convertOldStyleModel(model, printLevel)
 %    merged into new fields, with the data of new fields taking precedence
 %    (i.e. if not data is present in the new field at any position, the old
 %    field data replaces it, otherwise the new field data is kept.
-%    Furthermore, the following fields are created:
+%    Furthermore, fields deemed to be required for Flux Balance analysis are generated if not present:
 %    osense: Objective Sense.
 %            By default this field is initialized as -1 (maximisation)
 %            If the osenseStr field is present, that field will be
@@ -47,6 +47,7 @@ function model = convertOldStyleModel(model, printLevel)
 %            stands for lower than ('L') or greater than ('G') or equality constraints ('E'). It
 %            is initialized as a char vector of 'E' with the same size as
 %            model.mets.
+%    genes:  A Field for genes present in the model.
 %    rules:  The rules field is a logical representation of the GPR rules,
 %            and used in multiple functions. If the grRules field is
 %            present, this field will be initialized according to grRules,
@@ -142,6 +143,10 @@ if ~isfield(model,'csense')
     model.csense = repmat('E',numel(model.mets),1);
 else
     model.csense = columnVector(model.csense);
+end
+
+if ~isfield(model, 'genes')
+    model.genes = cell(0,1);
 end
 
 if ~isfield(model, 'rules') 

--- a/src/base/io/utilities/getDefinedFieldProperties.m
+++ b/src/base/io/utilities/getDefinedFieldProperties.m
@@ -143,8 +143,8 @@ if isempty(CBT_PROG_FIELD_PROPS)
      end
     %Get the indices for database, qualifier and reference.
     relrows = cellfun(@(x) ischar(x) && ~isempty(x),raw.Model_Field);
-    relarray = [raw.Model_Field(relrows),raw.Xdim(relrows),raw.Ydim(relrows),raw.Evaluator(relrows),raw.Default_Value(relrows)];
-    dbInfo = cell(0,5);
+    relarray = [raw.Model_Field(relrows),raw.Xdim(relrows),raw.Ydim(relrows),raw.Evaluator(relrows),raw.Default_Value(relrows),raw.FBABasicField(relrows)];
+    progInfo = cell(0,6);
     for i = 1:size(relarray)
         xval = relarray{i,2};
         if ~isnumeric(xval)
@@ -166,9 +166,10 @@ if isempty(CBT_PROG_FIELD_PROPS)
                 default = str2num(default);
             end
         end
-         dbInfo(i,:) = { relarray{i,1},xval,yval,relarray{i,4}, default};
+        fbaReq = eval(eval(relarray{i,6}));        
+        progInfo(i,:) = { relarray{i,1},xval,yval,relarray{i,4}, default,fbaReq};
     end
-    CBT_PROG_FIELD_PROPS = dbInfo;
+    CBT_PROG_FIELD_PROPS = progInfo;
 end
 fields = CBT_PROG_FIELD_PROPS;
 

--- a/src/reconstruction/modelGeneration/modelVerification/verifyModel.m
+++ b/src/reconstruction/modelGeneration/modelVerification/verifyModel.m
@@ -61,7 +61,10 @@ function results = verifyModel(model, varargin)
 % .. Authors:
 %       - Thomas Pfau, May 2017
 
-fluxConsistencyFields = {'S','b','csense','lb','ub','c','osense','rxns','mets','genes','rules'};
+
+optionalFields = getDefinedFieldProperties();
+
+fluxConsistencyFields = optionalFields(cellfun(@(x) x, optionalFields(:,6)),1);
 
 parser = inputParser();
 parser.addRequired('model',@isstruct);
@@ -88,7 +91,7 @@ stoichiometricConsistency = parser.Results.stoichiometricConsistency;
 checkDBs = parser.Results.checkDatabaseIDs;
 silentCheck = parser.Results.silentCheck;
 
-[optionalFields] = getDefinedFieldProperties();
+
 requiredFields = optionalFields(ismember(optionalFields(:,1), requiredFields),:);
 optionalFields = optionalFields(~ismember(optionalFields(:,1), requiredFields(:,1)),:);
 


### PR DESCRIPTION
Added the definitions of basic FBA fields to the Field Definition file and updated convertCobraModel to add those fields to models that lack them. This allows reading most basic models from mat files using readCbModel.

*Please include a short description of enhancement here*

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
