### PR TITLE
Test restrict model fields

### DIFF
--- a/src/base/io/utilities/restrictModelsToFields.m
+++ b/src/base/io/utilities/restrictModelsToFields.m
@@ -23,15 +23,16 @@ if isstruct(models)
     structin = true;
 end
 restrictedModels = cell(size(models));
-for i = 1: numel(models)
-    newModel = struct();
+
+for i = 1: numel(models)    
     cmodel = models{i};    
-    for f = 1:numel(fieldNames)
-        if isfield(cmodel,fieldNames{f})
-            newModel.(fieldNames{f}) = cmodel.(fieldNames{f});
+    modelfields = fieldnames(cmodel);
+    for f = 1:numel(modelfields)
+        if ~any(ismember(fieldNames,modelfields{f}))
+            cmodel = rmfield(cmodel,modelfields{f});
         end
     end
-    restrictedModels{i} = newModel;
+    restrictedModels{i} = cmodel;
 end
 
 if structin

--- a/src/base/io/utilities/restrictModelsToFields.m
+++ b/src/base/io/utilities/restrictModelsToFields.m
@@ -25,9 +25,11 @@ end
 restrictedModels = cell(size(models));
 for i = 1: numel(models)
     newModel = struct();
-    cmodel = models{i};
+    cmodel = models{i};    
     for f = 1:numel(fieldNames)
-        newModel.(fieldNames{f}) = cmodel.(fieldNames{f});
+        if isfield(cmodel,fieldNames{f})
+            newModel.(fieldNames{f}) = cmodel.(fieldNames{f});
+        end
     end
     restrictedModels{i} = newModel;
 end

--- a/test/verifiedTests/base/testIO/testUtilities/testRestrictModelsToFields.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testRestrictModelsToFields.m
@@ -14,14 +14,34 @@ fileDir = fileparts(which('testRestrictModelsToFields'));
 cd(fileDir);
 
 % test variables
-models = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'ecoli_core_model.mat']);
-fieldNames = fieldnames(models);
+models{1} = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'ecoli_core_model.mat']);
+models{2} = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'Abiotrophia_defectiva_ATCC_49176.xml']);
+fieldNames = fieldnames(models{1});
+fieldNames2 = fieldnames(models{2});
 
-% function outputs
-restrictedModels = restrictModelsToFields(models, fieldNames);
+%test whether fields are removed:
+commonfields = intersect(fieldNames,fieldNames2);
+restrictedModels = restrictModelsToFields(models, commonfields);
+
+for i = 1:numel(models)
+    assert(isempty(setxor(commonfields,fieldnames(restrictedModels{i}))));
+end
+
+%Test whether random fields are retained.
+
+fieldsKept = commonfields([1,2,3]);
+restrictedModels = restrictModelsToFields(models, fieldsKept);
+for i = 1:numel(models)
+    assert(isempty(setxor(fieldsKept,fieldnames(restrictedModels{i}))));
+end
+
+%leave all fields in
+allFields = union(fieldNames,fieldNames2);
+restrictedModels = restrictModelsToFields(models, allFields);
 
 % test
-assert(isequal(restrictedModels, models));
+assert(isSameCobraModel(restrictedModels{1}, models{1}));
+assert(isSameCobraModel(restrictedModels{2}, models{2}));
 
 % change to old directory
 cd(currentDir);


### PR DESCRIPTION
Testing whether restrictModelToFields actually removed fields from the model, 
Also bugfix for testRestrictModelToFields to allow fieldNames which are not present in a model (and are ignored).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
