### PR TITLE
Fix for metabolites not present in the model

### DIFF
--- a/src/reconstruction/refinement/addExchangeRxn.m
+++ b/src/reconstruction/refinement/addExchangeRxn.m
@@ -33,7 +33,7 @@ AddedExchRxn = '';
 % check duplicate here to save time (avoid checking duplicate by calling ismember in addReaction)
 metOrd = findMetIDs(newModel, metList);  % met Id for metList
 % duplicate if there are exchange reactions with -1 stoichiometry involving any mets in metList
-duplicate = find(sum(newModel.S ~= 0, 1) == 1 & any(newModel.S == -1, 1) & any(newModel.S(metOrd, :), 1));
+duplicate = find(sum(newModel.S ~= 0, 1) == 1 & any(newModel.S == -1, 1) & any(newModel.S(metOrd(metOrd~=0), :), 1));
 if ~isempty(duplicate)
     % metWtExchRxn(j) is the met order already having exchange rxns duplicate(j) 
     [metWtExchRxn, ~] = find(newModel.S(:, duplicate));


### PR DESCRIPTION
Metabolites not yet in the model caused an error, while previous versions allowed this.
Fixed to only consider present metabolites for duplicate checking restoring the previous functionality.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
