### PR TITLE
Generate rules field as column Vector

### DIFF
--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -28,9 +28,9 @@ for i = 1:length(grRules)
         tmp = regexprep(tmp, ' * (?i)(and) *', ' & ');
         tmp = regexprep(tmp, ' * (?i)(or) *', ' | ');
         rules = regexprep(tmp, '([^\(\)\|\&\ ]+)', '${convertGenes($0)}');
-        model2.rules{i} = rules;
+        model2.rules{i,1} = rules;
     else
-        model2.rules{i} = model.grRules{i};
+        model2.rules{i,1} = model.grRules{i};
     end
 end
 end


### PR DESCRIPTION
Corrected generateRules to create Rules as a column vector

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
