### PR TITLE
Fix Gurobi-specific parameter structure in solveCobraMILP.m 

### DIFF
--- a/src/analysis/topology/conservedMoieties/decomposeMoietyVectors.m
+++ b/src/analysis/topology/conservedMoieties/decomposeMoietyVectors.m
@@ -48,7 +48,7 @@ while rp > 0 % Iterate since decomposed moiety vectors might themselves be decom
         P.osense = 1;
         P.csense = [repmat('E', 2*size(Np,2) + length(c), 1); 'L'; 'G'; 'G'];
         P.vartype = repmat('I', size(P.A,2), 1);
-        P.x0 = suma*[c; c];
+        P.x0 = suma(:);
 
         % Run MILP
         solution = solveCobraMILP(P);

--- a/src/analysis/topology/conservedMoieties/decomposeMoietyVectors.m
+++ b/src/analysis/topology/conservedMoieties/decomposeMoietyVectors.m
@@ -48,7 +48,7 @@ while rp > 0 % Iterate since decomposed moiety vectors might themselves be decom
         P.osense = 1;
         P.csense = [repmat('E', 2*size(Np,2) + length(c), 1); 'L'; 'G'; 'G'];
         P.vartype = repmat('I', size(P.A,2), 1);
-        P.x0 = suma(:);
+        P.x0 = suma' .* [c; c];
 
         % Run MILP
         solution = solveCobraMILP(P);

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -501,6 +501,9 @@ switch solver
         MILPproblem.vtype = vartype;
         MILPproblem.modelsense = MILPproblem.osense;
         [MILPproblem.A,MILPproblem.rhs,MILPproblem.obj,MILPproblem.sense] = deal(sparse(MILPproblem.A),MILPproblem.b,double(MILPproblem.c),MILPproblem.csense);
+        if isfield(MILPproblem, 'x0') && ~isempty(x0)
+			MILPproblem.start = x0;
+		end
         resultgurobi = gurobi(MILPproblem,params);
 
         stat = resultgurobi.status;

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -319,8 +319,8 @@ switch solver
         end
 
         % minimum intTol for gurobi = 1e-9
-        if solverParams.intTol<1e-9,
-            solverParams.intTol=1e-9
+        if solverParams.intTol<1e-9
+            solverParams.intTol = 1e-9;
         end
 
         opts.TimeLimit=solverParams.timeLimit;
@@ -501,7 +501,7 @@ switch solver
         MILPproblem.vtype = vartype;
         MILPproblem.modelsense = MILPproblem.osense;
         [MILPproblem.A,MILPproblem.rhs,MILPproblem.obj,MILPproblem.sense] = deal(sparse(MILPproblem.A),MILPproblem.b,double(MILPproblem.c),MILPproblem.csense);
-        if isfield(MILPproblem, 'x0') && ~isempty(x0)
+        if ~isempty(x0)
 			MILPproblem.start = x0;
 		end
         resultgurobi = gurobi(MILPproblem,params);

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -88,7 +88,7 @@ optParamNames = {'intTol', 'relMipGapTol', 'timeLimit', ...
                  'feasTol', 'optTol', 'absMipGapTol', 'NUMERICALEMPHASIS', 'solver'};
 
 parameters = [];
-
+parametersStructureFlag = false;
 % First input can be 'default' or a solver-specific parameter structure
 if ~isempty(varargin)
     isdone = false(size(varargin));
@@ -99,8 +99,8 @@ if ~isempty(varargin)
         varargin = varargin(~isdone);
 
     elseif isstruct(varargin{1})  % solver-specific parameter structure
-        solverParams = varargin{1};
-
+        [solverParams, directParamStruct] = deal(varargin{1});
+        parametersStructureFlag = true;
         isdone(1) = true;
         varargin = varargin(~isdone);
     end
@@ -111,8 +111,8 @@ if ~isempty(varargin)
     isdone = false(size(varargin));
 
     if isstruct(varargin{end})
-        solverParams = varargin{end};
-
+        [solverParams, directParamStruct] = deal(varargin{end});
+        parametersStructureFlag = true;
         isdone(end) = true;
         varargin = varargin(~isdone);
     end
@@ -122,7 +122,6 @@ if nargin ~= 1
     if mod(length(varargin), 2) == 0
         try
             parameters = struct(varargin{:});
-            parametersStructureFlag = 0;
         catch
             error('solveCobraLP: Invalid parameter name-value pairs.')
         end

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -506,8 +506,8 @@ switch solver
         MILPproblem.modelsense = MILPproblem.osense;
         [MILPproblem.A,MILPproblem.rhs,MILPproblem.obj,MILPproblem.sense] = deal(sparse(MILPproblem.A),MILPproblem.b,double(MILPproblem.c),MILPproblem.csense);
         if ~isempty(x0)
-			MILPproblem.start = x0;
-		end
+            MILPproblem.start = x0;
+        end
         resultgurobi = gurobi(MILPproblem,params);
 
         stat = resultgurobi.status;

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -395,10 +395,16 @@ switch solver
         cplexlp.Param.timelimit.Cur = solverParams.timeLimit;
         cplexlp.Param.output.writelevel.Cur = solverParams.printLevel;
         
-        if printLevel < 3
+        
+        if isscalar(solverParams.logFile) && solverParams.logFile == 1
+            % allow print to command window by setting solverParams.logFile == 1
+            outputfile = 1;
+            logToConsole = true;
+        else
             outputfile = fopen(solverParams.logFile,'a');
-            cplexlp.DisplayFunc = @redirect;
+            logToConsole = false;
         end
+        cplexlp.DisplayFunc = @redirect;
 
         cplexlp.Param.simplex.tolerances.optimality.Cur = solverParams.optTol;
         cplexlp.Param.mip.tolerances.absmipgap.Cur =  solverParams.absMipGapTol;
@@ -420,7 +426,7 @@ switch solver
         % Solve problem
         Result = cplexlp.solve();
         
-        if printLevel < 3
+        if ~logToConsole
             % Close the output file
             fclose(outputfile);
         end

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -193,6 +193,10 @@ xInt = [];
 xCont = [];
 f = [];
 
+if ~isfield(MILPproblem, 'x0')
+    MILPproblem.x0 = [];
+end
+
 [A, b, c, lb, ub, csense, osense, vartype, x0] = ...
     deal(MILPproblem.A, MILPproblem.b, MILPproblem.c, MILPproblem.lb, MILPproblem.ub, ...
     MILPproblem.csense, MILPproblem.osense, MILPproblem.vartype, MILPproblem.x0);

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -155,12 +155,16 @@ if nargin ~= 1
     else
         error('solveCobraMILP: Invalid number of parameters/values')
     end
+%     [minNorm, printLevel, primalOnlyFlag, saveInput, feasTol, optTol] = ...
+%     getCobraSolverParams('LP', optParamNames(1:6), parameters);
     [minNorm, printLevel, primalOnlyFlag, saveInput, feasTol, optTol] = ...
-    getCobraSolverParams('LP', optParamNames(1:6), parameters);
+    getCobraSolverParams('LP', {'minNorm', 'printLevel', 'primalOnlyFlag', 'saveInput', 'feasTol', 'optTol'}, parameters);
 else
     parametersStructureFlag = 0;
+%     [minNorm, printLevel, primalOnlyFlag, saveInput, feasTol, optTol] = ...
+%     getCobraSolverParams('LP', optParamNames(1:6));
     [minNorm, printLevel, primalOnlyFlag, saveInput, feasTol, optTol] = ...
-    getCobraSolverParams('LP', optParamNames(1:6));
+    getCobraSolverParams('LP', {'minNorm', 'printLevel', 'primalOnlyFlag', 'saveInput', 'feasTol', 'optTol'}, parameters);
     % parameters will later be accessed and should be initialized.
     parameters = '';
 end
@@ -386,9 +390,11 @@ switch solver
         cplexlp.Param.mip.tolerances.integrality.Cur =  solverParams.intTol;
         cplexlp.Param.timelimit.Cur = solverParams.timeLimit;
         cplexlp.Param.output.writelevel.Cur = solverParams.printLevel;
-
-        outputfile = fopen(solverParams.logFile,'a');
-        cplexlp.DisplayFunc = @redirect;
+        
+        if printLevel < 3
+            outputfile = fopen(solverParams.logFile,'a');
+            cplexlp.DisplayFunc = @redirect;
+        end
 
         cplexlp.Param.simplex.tolerances.optimality.Cur = solverParams.optTol;
         cplexlp.Param.mip.tolerances.absmipgap.Cur =  solverParams.absMipGapTol;
@@ -410,8 +416,10 @@ switch solver
         % Solve problem
         Result = cplexlp.solve();
         
-        % Close the output file
-        fclose(outputfile);
+        if printLevel < 3
+            % Close the output file
+            fclose(outputfile);
+        end
         
         % Get results
         x = Result.x;

--- a/test/verifiedTests/base/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraMILP.m
@@ -102,6 +102,26 @@ for k = 1:length(solverPkgs)
                 delete(['testIBMcplexMILPparam' num2str(jTest) '.log']);
             end
         end
+        
+        % check additional parameters for Gurobi 
+        if strcmp(solverPkgs{k}, 'gurobi6')
+            sol = solveCobraMILP(MILPproblem, struct('TimeLimit',0));
+            assert(strcmp(sol.origStat, 'TIME_LIMIT'))
+            
+            diary testGurobiMipStart.txt
+            sol = solveCobraMILP(MILPproblem, 'printLevel', 1);
+            diary off
+            text = '';
+            f = fopen('testGurobiMipStart.txt', 'r');
+            l = fgets(f);
+            while ~isequal(l, -1)
+                text = [text, l];
+                l = fgets(f);
+            end
+            fclose(f);
+            assert(~isempty(strfind(text, 'Loaded MIP start')))
+            delete('testGurobiMipStart.txt')
+        end
     end
 
     % output a success message

--- a/test/verifiedTests/base/testSolvers/testSolveCobraMILP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraMILP.m
@@ -17,6 +17,10 @@ currentDir = pwd;
 fileDir = fileparts(which('testSolveCobraMILP'));
 cd(fileDir);
 
+% save original solve
+global CBT_MILP_SOLVER;
+orig_solver = CBT_MILP_SOLVER;
+
 % test solver packages
 solverPkgs = {'cplex_direct', 'ibm_cplex', 'tomlab_cplex', 'gurobi6', 'glpk'};
 
@@ -145,11 +149,47 @@ for k = 1:length(solverPkgs)
     fprintf('Done.\n');
 end
 
+% test ibm_cplex output to command window
+solverOK = changeCobraSolver('ibm_cplex', 'MILP', 0);
+if solverOK
+    fprintf('Test ibm_cplex output to command window ...\n')
+    % solve without logToFile = 1
+    diary test_ibm_cplex_output_to_console1.txt
+    sol = solveCobraMILP(MILPproblem);
+    diary off
+    % read the diary, which should be empty
+    f = fopen('test_ibm_cplex_output_to_console1.txt', 'r');
+    l = fgets(f);
+    assert(isequal(l, -1))
+    fclose(f);
+    delete('test_ibm_cplex_output_to_console1.txt')
+    
+    % solve wit logToFile = 1
+    diary test_ibm_cplex_output_to_console2.txt
+    sol = solveCobraMILP(MILPproblem, 'logFile', 1);
+    diary off
+    % read the diary, which should be non-empty
+    f = fopen('test_ibm_cplex_output_to_console2.txt', 'r');
+    l = fgets(f);
+    line = 0;
+    while ~isequal(l, -1)
+        line = line + 1;
+        l = fgets(f);
+    end
+    fclose(f);
+    assert(line > 3)
+    delete('test_ibm_cplex_output_to_console2.txt')
+    fprintf('Test ibm_cplex output to command window ... Done\n')
+end
+
 % remove the generated file
 fullFileNamePath = [fileparts(which(mfilename)), filesep, 'MILPProblem.mat'];
 if exist(fullFileNamePath, 'file') == 2
     delete(fullFileNamePath);
 end
+
+% change back to the original solver
+changeCobraSolver(orig_solver, 'MILP', 0);
 
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
*Please include a short description of enhancement here*

Initialization section:
- assign parametersStructureFlag (used only for gurobi) to all cases to allow for Gurobi-specific parameter structure. Currently the supplied solver-specific parameter structure is not used in gurobi (Test added in testSolveCobraMILP.m)
- set default MIP start (x0) to be []. Currently MILPproblem.x0 must be supplied. But I think most solvers do not require that. (Test added in testSolveCobraMILP.m)
- fix parameter names from matching with optParamNames (currently mismatched) to matching with their names directly (line 160, 164)

gurobi section:
- Add lines to use supplied MIP start (x0). Current not used. (Test added in testSolveCobraMILP.m)

ibm_cplex section:
- Allow display to command window by supplying option logFile = 1. Currently no way to have output to command window. (Test added in testSolveCobraMILP.m)

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
