### PR TITLE
CBT defaults are more stringent than solvers defaults

### DIFF
--- a/src/base/solvers/getCobraSolverParams.m
+++ b/src/base/solvers/getCobraSolverParams.m
@@ -49,8 +49,8 @@ end
 %% Default Values
 valDef.minNorm = 0;
 %valDef.objTol = 1e-6; %cannot find where this is being used -RF
-valDef.optTol = 1e-9;
-valDef.feasTol = 1e-9;
+valDef.optTol = 1e-6;
+valDef.feasTol = 1e-6;
 valDef.printLevel = 0;
 valDef.primalOnly = 0;
 valDef.timeLimit = 1e36; %this should indicate No time limit per default


### PR DESCRIPTION
*Please include a short description of enhancement here*
-feaopt and tolopt are set to 1e-9 which considerably slows solving of medium to large models.
-cplex defaults are set to 1e-6 (EPOPT and EPRHS)
https://tomopt.com/docs/cplexug/tomlab_cplex014.php

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- []x Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
