### PR TITLE
HotFix, xls2model, comps vector has wrong format.

### DIFF
--- a/src/base/io/utilities/xls2model.m
+++ b/src/base/io/utilities/xls2model.m
@@ -364,6 +364,9 @@ else
     [model.comps,~,origin] = unique(metCompAbbrev(origpos));
     %Column Vector
     model.comps = columnVector(model.comps);
+    if ischar(model.comps)
+        model.comps = cellstr(model.comps);
+    end
     for i = 1:numel(model.comps)
         %combine all, ignoring empty entries.
         CompNames{i} = strjoin(setdiff(ucomps(origin==i),''),' or ');


### PR DESCRIPTION
The comps vector in xls2model was created as a char array, converted to a cell array of chars to match specification.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
