### PR TITLE
Field Merging and change to updateGenes

### DIFF
--- a/src/base/io/utilities/buildRxnGeneMat.m
+++ b/src/base/io/utilities/buildRxnGeneMat.m
@@ -15,17 +15,18 @@ function model = buildRxnGeneMat(model)
 % .. Authors: - written by ?
 %             Diana El Assal 30/6/2017 - updates
 
-% First, update the genes in the model
-if ~isempty(model.grRules)
-    model = updateGenes(model);
+
+if ~isfield(model,'rules')
+    %If rules does not exist, we need to create it. This will either happen
+    %by generating it from grRules or initializing it as empty.
+    if isfield(model,'grRules')
+        model = generateRules(model);
+    else
+        %Empty rules field.
+        model.rules = repmat({''},size(model.rxns,1),1);
+    end    
 end
 
-%Then, update the gene rules of the model
-if ~isempty(model.grRules)
-    model = generateRules(model);
-end
-
-%Finally, update the rxnGeneMat
 model.rxnGeneMat = false(numel(model.rxns), numel(model.genes));
 if isfield(model,'rules')
     for i = 1:numel(model.rxns)

--- a/src/reconstruction/refinement/mergeModelFieldPositions.m
+++ b/src/reconstruction/refinement/mergeModelFieldPositions.m
@@ -87,24 +87,24 @@ for i = 1:numel(fields)
     %present
     if strcmp(type,'genes')
          if isfield(modelNew,'rules')
-            for i = 1:numel(posToMerge)                
+            for j = 1:numel(posToMerge)                
                 %Replace by new position.
-                modelNew.rules = strrep(modelNew.rules,['x(' num2str(posToMerge(i)) ')'],['x(' num2str(posToKeep) ')']);                                
+                modelNew.rules = strrep(modelNew.rules,['x(' num2str(posToMerge(j)) ')'],['x(' num2str(posToKeep) ')']);                                
             end
          end
-         %Update the grRules field.
-        if isfield(modelNew, 'grRules')
-            for i = 1:numel(positions)                
+         %Update the grRules field (if necessary).         
+        if isfield(modelNew, 'grRules') && numel(unique(origNames)) > 1
+            for j = 1:numel(positions)                
                 %Replace by new name.
                 %First, replace all occurences, which only contain the
                 %name.                
-                modelNew.rules = regexprep(modelNew.grRules,['^' regexptranslate(origNames{i}) '$'],modelNew.genes(posToKeep));            
+                modelNew.grRules = regexprep(modelNew.grRules,['^' regexptranslate('escape',origNames{j}) '$'],modelNew.genes{posToKeep});            
                 %The replace all occurences which are at the beginning or
                 %end of a formula.
-                modelNew.rules = regexprep(modelNew.grRules,['^' regexptranslate(origNames{i}) '([\) ]+)'],[ modelNew.genes(posToKeep) '$1']);                                
-                modelNew.rules = regexprep(modelNew.grRules,['([\( ])+' regexptranslate(origNames{i}) '$'],['$1' modelNew.genes(posToKeep) ]);                                
+                modelNew.grRules = regexprep(modelNew.grRules,['^' regexptranslate('escape',origNames{j}) '([\) ]+)'],[ modelNew.genes{posToKeep} '$1']);                                
+                modelNew.grRules = regexprep(modelNew.grRules,['([\( ]+)' regexptranslate('escape',origNames{j}) '$'],['$1' modelNew.genes{posToKeep} ]);                                
                 %finally replace all  in the middle.
-                modelNew.rules = regexprep(modelNew.grRules,['([\( ])+' regexptranslate(origNames{i}) '([\) ]+)'],['$1' modelNew.genes(posToKeep) '$2']);                                
+                modelNew.grRules = regexprep(modelNew.grRules,['([\( ]+)' regexptranslate('escape',origNames{j}) '([\) ]+)'],['$1' modelNew.genes{posToKeep} '$2']);                                
             end            
         end
     end

--- a/src/reconstruction/refinement/mergeModelFieldPositions.m
+++ b/src/reconstruction/refinement/mergeModelFieldPositions.m
@@ -1,0 +1,171 @@
+function modelNew = mergeModelFieldPositions(model,type,positions)
+% USAGE:
+%    [modelNew] = mergeModelFieldPositions(model,type,positions)
+%
+% INPUTS:
+%    model:           The model with the fields to merge
+%    type:            the field type to merge ( rxns, mets, comps or genes)
+%    positions:       The positions in the given field type to merge.
+%
+%
+% OUTPUT:
+%
+%    modelNew:         merged model with the positions merged into one.
+%                      Unique entries in Related String fields will be
+%                      concatenated with ';' matrices will be summed up.
+%
+% .. Authors:
+%                   - Thomas Pfau Sept 2017
+
+
+modelNew = model;
+if numel(positions) <= 1
+    %If there is less than two positions to merge, we don't do anything.
+    return;
+end
+
+posToKeep = positions(1);
+posToMerge = positions(2:end);
+
+%Store the original names.
+origNames = modelNew.(type)(positions);
+
+%get The fields and associated dimensions
+[fields,dimensions] = getModelFieldsForType(modelNew, type, numel(model.(type)));
+
+
+for i = 1:numel(fields)
+    %Lets assume, that we only have 2 dimensional fields.    
+    if isnumeric(modelNew.(fields{i})) || islogical(modelNew.(fields{i}))
+        modelNew.(fields{i}) = setSlice(modelNew.(fields{i}),posToKeep,dimensions(i),sum(getSlice(modelNew.(fields{i}),positions,dimensions(i)),dimensions(i)));        
+    end
+    % if its cell arrays, concatenate unique data, we will assume here, that
+    % all cell arrays are string arrays and that there are no
+    % multi-dimensional 
+    %There are two options for cell arrays currently. Either its all char
+    %arrays, or its all cell arrays.
+    if iscell(modelNew.(fields{i}))
+        data = getSlice(modelNew.(fields{i}),positions,dimensions(i));
+        if ischar([data{:}])
+            %We have cell arrays with individual char arrays, So we will
+            %take the concatenation of the unique values.
+            %We have two exceptions for this: grRules and rules. All parts
+            %of the old rules need to be present together.
+            newData = {strjoin(unique(data),';')};
+            if strcmp(fields{i}, 'rules')
+                clauses = unique(data);
+                clauses = setdiff(clauses,{''}); % remove empty clauses
+                if ~isempty(clauses)
+                    newData = {strjoin( strcat('(',unique(data),')'),' & ')};
+                else
+                    newData = {''};
+                end
+                    
+            end
+            if strcmp(fields{i}, 'grRules')
+                clauses = unique(data);
+                clauses = setdiff(clauses,{''}); % remove empty clauses
+                if ~isempty(clauses)
+                    newData = {strjoin( strcat('(',unique(data),')'),' and ')};
+                else
+                    newData = {''};
+                end
+            end
+            modelNew.(fields{i}) = setSlice(modelNew.(fields{i}),posToKeep,dimensions(i),newData);     
+        else
+            modelNew.(fields{i}) = setSlice(modelNew.(fields{i}),posToKeep,dimensions(i),unique([data{:}]));     
+        end
+    end
+    if ischar(modelNew.(fields{i}))
+        %This is a problem. as this is VERY dependent on the type of char
+        %we have. We will simple not handle it for now... (as it is
+        %currently only present in csense and whoever is doing it should
+        %take care not to screw around when merging mets....
+    end
+    %now, having done this, we need to check whether we modified genes. If
+    %so, we have to update the rules vector and the grRules vector, if
+    %present
+    if strcmp(type,'genes')
+         if isfield(modelNew,'rules')
+            for i = 1:numel(posToMerge)                
+                %Replace by new position.
+                modelNew.rules = strrep(modelNew.rules,['x(' num2str(posToMerge(i)) ')'],['x(' num2str(posToKeep) ')']);                                
+            end
+         end
+         %Update the grRules field.
+        if isfield(modelNew, 'grRules')
+            for i = 1:numel(positions)                
+                %Replace by new name.
+                %First, replace all occurences, which only contain the
+                %name.                
+                modelNew.rules = regexprep(modelNew.grRules,['^' regexptranslate(origNames{i}) '$'],modelNew.genes(posToKeep));            
+                %The replace all occurences which are at the beginning or
+                %end of a formula.
+                modelNew.rules = regexprep(modelNew.grRules,['^' regexptranslate(origNames{i}) '([\) ]+)'],[ modelNew.genes(posToKeep) '$1']);                                
+                modelNew.rules = regexprep(modelNew.grRules,['([\( ])+' regexptranslate(origNames{i}) '$'],['$1' modelNew.genes(posToKeep) ]);                                
+                %finally replace all  in the middle.
+                modelNew.rules = regexprep(modelNew.grRules,['([\( ])+' regexptranslate(origNames{i}) '([\) ]+)'],['$1' modelNew.genes(posToKeep) '$2']);                                
+            end            
+        end
+    end
+   
+end
+%After merging remove the merged fields.
+
+modelNew = removeFieldEntriesForType(modelNew,posToMerge,type,numel(modelNew.(type)));  
+
+end
+
+
+
+
+function out = getSlice(A,idx,dim)
+%Get a slice from a given matrix/vector 
+% USAGE:
+%    out = getSlice(A,idx,dim)
+%
+% INPUTS:
+%    A:               The matrix/vector to obtain a slice from
+%    idx:             the indices in the given dimension to extract
+%    dim:             The dimension to obtain the given indices from.
+%
+%
+% OUTPUT:
+%
+%    out:             A slice from the matix/vector with the given indices
+%
+% Note:  
+%     Based on https://stackoverflow.com/questions/22537326/on-shape-agnostic-slicing-of-ndarrays
+%
+% .. Authors:
+%                   - Thomas Pfau Sept 2017
+
+slice = repmat({':'},1, ndims(A));
+slice{dim} = idx;
+out = A(slice{:});
+end
+
+function A = setSlice(A,idx,dim,B)
+%Set a slice from a given matrix/vector 
+% USAGE:
+%    A = setSlice(A,idx,dim,B)
+%
+% INPUTS:
+%    A:               The matrix/vector to obtain a slice from
+%    idx:             the indices in the given dimension to extract
+%    dim:             The dimension to obtain the given indices from.
+%    B:               The values to set at the given position
+%
+% OUTPUT:
+%    A:             A slice from the matix/vector with the given indices
+%
+% Note:  
+%     Based on https://stackoverflow.com/questions/22537326/on-shape-agnostic-slicing-of-ndarrays
+%
+% .. Authors:
+%                   - Thomas Pfau Sept 2017
+
+slice = repmat({':'},1, ndims(A));
+slice{dim} = idx;
+A(slice{:}) = B;
+end

--- a/src/reconstruction/refinement/removeUnusedGenes.m
+++ b/src/reconstruction/refinement/removeUnusedGenes.m
@@ -14,15 +14,26 @@ function modelNew = removeUnusedGenes(model)
 %                  content present in the model
 %
 % .. Authors:
-%           - Sjoerd Opdam - 6/24/2014    
+%           - Sjoerd Opdam - 6/24/2014
 %           - Thomas Pfau - June 2016 - updated to catch all fields.
-	genes=unique(model.genes);
-    if length(model.genes) ~= length(genes)
-        disp('Some genes have identical IDs')
-    end
-    %update the rxnGeneMatField;    
+
+if ~isfield(model,'genes')
+    %This should not happen, but well, we can generate the genes field from
+    %the grRules field, if that exists.
+    model = updateGenes(model);
+end
+
+if ~isfield(model,'rules')
+    model = generateRules(model);
+end
+
+if ~isfield(model,'rxnGeneMat')
+    %If it doesn't exist, we generate the rxnGeneMat field.
     model = buildRxnGeneMat(model);
-    genesToRemove = sum(model.rxnGeneMat) == 0;
-    model = removeFieldEntriesForType(model,genesToRemove,'genes',numel(model.genes));
-    modelNew=model;    
+end
+
+genesToRemove = sum(model.rxnGeneMat) == 0;
+model = removeFieldEntriesForType(model,genesToRemove,'genes',numel(model.genes));
+modelNew=model;
+
 end

--- a/src/reconstruction/refinement/removeUnusedGenes.m
+++ b/src/reconstruction/refinement/removeUnusedGenes.m
@@ -33,11 +33,11 @@ if ~isfield(model,'genes')
 end
 
 
-if ~isfield(model,'rules')
+if ~isfield(modelNew,'rules')
     modelNew = generateRules(modelNew);
 end
 
-if ~isfield(model,'rxnGeneMat')
+if ~isfield(modelNew,'rxnGeneMat')
     %If it doesn't exist, we generate the rxnGeneMat field.
     modelNew = buildRxnGeneMat(modelNew);
 end

--- a/src/reconstruction/refinement/removeUnusedGenes.m
+++ b/src/reconstruction/refinement/removeUnusedGenes.m
@@ -17,23 +17,33 @@ function modelNew = removeUnusedGenes(model)
 %           - Sjoerd Opdam - 6/24/2014
 %           - Thomas Pfau - June 2016 - updated to catch all fields.
 
+modelNew=model;
 if ~isfield(model,'genes')
-    %This should not happen, but well, we can generate the genes field from
-    %the grRules field, if that exists.
-    model = updateGenes(model);
+    %This is VERY odd and should not happen, but lets see    
+    grRules = model.grRules;
+    grRules = grRules(~cellfun(@isempty,grRules));
+    genes = regexprep(grRules, {'and', 'AND', 'or', 'OR', '(', ')'}, '');
+    genes = splitString(genes, ' ');
+    genes = [genes{:}]';
+    genes = unique(genes(cellfun('isclass', genes, 'char')));    
+    %Now, we created the genes field, so lets build the rules field as
+    %well.
+    modelNew.genes = genes(~cellfun('isempty', genes));  % Not sure this is necessary anymore, but it won't hurt.
+    modelNew = generateRules(modelNew);   
 end
 
+
 if ~isfield(model,'rules')
-    model = generateRules(model);
+    modelNew = generateRules(modelNew);
 end
 
 if ~isfield(model,'rxnGeneMat')
     %If it doesn't exist, we generate the rxnGeneMat field.
-    model = buildRxnGeneMat(model);
+    modelNew = buildRxnGeneMat(modelNew);
 end
 
-genesToRemove = sum(model.rxnGeneMat) == 0;
-model = removeFieldEntriesForType(model,genesToRemove,'genes',numel(model.genes));
-modelNew=model;
+genesToRemove = sum(modelNew.rxnGeneMat) == 0;
+modelNew = removeFieldEntriesForType(modelNew,genesToRemove,'genes',numel(modelNew.genes));
+
 
 end

--- a/src/reconstruction/refinement/updateGenes.m
+++ b/src/reconstruction/refinement/updateGenes.m
@@ -1,5 +1,6 @@
 function [modelNew] = updateGenes(model)
-% Updates model.genes in a new model, based on model.grRules.
+% Update the model genes field (if it does not exist, generate it from the
+% grRules field, if it exists, remove Unused genes and  remove duplicate genes.
 %
 % USAGE:
 %
@@ -18,13 +19,48 @@ function [modelNew] = updateGenes(model)
 % .. Authors:
 %       - written by Diana El Assal 30/06/2017
 %       - fixed by Uri David Akavia 16/07/2017
+%       - Only recreate model.genes if it does not exist by Thomas Pfau Sept 2017
 
-grRules = model.grRules;
 modelNew = model;
 
-genes = regexprep(grRules, {'and', 'AND', 'or', 'OR', '(', ')'}, '');
-genes = splitString(genes, ' ');
-genes = [genes{:}]';
+if ~isfield(model.genes) %This is VERY odd and should not happen, but lets see    
+    grRules = model.grRules;
+    grRules = grRules(~cellfun(@isempty,grRules));
+    genes = regexprep(grRules, {'and', 'AND', 'or', 'OR', '(', ')'}, '');
+    genes = splitString(genes, ' ');
+    genes = [genes{:}]';
+    genes = unique(genes(cellfun('isclass', genes, 'char')));    
+    %Now, we created the genes field, so lets build the rules field as
+    %well.
+    modelNew.genes = genes(~cellfun('isempty', genes));  % Not sure this is necessary anymore, but it won't hurt.
+    modelNew = generateRules(modelNew);   
+end
 
-genes = unique(genes(cellfun('isclass', genes, 'char')));
-modelNew.genes = genes(~cellfun('isempty', genes));  % Not sure this is necessary anymore, but it won't hurt.
+%Now, remove unused genes.
+modelNew = removeUnusedGenes(modelNew);
+
+%Finally, check for duplicate genes. This is actually tricky. because we
+%might need to merge stuff.
+[genes,ia,ic] = unique(model.genes);
+
+if numel(genes) < numel(model.genes)
+    checkedgene = 1;
+    while numel(genes) < numel(model.genes)
+        %We only check from where we know that we are done (avoiding double
+        %checks).
+        for checkedgene = checkedgene:numel(genes)
+            dupidx = find(ic == checkedgene);
+            if numel(dupidx) > 1
+                model = mergeModelFieldPositions(model,'genes',dupidx);
+                [genes,ia,ic] = unique(model.genes);
+                break
+            end
+        end
+    end
+end
+
+%And now, reorder the gene field alphabetically (again updating all
+%dependent fields).
+[~,sortedOrder] = sort(modelNew.genes);
+modelNew = updateFieldOrderForType(model,'gene',sortedOrder);
+

--- a/src/reconstruction/refinement/updateGenes.m
+++ b/src/reconstruction/refinement/updateGenes.m
@@ -23,35 +23,22 @@ function [modelNew] = updateGenes(model)
 
 modelNew = model;
 
-if ~isfield(model.genes) %This is VERY odd and should not happen, but lets see    
-    grRules = model.grRules;
-    grRules = grRules(~cellfun(@isempty,grRules));
-    genes = regexprep(grRules, {'and', 'AND', 'or', 'OR', '(', ')'}, '');
-    genes = splitString(genes, ' ');
-    genes = [genes{:}]';
-    genes = unique(genes(cellfun('isclass', genes, 'char')));    
-    %Now, we created the genes field, so lets build the rules field as
-    %well.
-    modelNew.genes = genes(~cellfun('isempty', genes));  % Not sure this is necessary anymore, but it won't hurt.
-    modelNew = generateRules(modelNew);   
-end
-
 %Now, remove unused genes.
 modelNew = removeUnusedGenes(modelNew);
 
 %Finally, check for duplicate genes. This is actually tricky. because we
 %might need to merge stuff.
-[genes,ia,ic] = unique(model.genes);
+[genes,ia,ic] = unique(modelNew.genes);
 
-if numel(genes) < numel(model.genes)
+if numel(genes) < numel(modelNew.genes)
     checkedgene = 1;
-    while numel(genes) < numel(model.genes)
+    while numel(genes) < numel(modelNew.genes)
         %We only check from where we know that we are done (avoiding double
         %checks).
         for checkedgene = checkedgene:numel(genes)
             dupidx = find(ic == checkedgene);
             if numel(dupidx) > 1
-                model = mergeModelFieldPositions(model,'genes',dupidx);
+                modelNew = mergeModelFieldPositions(modelNew,'genes',dupidx);
                 [genes,ia,ic] = unique(model.genes);
                 break
             end
@@ -62,5 +49,5 @@ end
 %And now, reorder the gene field alphabetically (again updating all
 %dependent fields).
 [~,sortedOrder] = sort(modelNew.genes);
-modelNew = updateFieldOrderForType(model,'gene',sortedOrder);
+modelNew = updateFieldOrderForType(modelNew,'genes',sortedOrder);
 

--- a/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
+++ b/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
@@ -1,0 +1,86 @@
+% The COBRAToolbox: testMergeModelFieldPositions
+%
+% Purpose:
+%     - Test merging of model fields with the function
+%     mergeModelFieldPositions
+%
+% Author:
+%     - Original file: Thomas Pfau
+
+global CBTDIR
+
+% save the current path
+currentDir = pwd;
+
+% initialize the test
+fileDir = fileparts(which('testMergeModelFieldPositions.m'));
+cd(fileDir);
+
+% load reference data and model
+model = readCbModel([CBTDIR, filesep, 'test' filesep 'models' filesep 'ecoli_core_model.mat']);
+
+%Merge two reactions first two reactions which have a non empty rules
+%field. 
+
+rxnspos = [3,4,8];
+modelMerged = mergeModelFieldPositions(model,'rxns',rxnspos);
+%The new reaction is the merged reaction names, and the old ones get
+%removed.
+assert(~any(ismember(model.rxns(rxnspos),modelMerged.rxns)));
+%get the position of the merged rxn
+newreacpos = ismember(modelMerged.rxns,strjoin(model.rxns(rxnspos),';'));
+assert(any(newreacpos));
+
+%check that the new reac pos grRules and rules field is a merge of the two
+%old ones. (this should be the old ones concatenated with parenthesis and and or &)
+%The order could be any, so we need to check all and if any fits, we are fine.
+rulesperms = perms(rxnspos);
+newRules = cell(size(rulesperms,1),1);
+newgrRules = cell(size(rulesperms,1),1);
+for i = 1:size(rulesperms,1)
+    newRules{i} = ['(' strjoin(model.rules(rulesperms(i,:)), ') & (') , ')'];
+    newgrRules{i} = ['(' strjoin(model.grRules(rulesperms(i,:)), ') and (') , ')'];
+end
+assert(any(ismember(newRules,modelMerged.rules{newreacpos})));
+assert(any(ismember(newgrRules,modelMerged.grRules{newreacpos})));
+
+%The S matrix is added up.
+assert(isequal(modelMerged.S(:,newreacpos), sum(model.S(:,rxnspos),2)));
+
+%Now, lets change the model a bit, and duplicate the name of a gene
+%(replacing it in all grRules).
+geneReplaced = model.genes(end);
+modelWithReplacedGene = model;
+modelWithReplacedGene.genes(end) = modelWithReplacedGene.genes(1);
+modelWithReplacedGene.grRules = strrep(modelWithReplacedGene.grRules,geneReplaced,modelWithReplacedGene.genes(end));
+
+modelMerged = mergeModelFieldPositions(modelWithReplacedGene,'genes',[1,numel(modelWithReplacedGene.genes)]);
+%Assert, that the gene is still present.
+assert(sum(ismember(modelMerged.genes,modelWithReplacedGene.genes(1)))==1)
+
+%Assert, that all grRules are equal(the gene names were just merged and no
+%new gene name was introduced.
+assert(isequal(modelWithReplacedGene.grRules,modelMerged.grRules))
+
+%Check, that the rules positions are now merged.
+involvedInEnd = find(modelWithReplacedGene.rxnGeneMat(:,end));
+
+%Check that the rules have been updated
+assert(~isequal(modelMerged.rules(involvedInEnd),modelWithReplacedGene.rules(involvedInEnd)));
+%Also check, that they have been updated correctly
+assert(isequal(modelMerged.rules(involvedInEnd),strrep(modelWithReplacedGene.rules(involvedInEnd),['x(' num2str(numel(modelWithReplacedGene.genes)) ')'], 'x(1)')));
+
+%Finally, we will merge 2 no equal genes.
+modelMerged = mergeModelFieldPositions(model,'genes',[1,numel(model.genes)]);
+
+%Check that the rules have been updated (this is the same as above as the
+%genes are the same.
+assert(~isequal(modelMerged.rules(involvedInEnd),model.rules(involvedInEnd)));
+%Also check, that they have been updated correctly
+assert(isequal(modelMerged.rules(involvedInEnd),strrep(model.rules(involvedInEnd),['x(' num2str(numel(model.genes)) ')'], 'x(1)')));
+
+%Also check, that the grRules have been updated:
+assert(~isequal(model.grRules,modelMerged.grRules))
+%And correctly updated
+assert(isequal(modelMerged.grRules,regexprep(model.grRules,['(' model.genes{1} ')|(' model.genes{end} ')'],strjoin(model.genes([1,end]),';'))));
+

--- a/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
+++ b/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
@@ -84,3 +84,6 @@ assert(~isequal(model.grRules,modelMerged.grRules))
 %And correctly updated
 assert(isequal(modelMerged.grRules,regexprep(model.grRules,['(' model.genes{1} ')|(' model.genes{end} ')'],strjoin(model.genes([1,end]),';'))));
 
+fprintf('Done...\n');
+%Switch back
+cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testUpdateGenes.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testUpdateGenes.m
@@ -16,15 +16,17 @@ cd(fileDir);
 
 model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'Recon2.v04.mat']);
 
-% Check that updateGenes doesn't change the model
+% Check that updateGenes orders the gene list
 model2 = updateGenes(model);
 tmp = model;
 tmp.genes = sort(tmp.genes);
-assert(isSameCobraModel(tmp, model2));
+assert(isequal(tmp.genes,model2.genes));
+
+%Note the gens associated with the reaction for which we remove the gpr
+geneRemoved = model.genes(model.rxnGeneMat(strcmp(model.rxns, 'OROTGLUt'), :) == 1);
 
 % Remove one gene (by removing gene rules from one reaction)
-model2.grRules{strcmp(model.rxns, 'OROTGLUt')} = '';
-geneRemoved = model.genes(model.rxnGeneMat(strcmp(model.rxns, 'OROTGLUt'), :) == 1);
+model2 = changeGeneAssociation(model2,'OROTGLUt','');
 model2 = updateGenes(model2);
 
 assert(length(model.genes) == length(model2.genes) + 1);
@@ -32,7 +34,7 @@ geneDifference = setdiff(model.genes, model2.genes);
 assert(all(strcmp(geneRemoved, geneDifference)));
 
 % Test tolerance of capital letters and gene addition
-model2.grRules{strcmp(model.rxns, 'OROTGLUt')} = '(Foo AND bar) OR gene or gene2';
+model2 = changeGeneAssociation(model2,'OROTGLUt','(Foo AND bar) OR gene or gene2');
 model2 = updateGenes(model2);
 genesAddedShouldBe = {'Foo'; 'bar'; 'gene'; 'gene2'};
 assert(all(strcmp(setdiff(model2.genes, model.genes), genesAddedShouldBe)));


### PR DESCRIPTION
updateGenes currently breaks the model structure by completely reordering the gene field without correcting related fields. This leads to a resulting model with incorrectly sized annotation fields wrong rules. 
According to correspondence with @dayena, the intention of updateGenes is to remove surplus genes from models generated by extraction algorithms (and use of e.g. removeRxns). 
This functionality was already present in removeUnusedGenes. 
However, the current version of updateGenes also reorders the genes in alphabetic order, and eliminates duplicate genes, which is an additional function compared to removeUnusedGenes. 

To this end I introduce mergeModelFieldPositions which offers the ability to merge fields in the model.
Merging will add up numeric fields and create unions for fields which are cell arrays of cell arrays or create a concatenated list (with ; as separator), for cell arrays of strings that are merged. Char fields are left with the value of the first index provided.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
