### PR TITLE
CreateModel did not correctly check for defaults being used.

### DIFF
--- a/src/reconstruction/refinement/createModel.m
+++ b/src/reconstruction/refinement/createModel.m
@@ -131,8 +131,8 @@ for i = 1 : nRxns
        end
     end
     [metaboliteList,stoichCoeffList,revFlag_i] = parseRxnFormula(rxnList{i});
-    if  ~any(ismember('lowerBoundList',parser.UsingDefaults))
-        if ~any(ismember('revFlagList',parser.UsingDefaults))
+    if  any(ismember('lowerBoundList',parser.UsingDefaults))
+        if any(ismember('revFlagList',parser.UsingDefaults))
             %if both revFlag and lb are not given, update the revFlag
             %implied by the rxn formula
             revFlagList(i) = revFlag_i;


### PR DESCRIPTION
Bugfix for createModel. The formula parsing did not correctly check for defaults being used and thus did not infer the directionality of formulas correctly.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
