### PR TITLE
Making grRules field optional

### DIFF
--- a/external/RAVEN/checkMetabolicTasks.m
+++ b/external/RAVEN/checkMetabolicTasks.m
@@ -69,7 +69,8 @@ end
 if size(model.rules,2)>size(model.rules,1)
     model.rules=model.rules';
 end
-if size(model.grRules,2)>size(model.grRules,1)
+
+if isfield(model,'grRules') && size(model.grRules,2)>size(model.grRules,1)
     model.grRules=model.grRules';
 end
 

--- a/src/analysis/exploration/findNeighborRxns.m
+++ b/src/analysis/exploration/findNeighborRxns.m
@@ -10,6 +10,8 @@ function [neighborRxns, neighborGenes, mets] = findNeighborRxns(model, rxns, asS
 % INPUTS:
 %    model:            COBRA model structure
 %    rxns:             the target reaction as a string or multiple reactions as cell array
+%
+% OPTIONAL INPUTS:
 %    asSingleArray:    If false, then return cell array of cell arrays with neighbor reactions
 %                      for one particular connecting metabolite and input reaction combination.
 %                      Else just return all neighbors in one cell array. (Default = false)
@@ -23,7 +25,7 @@ function [neighborRxns, neighborGenes, mets] = findNeighborRxns(model, rxns, asS
 %
 % OUTPUTS:
 %    neighborRxns:     the neighboring rxns in the network, (having common metabolites)
-%    neighborGenes:    the `gprs` associated with the neighbor `rxns`
+%    neighborGenes:    the genes associated with the neighbor `rxns`
 %    mets:             the metabolites in the target reaction
 %
 % .. Authors:
@@ -88,7 +90,7 @@ for i = 1:numel(rxns)
 	end
 
 	% remove target rxn from list
-	for i = 1:length(metIndex);
+	for i = 1:length(metIndex)
     	nRxnIndexs{i} = setdiff(nRxnIndexs{i},findRxnIDs(model,rxn));
 	end
 
@@ -98,7 +100,9 @@ for i = 1:numel(rxns)
 
 	%get genes for each rxn
 	for i = 1:length(metIndex)
-    	neighborGenes{runningGeneIndex + i} = model.grRules(nRxnIndexs{i});
+        allpos = regexp(model.rules(nRxnIndexs{i}),'x\((?<IDs>[0-9]+)\)','names');        
+        genes = cellfun(@(x) cellfun(@str2num, {x.IDs}),allpos, 'UniformOutput', 0);
+        neighborGenes{runningGeneIndex + i} = cellfun(@(x) strjoin(model.genes(unique(x)),'; '),genes,'Uni',false);
 	end
 
 	mets = unique([mets; model.mets(metIndex)]);

--- a/src/analysis/exploration/findOrphanRxns.m
+++ b/src/analysis/exploration/findOrphanRxns.m
@@ -14,6 +14,7 @@ function orphans = findOrphanRxns(model)
 %
 % .. Author: - Jeff Orth 4/15/09
 
-rxns = find(strcmp('',model.grRules));
+
+rxns = find(strcmp('',model.rules));
 [selExc,selUpt] = findExcRxns(model,true,false);
 orphans = model.rxns(setdiff(rxns,find(selExc)));

--- a/src/base/parseMetNames.m
+++ b/src/base/parseMetNames.m
@@ -19,9 +19,24 @@ function [baseMetNames, compSymbols, uniqueMetNames, uniqueCompSymbols] = parseM
 %
 % .. Author: - Markus Herrgard 10/4/06
 %            - Thomas Pfau Speedup and cleanup Oct 2017
+if ~iscell(metNames)
+    metNames = {metNames};
+end
 
-data = cellfun(@(x) regexp(x,'^(?<metNames>.*)\[(?<compSymbols>[^\[*])\]$','names'),metNames);
-
+try
+    data = cellfun(@(x) regexp(x,'^(?<metNames>.*)\[(?<compSymbols>[^\[*])\]$','names'),metNames);
+catch
+    %If the above doesn't work, its likely, that we either have an odd
+    %compartment symbol (e.g. (), or that we have a non compartmented
+    %entry.
+    %Lets see if we have a ()compartment symbol
+    try
+        data = cellfun(@(x) regexp(x,'^(?<metNames>.*)\((?<compSymbols>[^\[*])\)$','names'),metNames);
+    catch
+        %No, we don't lets assume, we only have a metabolite name
+        data = cellfun(@(x) regexp(x,'^(?<metNames>.*)[\(\[]*(?<compSymbols>.*)[^\[\(]*[\]\)]*$','names'),metNames);
+    end
+end
 baseMetNames = columnVector({data.metNames});
 compSymbols = columnVector({data.compSymbols});
 uniqueCompSymbols = unique(compSymbols);

--- a/src/base/parseMetNames.m
+++ b/src/base/parseMetNames.m
@@ -14,35 +14,15 @@ function [baseMetNames, compSymbols, uniqueMetNames, uniqueCompSymbols] = parseM
 %    uniqueMetNames:       Unique metabolite names (w/o comp symbol)
 %    uniqueCompSymbols:    Unique compartment symbols
 %
-% Metabolite names should describe the compartment assignment in either the
-% form "metName[compName]" or "metName(compName)"
+% Metabolite names should describe the compartment assignment in the
+% form "metName[compName]" 
 %
 % .. Author: - Markus Herrgard 10/4/06
+%            - Thomas Pfau Speedup and cleanup Oct 2017
 
-uniqueCompSymbols = {};
-uniqueMetNames = {};
-for metNo = 1:length(metNames)
-    metName = metNames{metNo};
-    if (~isempty(regexp(metName,'\[')))
-        [tokens,tmp] = regexp(metName,'(.+)\[(.+)\]','tokens','match');
-    else
-        [tokens,tmp] = regexp(metName,'(.+)\((.+)\)','tokens','match');
-    end
-    if ~isempty(tokens)
-        compSymbol = tokens{1}{2};
-        baseMetName = tokens{1}{1};
-    else
-        compSymbol = '';
-        baseMetName = metName;
-    end
-    compSymbols{metNo} = compSymbol;
-    baseMetNames{metNo} = baseMetName;
-end
+data = cellfun(@(x) regexp(x,'^(?<metNames>.*)\[(?<compSymbols>[^\[*])\]$','names'),metNames);
 
-% Get the list of unique compartment symbols and unique metabolite base
-% names
-uniqueCompSymbols = columnVector(unique(compSymbols));
-uniqueMetNames = columnVector(unique(baseMetNames));
-
-compSymbols = columnVector(compSymbols);
-baseMetNames = columnVector(baseMetNames);
+baseMetNames = columnVector({data.metNames});
+compSymbols = columnVector({data.compSymbols});
+uniqueCompSymbols = unique(compSymbols);
+uniqueMetNames = unique(baseMetNames);

--- a/src/design/GDLS.m
+++ b/src/design/GDLS.m
@@ -85,6 +85,14 @@ switch lower(options.koType)
     case 'genesets'
         %% Generate reaction gene set mapping matrix
         %remove biomass reaction from grRules and generate unique gene set list
+        %I would suggest a proper rewrite for this, as it does not make a
+        %lot of sense to explicitly check identical GPR Rules (which can be ordered in a different way while being the same).
+        %What would make sense is to check required gene sets, e.g. if 
+        %a gprRule has A and B, A would be one "required" set and B would
+        %be one required set.
+        if ~isfield(model, 'grRules')
+            model = creategrRulesField(model);
+        end
         possibleKOList = unique(model.grRules(selSelectedRxns));
         if isempty(possibleKOList{1}), possibleKOList = possibleKOList(2:end); end
         for i = 1:length(possibleKOList)

--- a/src/reconstruction/fastGapFill/prepareFastGapFill.m
+++ b/src/reconstruction/fastGapFill/prepareFastGapFill.m
@@ -137,7 +137,9 @@ while m == 0
     MatricesSUX.lb(NullRxns==1)=[];
     MatricesSUX.ub(NullRxns==1)=[];
     MatricesSUX.rules(NullRxns==1)=[];
-    MatricesSUX.grRules(NullRxns==1)=[];
+    if isfield(MatricesSUX,'grRules')
+        MatricesSUX.grRules(NullRxns==1)=[];
+    end
     MatricesSUX.c(NullRxns==1)=[];
 end
 

--- a/src/reconstruction/rBioNet/inc/model2data.m
+++ b/src/reconstruction/rBioNet/inc/model2data.m
@@ -43,6 +43,12 @@ if sum(match) == length(name)
         ' it as a mat file.'], 'Incorrect file type','Help');
     return
 end
+
+%This field is necessary for the output.
+if ~isfield(model,'grRules')
+    model = creategrRulesField(model);
+end
+
 Mandatory = {'rxns','rxnNames', 'rev','grRules', 'lb', 'ub','S','genes'};
 %Opt numbers: CS = 1, subsystem = 2, citations = 3, comments = 4, ecNumbers = 5,
 % rxnKEGGID = 6, description = 7

--- a/src/reconstruction/refinement/addReactionGEM.m
+++ b/src/reconstruction/refinement/addReactionGEM.m
@@ -45,12 +45,23 @@ if ~exist('subSystems', 'var') || isempty(subSystems)
         subSystems(i,1) = {''};
     end
 end
+%We later assume, that this field exists, so we have to initialize it
+%properly.
+if ~isfield(model,'subSystems')
+    model.subSystems = repmat({''},size(model.rxns));
+end
 
 if ~exist('grRules', 'var') || isempty(grRules)
     clear grRules;
     for i = 1:length(rev)
         grRules(i,1) = {''};
     end
+end
+
+%We later assume, that this field exists, so we have to initialize it
+%properly.
+if ~isfield(model,'grRules')
+    model.grRules = repmat({''},size(model.rxns));
 end
 
 if ~exist('rules', 'var')|| isempty(rules)


### PR DESCRIPTION
Addressing issue #825.
Except for functions updated in different PRs, all functions using grRules (outside of model Borgifier, which uses its own field definitions), are updated such that either grRules is made optional, OR grRules are created if necessary.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
