### PR TITLE
Adjusting testAll and fixing other tests

### DIFF
--- a/test/testAll.m
+++ b/test/testAll.m
@@ -34,7 +34,7 @@ else
     cd(CBTDIR);
 end
 % include the root folder and all subfolders.
-addpath(genpath(pwd));
+addpath(genpath([pwd filesep 'test']));
 
 % change to the root folder of The COBRA TOolbox
 cd(CBTDIR);

--- a/test/verifiedTests/analysis/testConnectedComponents/testConnectedComponents.m
+++ b/test/verifiedTests/analysis/testConnectedComponents/testConnectedComponents.m
@@ -28,9 +28,10 @@ testdir = fileparts(which('testConnectedComponents.m'));
 cd(testdir)
 
 IPT = 'Image Processing Toolbox';
+IPT_Lic = 'Image_Toolbox';
 v = ver;
 
-if ~any(strcmp(IPT, {v.Name})) || ~license('test', IPT)
+if ~any(strcmp(IPT, {v.Name})) || ~license('test', IPT_Lic)
     warning([IPT, ' is not installed or not licensed. Aborting test.'])
 else
     model = createToyModelForConnectedComponentAnalysis();


### PR DESCRIPTION
Changed testAll to not add the whole base folder but only the test folder (everything else is added by the call to initCobraToolbox). This way, the .git folders are not added to the path (which can lead to conflicts when running functions that also have a git branch with the same name).

Also corrected the check for a license in testConnectedComponents, according to the Matlab page. The current check returned without testing even if the Image processing toolbox was installed.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
