### PR TITLE
Corrected parsing of GPR Rules

### DIFF
--- a/src/base/io/utilities/readSBML.m
+++ b/src/base/io/utilities/readSBML.m
@@ -473,8 +473,7 @@ if sbmlIDFlag
     %Easy, if this is an SBML with an FBC constraint string
     grRule = strrep(grRule,' and ',' & ');
     grRule = strrep(grRule,' or ',' | ');
-    ruleGenes = unique(regexp(grRule,'[A-Za-z_]+[A-Za-z0-9_]*','match')); %we can restict to acceptable SBML SIds.
-    
+    ruleGenes = unique(regexp(grRule,'[A-Za-z_]+[A-Za-z0-9_]*','match')); %we can restict to acceptable SBML SIds.    
 else
     %We will remove empty parenthesis.
     grRule = regexprep(grRule,'^ *\( *\) *$','');
@@ -501,10 +500,20 @@ ruleGenes = unique(ruleGenes);
 %now, replace every gene by its position
 for i = 1:numel(ruleGenes)
     if pres(iPos(i))
-        grRule = regexprep(grRule,['([\(\) ]?)' regexptranslate('escape',ruleGenes{iPos(i)}) '([\(\) ]?)'],['$1x(' num2str(posDes(i)) ')$2']);
+        %We have to ensure, that this is really the gene and not just a
+        %substring. So, its either at the start or preceded by a
+        %separator or its at the end and preceded by a separator,
+        % or its on its own.
+        grRule = regexprep(grRule,['([\(\) ])' regexptranslate('escape',ruleGenes{iPos(i)}) '([\(\) ])'],['$1x(' num2str(posDes(i)) ')$2']);
+        grRule = regexprep(grRule,['^' regexptranslate('escape',ruleGenes{iPos(i)}) '([\( ])'],['x(' num2str(posDes(i)) ')$1']);
+        grRule = regexprep(grRule,['([\(\) ])' regexptranslate('escape',ruleGenes{iPos(i)}) '$'],['$1x(' num2str(posDes(i)) ')']);
+        grRule = regexprep(grRule,['^' regexptranslate('escape',ruleGenes{iPos(i)}) '$'],['x(' num2str(posDes(i)) ')']);
     else
         newGenes(end+1) = ruleGenes(iPos(i));
-        grRule = regexprep(grRule,['([\(\) ]?)' regexptranslate('escape',ruleGenes{iPos(i)}) '([\(\) ]?)'],['$1x(' num2str(numel(newGenes)) ')$2']);
+        grRule = regexprep(grRule,['([\(\) ])' regexptranslate('escape',ruleGenes{iPos(i)}) '([\(\) ])'],['$1x(' num2str(numel(newGenes)) ')$2']);
+        grRule = regexprep(grRule,['^' regexptranslate('escape',ruleGenes{iPos(i)}) '([\( ])'],['x(' num2str(numel(newGenes)) ')$1']);
+        grRule = regexprep(grRule,['([\(\) ])' regexptranslate('escape',ruleGenes{iPos(i)}) '$'],['$1x(' num2str(numel(newGenes)) ')']);
+        grRule = regexprep(grRule,['^' regexptranslate('escape',ruleGenes{iPos(i)}) '$'],['x(' num2str(numel(newGenes)) ')']);        
     end
 end
 

--- a/src/base/io/utilities/readSBML.m
+++ b/src/base/io/utilities/readSBML.m
@@ -220,7 +220,7 @@ end
 if isfield(sbmlReactions,'fbc_geneProductAssociation')
     gprAssoc = {sbmlReactions.fbc_geneProductAssociation};
     fbc_grRules = cellfun(@(x) getFBCAssoc(x) , gprAssoc,'UniformOutput',0);
-    model.rules = cellfun(@(x) extractGPRRule(x,model.genes,1),fbc_grRules','UniformOutput',0);
+    model.rules = cellfun(@(x) parseGPR(x,model.genes),fbc_grRules','UniformOutput',0);
 else
     %otherwise use the grRules extracted.
     model.rules = cell(numel(model.rxns),1);
@@ -229,7 +229,7 @@ else
         model.genes = {};
     end
     for i = 1:numel(grRule)
-        [rule,cgenes] = extractGPRRule(grRule{i},model.genes,0);
+        [rule,cgenes] = parseGPR(grRule{i},model.genes);
         model.genes = cgenes;
         model.rules{i} = rule;
         model.genes = columnVector(model.genes);
@@ -457,20 +457,6 @@ if ~isempty(prods)
     stoichiometry(pres) = prodstoichs(pos(pres));    
 end
 end
-
-
-%Convert a gprRule in String format to boolean format.
-function [rule,newGenes] = extractGPRRule(grRule,genes,sbmlIDFlag)
-%Copy the current genes;
-newGenes = genes;
-if isempty(grRule)
-    rule = '';
-    return
-end
-[rule,newGenes] = parseGPR(grRule,genes);
-end
-
-
 
 function rule = getFBCAssoc(fbc_gprAssoc)
 %extract the fbc_associations fbc_association field or return an empty

--- a/src/base/io/utilities/readSBML.m
+++ b/src/base/io/utilities/readSBML.m
@@ -467,6 +467,17 @@ if isempty(grRule)
     rule = '';
     return
 end
+%first, get all genes in this rule:
+tmp = regexprep(grRule,'\( *','('); %replace all spaces after opening parenthesis
+tmp = regexprep(tmp,' *\)',')'); %replace all spaces before closing paranthesis.
+tmp = regexprep(tmp, '([ \)]) *(?i)(and) *', '$1 & ');
+tmp = regexprep(tmp, ' * (?i)(or) *', ' | ');
+
+ruleGenes = unique(regexp(grRule,'([^\(\)\|\&\ ]+)','match'))
+
+convertGenes = @(x) sprintf('%d', find(strcmp(x, genes)));
+
+rules = regexprep(tmp, , 'x(${convertGenes($0)})'); 
 
 %Convert the grRule to a boolean rule
 if sbmlIDFlag

--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -1,0 +1,46 @@
+function [ruleString, totalGeneList,newGeneList] = parseGPR( grRuleString, currentGenes)
+% Convert a GPR rule in string format to a rule in logic format. 
+% We assume the following properties of GPR Rules:
+% 1. There are no genes called "and" or "or" (in any capitalization).
+% 2. A gene name does not contain any of the following characters:
+% (),{},[],|,& and no whitespace.
+% 3. The general format of a GPR is: Gene1 or Gene2 and (Gene3 or Gene4)
+% 4. 'and' and 'or' operators as well as gene names have to be followed and preceded by either a
+% whitespace character or a opening or closing bracket, respectively. Gene
+% Names can also be at the beginning or the end of the string.
+% 
+% 
+% USAGE:
+%
+%    [newGeneList,totalGeneList,ruleString] = generateRules(grRuleString,currentGenes)
+%
+% INPUT:
+%    grRuleString:     The rule string in textual format.
+%    currentGenes:     Names of all currently known genes. Encountered
+%                      genes (column cell Array of Strings)
+% OUTPUT:
+%    ruleString:       The logical formula representing the grRuleString.
+%                      Any position refers to the totalGeneList returned.
+%    totalGeneList:    The concatenation of currentGenes and newGeneList
+%    newGeneList:      A list of gene Names that were not present in
+%                      currentGenes
+%
+% .. Author: -  Thomas Pfau Okt 2017 
+
+
+tmp = regexprep(grRuleString,'([\(\{\[])\s*','$1'); %replace all spaces after opening parenthesis
+tmp = regexprep(tmp,'\s*([\]\}\)])','$1'); %replace all spaces before closing paranthesis.
+tmp = regexprep(tmp, '([\]\}\)]\s?|\s)\s*(?i)(and)\s*?(\s?[\[\{\(]|\s)\s*', '$1&$3'); %Replace all ands
+tmp = regexprep(tmp, '([\]\}\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\[\{\(]|\s)\s*', '$1|$3'); %replace all ors
+tmp = regexprep(tmp, '[\]\}]',')'); %replace other brackets by parenthesis.
+tmp = regexprep(tmp, '[\[\{]','('); %replace other brackets by parenthesis.
+
+%Now, genes are items which do not have brackets, operators or whitespace
+%characters
+genes = regexp(tmp,'([^\(\)\|\&\s]+)','match');
+%We have a new Gene List (which can be empty).
+newGeneList = columnVector(setdiff(genes,currentGenes));
+%So generate the new gene list.
+totalGeneList = [currentGenes;newGeneList];
+convertGenes = @(x) sprintf('x(%d)', find(ismember(totalGeneList,x)));
+ruleString = regexprep(tmp, '([^\(\)\|\&\s]+)', '${convertGenes($0)}');

--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -27,6 +27,15 @@ function [ruleString, totalGeneList,newGeneList] = parseGPR( grRuleString, curre
 %
 % .. Author: -  Thomas Pfau Okt 2017 
 
+if isempty(grRuleString) || ~isempty(regexp(grRuleString,'^[\s\(\{\[\}\]\)]*$')) 
+    %If the provided string is empty or consists only of whitespaces or
+    %brackets, i.e. it does not contain a rule
+    ruleString = '';
+    totalGeneList = currentGenes;
+    newGeneList = {};
+    return
+end
+    
 tmp = regexprep(grRuleString, '[\]\}]',')'); %replace other brackets by parenthesis.
 tmp = regexprep(tmp, '[\[\{]','('); %replace other brackets by parenthesis.
 tmp = regexprep(tmp,'([\(])\s*','$1'); %replace all spaces after opening parenthesis

--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -27,13 +27,12 @@ function [ruleString, totalGeneList,newGeneList] = parseGPR( grRuleString, curre
 %
 % .. Author: -  Thomas Pfau Okt 2017 
 
-
-tmp = regexprep(grRuleString,'([\(\{\[])\s*','$1'); %replace all spaces after opening parenthesis
-tmp = regexprep(tmp,'\s*([\]\}\)])','$1'); %replace all spaces before closing paranthesis.
-tmp = regexprep(tmp, '([\]\}\)]\s?|\s)\s*(?i)(and)\s*?(\s?[\[\{\(]|\s)\s*', '$1&$3'); %Replace all ands
-tmp = regexprep(tmp, '([\]\}\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\[\{\(]|\s)\s*', '$1|$3'); %replace all ors
 tmp = regexprep(tmp, '[\]\}]',')'); %replace other brackets by parenthesis.
 tmp = regexprep(tmp, '[\[\{]','('); %replace other brackets by parenthesis.
+tmp = regexprep(grRuleString,'([\(])\s*','$1'); %replace all spaces after opening parenthesis
+tmp = regexprep(tmp,'\s*([\)])','$1'); %replace all spaces before closing paranthesis.
+tmp = regexprep(tmp, '([\)]\s?|\s)\s*(?i)(and)\s*?(\s?[\(]|\s)\s*', '$1&$3'); %Replace all ands
+tmp = regexprep(tmp, '([\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\(]|\s)\s*', '$1|$3'); %replace all ors
 
 %Now, genes are items which do not have brackets, operators or whitespace
 %characters

--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -27,9 +27,9 @@ function [ruleString, totalGeneList,newGeneList] = parseGPR( grRuleString, curre
 %
 % .. Author: -  Thomas Pfau Okt 2017 
 
-tmp = regexprep(tmp, '[\]\}]',')'); %replace other brackets by parenthesis.
+tmp = regexprep(grRuleString, '[\]\}]',')'); %replace other brackets by parenthesis.
 tmp = regexprep(tmp, '[\[\{]','('); %replace other brackets by parenthesis.
-tmp = regexprep(grRuleString,'([\(])\s*','$1'); %replace all spaces after opening parenthesis
+tmp = regexprep(tmp,'([\(])\s*','$1'); %replace all spaces after opening parenthesis
 tmp = regexprep(tmp,'\s*([\)])','$1'); %replace all spaces before closing paranthesis.
 tmp = regexprep(tmp, '([\)]\s?|\s)\s*(?i)(and)\s*?(\s?[\(]|\s)\s*', '$1&$3'); %Replace all ands
 tmp = regexprep(tmp, '([\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\(]|\s)\s*', '$1|$3'); %replace all ors

--- a/src/reconstruction/refinement/changeGeneAssociation.m
+++ b/src/reconstruction/refinement/changeGeneAssociation.m
@@ -54,15 +54,15 @@ model.rules{rxnID,1} = '';
 if addRxnGeneMat ==1 
     model.rxnGeneMat(rxnID,1:nGenes) = zeros(1,nGenes);
 end  
-    
+
 [rule,~,newGenes] = parseGPR(grRule,model.genes);
 if translateNamesFlag
     [pres,pos] = ismember(newGenes,geneNameList);
     newGenes = columnVector(systNameList(pres(pos)));
-end   
-    
+end
 model.genes = [model.genes;newGenes];
 model.rules{rxnID,1} = rule;
+
 getGene = @(x) model.genes{str2num(x)};
 if addRxnGeneMat
     res = regexp(model.rules{rxnID},'x\((?<ID>[0-9]+)\)','names');

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -18,17 +18,16 @@ function [model2] = generateRules(model)
 
 grRules = model.grRules;
 genes = model.genes;
-convertGenes = @(x) sprintf('x(%d)', find(strcmp(x, genes)));
 model2 = model;
 
 for i = 1:length(grRules)
     if~isempty(grRules{i})
-        tmp = regexprep(grRules{i},'\( *','('); %replace all spaces after opening parenthesis
-        tmp = regexprep(tmp,' *\)',')'); %replace all spaces before closing paranthesis.
-        tmp = regexprep(tmp, ' * (?i)(and) *', ' & ');
-        tmp = regexprep(tmp, ' * (?i)(or) *', ' | ');
-        rules = regexprep(tmp, '([^\(\)\|\&\ ]+)', '${convertGenes($0)}');
-        model2.rules{i,1} = rules;
+        [rule,~,newGenes] = parseGPR(model2.grRules{i},model2.genes);
+        if ~isempty(newGenes)
+            warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
+            model2.genes = [model2.genes ; newGenes];
+        end
+        model2.rules{i,1} = rule;
     else
         model2.rules{i,1} = model.grRules{i};
     end

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -21,16 +21,12 @@ genes = model.genes;
 model2 = model;
 
 for i = 1:length(grRules)
-    if~isempty(grRules{i})
-        [rule,~,newGenes] = parseGPR(model2.grRules{i},model2.genes);
-        if ~isempty(newGenes)
-            warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
-            model2.genes = [model2.genes ; newGenes];
-        end
-        model2.rules{i,1} = rule;
-    else
-        model2.rules{i,1} = model.grRules{i};
+    [rule,~,newGenes] = parseGPR(model2.grRules{i},model2.genes);
+    if ~isempty(newGenes)
+        warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
+        model2.genes = [model2.genes ; newGenes];
     end
+    model2.rules{i,1} = rule;
 end
 end
 

--- a/src/reconstruction/refinement/removeUnusedGenes.m
+++ b/src/reconstruction/refinement/removeUnusedGenes.m
@@ -19,17 +19,13 @@ function modelNew = removeUnusedGenes(model)
 
 modelNew=model;
 if ~isfield(model,'genes')
-    %This is VERY odd and should not happen, but lets see    
-    grRules = model.grRules;
-    grRules = grRules(~cellfun(@isempty,grRules));
-    genes = regexprep(grRules, {'and', 'AND', 'or', 'OR', '(', ')'}, '');
-    genes = splitString(genes, ' ');
-    genes = [genes{:}]';
-    genes = unique(genes(cellfun('isclass', genes, 'char')));    
-    %Now, we created the genes field, so lets build the rules field as
-    %well.
-    modelNew.genes = genes(~cellfun('isempty', genes));  % Not sure this is necessary anymore, but it won't hurt.
+    %This is VERY odd and should not happen, but lets see            
+    modelNew.genes = {};
+    warning('Model did not contain a genes field. Building it along with the rules field');
+    res = warning();
+    warning('off','all')
     modelNew = generateRules(modelNew);   
+    warning(res)
 end
 
 


### PR DESCRIPTION
This PR partially addresses #852 
GPR rules in old style cobra format could sometimes be parsed in the wrong way, as gene names that were prefixes of other gene names could lead to wrong replacements when generating rules. 
This has been fixed here, by ensuring, that only "full" IDs are replaced.

To keep the parsing consistent over different functions, I introduced a parseGPR function, that is now used over multiple different functions.  

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
