### PR TITLE
Fix for the failing listBiGGModels test

### DIFF
--- a/test/verifiedTests/base/testIO/testListBiGGModels.m
+++ b/test/verifiedTests/base/testIO/testListBiGGModels.m
@@ -13,14 +13,24 @@ currentDir = pwd;
 fileDir = fileparts(which('testListBiGGModels'));
 cd(fileDir);
 
-% test variables
-refData_str = fileread('refData_listBiGGModels.txt');
-refData_str = refData_str(1:end-1);
 % function outputs
+
 [str] = listBiGGModels();
 
-% test
-assert(isequal(refData_str, str));
+%With 2016b we can properly test this
+cver = ver('MATLAB');
+
+if str2num(cver.Version) >= 9.1 % after 2016b
+    data = jsondecode(str);
+    %Structure
+    assert(isfield(data,'results'))
+    assert(isfield(data,'results_count'));
+    %At least ecoli core should be there.
+    assert(any(ismember({data.results.bigg_id},'e_coli_core')));
+else
+    %Lets see, if there is at least e_coli_core in the result
+    assert(~isempty(regexp(str,'"bigg_id" *: *"e_coli_core"','once')));
+end
 
 % change to old directory
 cd(currentDir);


### PR DESCRIPTION
List BIGG models is failing due to the database having added a new model. 
Since currently there is a direct comparison with a saved historic return value, this test will always fail.
Changed it to check for presence of a specific BiGG model and (under 2016b) to check for the structure of the returned argument.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
