### PR TITLE
Making definitions independent of Statistics Toolbox

### DIFF
--- a/src/base/io/definitions/descFileRead.m
+++ b/src/base/io/definitions/descFileRead.m
@@ -1,0 +1,51 @@
+function raw = descFileRead(fileName)
+% This function provides the same raw output as tdfread from the 
+% statistics toolbox, making sure, that we don't need that as a
+% prerequesite
+%
+% USAGE:
+%
+%    [raw] = descFileRead(fileName)
+%
+% INPUT:
+%    fileName:             The filename of a tab delimited data file. The
+%                          first row of the file will be considered to be headers (with spaces
+%                          being replaced by '_'.
+%
+% OUTPUTS:
+%    raw:                  A struct with one field per header and a char
+%                          array of all data listed in the column.
+%
+% .. Author: - Thomas Pfau Oct 2017
+
+f = fopen(fileName);
+
+%Get the headers
+header = fgetl(f);
+headers = strrep(strsplit(header,'\t','CollapseDelimiters',false),' ','_');
+
+%Read the data
+cline = fgetl(f);
+%Initialize the data array.
+data = cell(2*length(headers),1);
+data(:) = {''};
+%Walk through the lines
+currentLine = 1;
+while cline ~= -1
+    %Keep empty entries.
+    cdata = strsplit(cline,'\t','CollapseDelimiters',false);
+    for i = 1:length(cdata)
+        cdataElem = cdata{i};
+        exData = data{2*i};
+        exData(currentLine,1:length(cdataElem)) = cdataElem;
+        data{2*i} = exData;
+    end
+    currentLine = currentLine + 1;
+    cline = fgetl(f);
+end
+%Distribute the headers.
+[data{1:2:end}] = deal(headers{:});
+
+raw = struct(data{:});
+    
+fclose(f);

--- a/src/base/io/utilities/getDefinedFieldProperties.m
+++ b/src/base/io/utilities/getDefinedFieldProperties.m
@@ -73,7 +73,7 @@ end
 if db
     if isempty(CBT_DB_FIELD_PROPS)
         fileName = which('COBRA_structure_fields.csv');
-        [raw] = tdfread(fileName);
+        [raw] = descFileRead(fileName);
 
         fields = fieldnames(raw);
         for i = 1:numel(fields)
@@ -103,7 +103,7 @@ end
 if desc
     if isempty(CBT_DESC_FIELD_PROPS)
         fileName = which('COBRA_structure_fields.csv');
-        [raw] = tdfread(fileName);
+        [raw] = descFileRead(fileName);
 
         fields = fieldnames(raw);
         for i = 1:numel(fields)
@@ -134,7 +134,7 @@ end
 
 if isempty(CBT_PROG_FIELD_PROPS)
      fileName = which('COBRA_structure_fields.csv');
-     [raw] = tdfread(fileName);
+     [raw] = descFileRead(fileName);
      
      fields = fieldnames(raw);
      for i = 1:numel(fields)


### PR DESCRIPTION
The code provided would change the field definition code to no longer use elements of the statistics toolbox (for some reason tdfread is part of that toolbox and not the basic matlab suite).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
