### PR TITLE
Update to testSbmlTestModelToMat

### DIFF
--- a/src/base/io/sbmlTestModelToMat.m
+++ b/src/base/io/sbmlTestModelToMat.m
@@ -40,18 +40,16 @@ for k = 3:length(files)
     if strcmp(files(k).name(end - 2:end), 'xml')
         % read in the xml file
         fileName = files(k).name;
-        if ~exist([fileName(1:end - 3) 'mat'], 'file')
+        if ~exist([destFolder filesep fileName(1:end - 3) 'mat'], 'file')
             filePathName = [originFolder filesep fileName];
             % save as mat file in the same directory
             % savedMatFile=[CBTDIR filesep 'testing' filesep 'testModels' filesep destFolder filesep fileName(1:end-4) '.mat'];
             savedMatFile = [destFolder filesep fileName(1:end - 4) '.mat'];
             try
-                defaultBound = 1000;
-                fileType = 'SBML';
                 if printLevel > 0
                     fprintf('%s%s\n', fileName, [' :compatible with readCbModel'])
                 end
-                model = readCbModel(filePathName, defaultBound, fileType);
+                model = readCbModel(filePathName);
                 % disp(savedMatFile)
                 save(savedMatFile, 'model');
             catch

--- a/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
+++ b/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
@@ -72,7 +72,7 @@ mkdir(defaultname);
 invalidFile = fopen([defaultname filesep 'Invalid.xml'],'w');
 fprintf(invalidFile,'Not a vlid XML\n');
 fclose(invalidFile);
-%Test with defaults, and notie nothing works
+%Test with defaults, and nothing works
 sbmlTestModelToMat()
 defaultfoldercontent = dir(defaultname);
 
@@ -83,21 +83,15 @@ cd(fileDir);
 
 
 
-%Clean up the folders.
-isdeleted = false;
-k = 0;
-
-while ~isdeleted && k < 10 %we don'T try it more than ten times.
-    try
-        rmdir(MATFolder,'s');
-        rmdir(SBMLFolder,'s');        
-        rmdir([tempfolder filesep defaultname],'s');
-        isdeleted = true;
-    catch
-        k = k + 1; % increase counter for timeout
-        pause(1); %wait a second before retry
-        rehash;
-    end
+%Clean up the folders. (In a try/catch for windows)
+%Even if this does not work, those folders are just temporary folders.
+try
+   rmdir(MATFolder,'s');
+   rmdir(SBMLFolder,'s');        
+   rmdir([tempfolder filesep defaultname],'s');
+   isdeleted = true;
+catch
+    
 end
 
 cd(currentDir)

--- a/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
+++ b/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
@@ -1,47 +1,59 @@
 % The COBRAToolbox: testSbmlTestModelToMat.m
 %
 % Purpose:
-%     - test the sbmlTestModelToMat function
+%     - tests the batch conversion of SBML models to .mat files.
 %
 % Authors:
-%     - Jacek Wachowiak
+%     - Original file: Thomas Pfau - Sept 2017
+%
+
 global CBTDIR
+
 % save the current path
 currentDir = pwd;
 
 % initialize the test
-fileDir = fileparts(which('testSbmlTestModelToMat'));
+fileDir = fileparts(which('testSbmlTestModelToMat.m'));
 cd(fileDir);
 
-% test variables
-% creating the default folder 'm_model_collection' for function call without input arguments, copying xml files to be worked on to this folder
-mkdir 'm_model_collection'
-cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'base', filesep, 'testIO', filesep, 'm_model_collection']);
-copyfile(strcat([CBTDIR, filesep, 'test', filesep, 'models', filesep], 'Abiotrophia_defectiva_ATCC_49176.xml'));
-% copying xml file as mat file so that it will be deleted by the function
-copyfile(strcat([CBTDIR, filesep, 'test', filesep, 'models', filesep], 'Abiotrophia_defectiva_ATCC_49176.xml'), 'Abiotrophia_defectiva_ATCC_49176.mat');
-copyfile(strcat([CBTDIR, filesep, 'test', filesep, 'models', filesep], 'Sc_iND750_flux1.xml'));
-cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'base', filesep, 'testIO']);
+%Create Temporary Folders
+SBMLFolder = tempname;
+mkdir(SBMLFolder);
 
-% function outputs
-% emptying CBTDIR global variable so that the function can recreate that
-clear CBTDIR
-sbmlTestModelToMat();
-CBTDIR = fileparts(which('initCobraToolbox'));
+MATFolder = tempname;
+mkdir(MATFolder);
 
-% test
-assert((exist('m_model_collection') == 7));
-cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'base', filesep, 'testIO', filesep, 'm_model_collection']);
-assert((exist('Abiotrophia_defectiva_ATCC_49176.xml') == 2));
-assert((exist('Sc_iND750_flux1.xml') == 2));
-cd([CBTDIR, filesep, 'test', filesep, 'verifiedTests', filesep, 'base', filesep, 'testIO']);
+%copy all xml files from the models to the temp folder 
+modeldir = [CBTDIR filesep 'test' filesep 'models'];
+copyfile([modeldir filesep '*.xml'], SBMLFolder);
 
-% since rmdir fails on windows it will be ignored and added to .gitignore
-if isunix
-try
-rmdir('m_model_collection','s')
+modelfiles = dir(SBMLFolder);
+models = cell(0);
+%Now, individually read all models
+for i = 1:size(modelfiles)
+    if ~isempty(regexp(modelfiles(i).name,'.*\.xml$'))
+        models{end+1} = readCbModel([modelfiles(i).folder filesep modelfiles(i).name]);
+    end
+end
+sbmlTestModelToMat(SBMLFolder,MATFolder)
+matModels = cell(0);
+for i = 1:size(modelfiles)
+    if ~isempty(regexp(modelfiles(i).name,'.*\.xml$'))
+        %We load them, as otherwise the ID would change to the mat file and
+        %they would no longer be equivalent.
+        load([MATFolder filesep strrep(modelfiles(i).name,'.xml','.mat')]);
+        matModels{end+1} = model;
 end
 end
 
-% back to old directory
-cd(currentDir);
+%Test that the models are the same
+assert(numel(matModels) == numel(models));
+for i = 1:numel(matModels)
+    assert(isSameCobraModel(matModels{i},models{i}));
+end
+
+%Clean up the folders.
+rmdir(MATFolder,'s');
+rmdir(SBMLFolder,'s');
+
+cd(currentDir)

--- a/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
+++ b/test/verifiedTests/base/testIO/testSbmlTestModelToMat.m
@@ -38,7 +38,7 @@ for i = 1:size(modelfiles)
     end
     if ~isempty(regexp(modelfiles(i).name,'.*\.xml$'))
         copyfile([modeldir filesep, modelfiles(i).name],SBMLFolder);
-        models{end+1} = readCbModel([modelfiles(i).folder filesep modelfiles(i).name]);
+        models{end+1} = readCbModel([modeldir filesep modelfiles(i).name]);
         modelNames{end+1} = modelfiles(i).name;
     end
 end


### PR DESCRIPTION
The previous test looked for the existence of specific xml files (which are present in the model folder and thus automatically succeed).
Also, fixed the original function to represent that the converted file should exist in the target folder (and not just anywhere) and removed the (default) inputs for readCbModel (not necessary any more).
The new test checks, whether the converted models are created and works purely in a temporary folder (which should avoid conflicts, with other test runs).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
