### PR TITLE
OrderModelFields from modelBorgifier overwrites existing function

### DIFF
--- a/src/reconstruction/comparison/modelBorgifier/TmodelFields.m
+++ b/src/reconstruction/comparison/modelBorgifier/TmodelFields.m
@@ -1,7 +1,7 @@
 function fields = TmodelFields()
 % Returns the field names of the `Tmodel` structure. This is
 % to help alleviate control between different scripts.
-% Called by `cleanTmodel`, `readCbTmodel`, `verifyModel`, `organizeModelCool`, `TmodelStats`, `orderModelFields`.
+% Called by `cleanTmodel`, `readCbTmodel`, `verifyModel`, `organizeModelCool`, `TmodelStats`, `orderModelFieldsMB`.
 %
 % USAGE:
 %

--- a/src/reconstruction/comparison/modelBorgifier/orderModelFieldsMB.m
+++ b/src/reconstruction/comparison/modelBorgifier/orderModelFieldsMB.m
@@ -1,10 +1,10 @@
-function Model = orderModelFields(Model)
+function Model = orderModelFieldsMB(Model)
 % Puts the fields in the correct order in the structure.
 % Called by `verifyModel`, `readCbTModel`, calls `TmodelFields`.
 %
 % USAGE:
 %
-%    Model = orderModelFields(Model)
+%    Model = orderModelFieldsMB(Model)
 %
 % INPUTS:
 %    Model:    model structure with unsorted fiels

--- a/src/reconstruction/comparison/modelBorgifier/readCbTmodel.m
+++ b/src/reconstruction/comparison/modelBorgifier/readCbTmodel.m
@@ -1,7 +1,7 @@
 function Model = readCbTmodel(modelName, Tmodel, varargin)
 % Creates COBRA format of a specific model from `Tmodel`.
 % (composite database).
-% Called by `mergeBorgModels`, `driveModelBorgifier`, calls `TmodelFields`, `orderModelFields`, `organizeModelCool`, `buildRxnEquations`, `ismatlab`, `parseBoolean`.
+% Called by `mergeBorgModels`, `driveModelBorgifier`, calls `TmodelFields`, `orderModelFieldsMB`, `organizeModelCool`, `buildRxnEquations`, `ismatlab`, `parseBoolean`.
 %
 % USAGE:
 %
@@ -265,5 +265,5 @@ if strcmpi(choice,'y') || strcmpi(choice, 'yes')
 end
 
 %% Order model.
-Model = orderModelFields(Model) ;
+Model = orderModelFieldsMB(Model) ;
 Model = organizeModelCool(Model) ;

--- a/src/reconstruction/comparison/modelBorgifier/verifyModelMB.m
+++ b/src/reconstruction/comparison/modelBorgifier/verifyModelMB.m
@@ -3,7 +3,7 @@ function Model = verifyModelMB(Model, varargin)
 % by any of the scripts in the `Tmodel` suite. It will add fields that are
 % missing and expected for comparison. It will remove fields not in this list.
 % Called by  `driveModelBorgifier`, calls `TmodelFields`, `fixNames`, `removeDuplicateNames`,
-% `makeNamesUnique`, `buildRxnEquations`, `fixChemFormulas`, `orderModelFields`, `organizeModelCool`.
+% `makeNamesUnique`, `buildRxnEquations`, `fixChemFormulas`, `orderModelFieldsMB`, `organizeModelCool`.
 %
 % USAGE:
 %
@@ -322,5 +322,5 @@ while needModelName
 end
 
 %% Reorder fields and organize model based on most common mets.
-Model = orderModelFields(Model);
+Model = orderModelFieldsMB(Model);
 Model = organizeModelCool(Model);


### PR DESCRIPTION
Changed the modelBorgifier orderModelFields function to orderModelFieldsMB, as it was overwriting the existing orderModelFields function which was used to order the fields in a model according to the field definitions.
Also updated all dependent functions.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
