### PR TITLE
Fix generate rules

### DIFF
--- a/src/base/io/writeMinosProblem.m
+++ b/src/base/io/writeMinosProblem.m
@@ -125,7 +125,7 @@ xu = LPproblem.ub;
 %              so that SQOPT will treat the problem as an LP, not a QP.
 %              This is ok for MINOS also.
 
-A = [A osense * sparse(c)']; % Luckily we only have to do it once
+A = [A ; osense * sparse(c)']; % Luckily we only have to do it once
 b = [b; 0];
 
 [m, n] = size(A);

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -28,9 +28,9 @@ for i = 1:length(grRules)
         tmp = regexprep(tmp, ' * (?i)(and) *', ' & ');
         tmp = regexprep(tmp, ' * (?i)(or) *', ' | ');
         rules = regexprep(tmp, '([^\(\)\|\&\ ]+)', '${convertGenes($0)}');
-        model2.rules{i} = rules;
+        model2.rules{i,1} = rules;
     else
-        model2.rules{i} = model.grRules{i};
+        model2.rules{i,1} = model.grRules{i};
     end
 end
 end

--- a/test/verifiedTests/base/testIO/testWriteMinosProblem.m
+++ b/test/verifiedTests/base/testIO/testWriteMinosProblem.m
@@ -18,7 +18,7 @@ LPproblem.A = [1 1 0; -1 0 -1; 0 -1 1];             %LHS matrix
 LPproblem.b = [5; -10; 7];                          %RHS vector
 LPproblem.lb = [0; -1; 0];                          %Lower bound vector
 LPproblem.ub = [4; 1; inf];                         %Upper bound vector
-LPproblem.c = [1 4 9];                              %Objective coeff vector
+LPproblem.c = [1; 4; 9];                              %Objective coeff vector
 LPproblem.csense = ['L'; 'L'; 'E'];                 %Constraint sense
 LPproblem.osense = 1;                               %Minimize
 
@@ -33,11 +33,11 @@ LPproblem2.S = ['L'; 'L'; 'E'];
 % test for the common part, the rest differs by precision
 testFile = fopen('FBA.txt', 'r');
 testVar = fscanf(testFile, '%c');
-testVar = testVar(4:158);
+testVar = testVar(4:149);
 fclose(testFile);
 testFile_2 = fopen('FBA2.txt', 'r');
 testVar_2 = fscanf(testFile_2, '%c');
-testVar_2 = testVar_2(5:159);
+testVar_2 = testVar_2(5:150);
 fclose(testFile_2);
 
 assert(isequal(testVar, testVar_2));


### PR DESCRIPTION
Generate Rules previously built the rules vector as a row vector. Fixed to column vector.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
