### PR TITLE
Fva speed up

### DIFF
--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -220,8 +220,8 @@ if  any(strcmp(PCT,{v.Name})) && license('test','Distrib_Computing_Toolbox')
 else
     PCT_status=0;  % Parallel Computing Toolbox not found.
 end
-minFlux = model.lb;
-maxFlux = model.ub;
+minFlux = model.lb(ismember(model.rxns,rxnNameList));
+maxFlux = model.ub(ismember(model.rxns,rxnNameList));
 if ~minNorm
     %We don't have to provide the solutions, so we can speed this up quiet
     %a bit.

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -245,9 +245,16 @@ QuickProblem = LPproblem;
 [Presence,Order] = ismember(rxnNameList,model.rxns);
 QuickProblem.c(:) = 0;
 QuickProblem.c(Order(Presence)) = 1;
+if ~allowLoops
+    QuickProblem = addLoopLawConstraints(QuickProblem,model,1:nRxns);
+end
 %Maximise all reactions
 QuickProblem.osense = -1;
-sol = solveCobraLP(QuickProblem);
+if ~allowLoops
+    sol = solveCobraMILP(QuickProblem);
+else
+    sol = solveCobraLP(QuickProblem);
+end
 relSol = sol.full(Order(Presence));
 %Obtain fluxes at their boundaries
 maxSolved = model.ub(Order(Presence)) == relSol;
@@ -259,7 +266,11 @@ end
 
 %Minimise reactions
 QuickProblem.osense = 1;
-sol = solveCobraLP(QuickProblem);
+if ~allowLoops
+    sol = solveCobraMILP(QuickProblem);
+else
+    sol = solveCobraLP(QuickProblem);
+end
 relSol = sol.full(Order(Presence));
 %Again obtain fluxes at their boundaries
 maxSolved = maxSolved | (model.ub(Order(Presence)) == relSol);

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -289,7 +289,7 @@ if ~PCT_status && (~exist('parpool') || poolsize == 0)  %aka nothing is active
         mins = -inf*ones(length(rxnListMin),1);
         LPproblem.osense = 1;
         for i = 1:length(rxnListMin)                        
-            [mins(i)] = calcSolForEntry(model,rxnListMin,i,LPproblem,0, method, allowLoops,printLevel,minNorm,cpxControl,preCompMinSols{i});
+            [mins(i)] = calcSolForEntry(model,rxnListMin,i,LPproblem,0, method, allowLoops,printLevel,minNorm,cpxControl,[]);
         end
         [minFluxPres,minFluxOrder] = ismember(rxnListMin,rxnNameList);
         minFlux(minFluxOrder(minFluxPres)) = mins;   
@@ -297,7 +297,7 @@ if ~PCT_status && (~exist('parpool') || poolsize == 0)  %aka nothing is active
         maxs = inf*ones(length(rxnListMax),1);
         LPproblem.osense = -1;
         for i = 1:length(rxnListMax)                        
-            [maxs(i)] = calcSolForEntry(model,rxnListMax,i,LPproblem,0, method, allowLoops,printLevel,minNorm,cpxControl,preCompMaxSols{i});
+            [maxs(i)] = calcSolForEntry(model,rxnListMax,i,LPproblem,0, method, allowLoops,printLevel,minNorm,cpxControl,[]);
         end
         [maxFluxPres,maxFluxOrder] = ismember(rxnListMax,rxnNameList);
         maxFlux(maxFluxOrder(maxFluxPres)) = maxs; 

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -230,14 +230,14 @@ if ~minNorm
     QuickProblem.c(:) = 0;
     QuickProblem.c(Order(Presence)) = 1;
     %Maximise all reactions
-    QuickProblem.osence = -1;    
+    QuickProblem.osense = -1;    
     sol = solveCobraLP(QuickProblem);
     relSol = sol.full(Order(Presence));
     %Obtain fluxes at their boundaries
     maxSolved = model.ub(Order(Presence)) == relSol;    
     minSolved = model.lb(Order(Presence)) == relSol;        
     %Minimise reactions
-    QuickProblem.osence = 1;
+    QuickProblem.osense = 1;
     sol = solveCobraLP(QuickProblem);
     relSol = sol.full(Order(Presence));
     %Again obtain fluxes at their boundaries

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -226,6 +226,7 @@ if  any(strcmp(PCT,{v.Name})) && license('test','Distrib_Computing_Toolbox')
 else
     PCT_status=0;  % Parallel Computing Toolbox not found.
 end
+
 minFlux = model.lb(ismember(model.rxns,rxnNameList));
 maxFlux = model.ub(ismember(model.rxns,rxnNameList));
 
@@ -299,7 +300,7 @@ else % parallel job.  pretty much does the same thing.
     lpsolver = CBT_LP_SOLVER;
     qpsolver = CBT_QP_SOLVER;
     if minNorm        
-        parfor i = 1:length(rxnNameList)
+        for i = 1:length(rxnNameList)
             changeCobraSolver(qpsolver,'QP',0,1);
             changeCobraSolver(lpsolver,'LP',0,1);
             parLPproblem = LPproblem;
@@ -339,12 +340,14 @@ end
 
 function [Flux,V] = calcSolForEntry(model,rxnNameList,i,LPproblem,parallelMode, method, allowLoops, printLevel, minNorm, cpxControl, sol)
 
+    %get Number of reactions
     nRxns = numel(model.rxns);
+    %Set the correct objective
+    LPproblem.c = double(ismember(model.rxns,rxnNameList{i}));
     if isempty(sol)
         if printLevel == 1 && ~parallelMode
             fprintf('iteration %d.\n', i);
         end
-        LPproblem.c = double(ismember(model.rxns,rxnNameList{i}));
         % do LP always
         if allowLoops
             LPsolution = solveCobraLP(LPproblem, cpxControl);

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -152,7 +152,7 @@ LPproblem.ub = model.ub;
 if ~isfield(model,'csense')
     LPproblem.csense(1:nMets,1) = 'E';
 else
-    LPproblem.csense = model.csense(1:nMets,1);
+    LPproblem.csense = model.csense(1:nMets);
 
     % print a warning message if the csense vector does not have the same length as the mets vector
     if length(model.mets) ~= length(model.csense)

--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -91,6 +91,12 @@ if isempty(rxnNameList)
     rxnNameList = model.rxns;
 end
 
+%Stop if there are reactions, which are not part of the model
+if any(~ismember(rxnNameList,model.rxns))
+    presence = ismember(rxnNameList,model.rxns);
+    error('There were reactions in the rxnList which are not part of the model:\n%s\n',strjoin(rxnNameList(~presence),'\n'));
+end
+
 % Set up the problem size
 [nMets,nRxns] = size(model.S);
 Vmin=[];

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -44,8 +44,9 @@ if myCluster.NumWorkers >= minWorkers
         % change the COBRA solver (LP)
         solverLPOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
         solverQPOK = changeCobraSolver(solverPkgs{k}, 'QP', 0);
+        solverMILPOK = changeCobraSolver(solverPkgs{k}, 'MILP', 0);
 
-        if solverLPOK && solverQPOK
+        if solverLPOK && solverQPOK && solverMILPOK
             fprintf('   Testing flux variability analysis using %s ... ', solverPkgs{k});
 
             rxnNames = {'PGI', 'PFK', 'FBP', 'FBA', 'TPI', 'GAPD', 'PGK', 'PGM', 'ENO', 'PYK', 'PPS', ...

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -31,6 +31,8 @@ load('testFVAData.mat');
 minWorkers = 2;
 myCluster = parcluster(parallel.defaultClusterProfile);
 
+loopToyModel = createToyModelForgapFind();
+
 if myCluster.NumWorkers >= minWorkers
     poolobj = gcp('nocreate');  % if no pool, do not create new one.
     if isempty(poolobj)
@@ -98,12 +100,30 @@ if myCluster.NumWorkers >= minWorkers
             end
 
             % output a success message
+            [minF,maxF] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
+            assert(maxF(2) == 0); %While R4 can carry a flux of 1000, it can't do so without a loop
+            assert(maxF(1) == 500); % Due to downstream reactions which have to carry "double" flux, this reaction can at most carry a flux of 500)
+            assert(minF(1)==5); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+            assert(minF(2)==0); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+            try
+                errored = false;
+                [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
+            catch ME
+                errored = true;
+            end
+            assert(errored);
+            [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0,'FBA');
+            assert(all(minSols(:,1) == maxSols(:,2))); %This is an odd assertion, but since the minimal solution for reaction 1 is the minimal solution of the system, 
+                                                  %it has to be the same as the maximal solution for the second tested
+                                                  %Reaction.
             fprintf('Done.\n');
         end
     end
 else
     warning(' > Skipping testFVA as the default parallel pool is not configured for more than 2 workers.');
 end
+
+
 
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -101,10 +101,10 @@ if myCluster.NumWorkers >= minWorkers
 
             % output a success message
             [minF,maxF] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
-            assert(maxF(2) == 0); %While R4 can carry a flux of 1000, it can't do so without a loop
-            assert(maxF(1) == 500); % Due to downstream reactions which have to carry "double" flux, this reaction can at most carry a flux of 500)
-            assert(minF(1)==5); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
-            assert(minF(2)==0); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+            assert(abs(maxF(2))< tol); %While R4 can carry a flux of 1000, it can't do so without a loop
+            assert(abs(maxF(1) -500) < tol); % Due to downstream reactions which have to carry "double" flux, this reaction can at most carry a flux of 500)
+            assert(abs(minF(1)-5) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+            assert(abs(minF(2)) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
             try
                 errored = false;
                 [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);


### PR DESCRIPTION
These changes improve speed (depending on the model size and the constraints on the model), by solving an initial optimization problem maximising/minimising all reactions that are checked.
All reactions which are at their upper or lower bound during maximisation need not be checked individually.
This speed up is however only useable when not requesting minimal flux distribution (i.e. 3rd and fourth output argument), as individual solutions are then required.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
