### PR TITLE
printLevel = 0 for fastFVA

### DIFF
--- a/external/fastFVAmex/cplexFVA.c
+++ b/external/fastFVAmex/cplexFVA.c
@@ -869,12 +869,12 @@ void mexFunction(int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
 
     mxArray         *STATUSSOLMAX = NULL;
     double          *statussolmax = NULL;
-    
+
     /*mxArray         *PRINTLEVEL = NULL;
     int             *printLevel = NULL;
     */
     int             printLevel = 0;
-    
+
     /* numThread_IN*/
     int             numThread = 0;
     char            numThreadstr[MAX_STR_LENGTH];
@@ -1070,17 +1070,17 @@ void mexFunction(int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
     nrxn          = mxGetM(RXNS_IN);
     rxnsOptMode   = mxGetPr(RXNS_OPTMODE_IN);
     printLevel    = mxGetScalar(PRINTLEVEL_IN);
-    
+
     if (printLevel > 0) {
       mexPrintf(" >> The number of reactions retrieved is %d\n", nrxn);
     }
-    
+
     /* Retrieve the number of the thread */
     numThread     = mxGetScalar(NUM_THREAD_IN);
 
     /* Retrieve the location of log files */
     logFileDir = mxArrayToString(prhs[LOGFILE_DIR_IN]);
-    
+
     if (printLevel > 0) {
       mexPrintf(" >> Log files will be stored at %s\n", logFileDir);
     }
@@ -1140,7 +1140,7 @@ void mexFunction(int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
     if (printLevel > 0) {
       mexPrintf(" -- Start time:     %s", c_time_string);
     }
-    
+
     /* Create a log file. */
     if (opt_logfile){
        	/*
@@ -1155,7 +1155,7 @@ void mexFunction(int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
         if (printLevel > 0) {
           mexPrintf(" >> #Task.ID = %s; logfile: %s\n", numThreadstr, concat3("cplexint_logfile_", numThreadstr,".log"));
         }
-        
+
         LogFile = CPXfopen(concat3(logFileName, numThreadstr,".log"), "w");
 
        if (LogFile == NULL) {
@@ -1425,7 +1425,7 @@ void mexFunction(int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
     if (c_time_string == NULL) {
         TROUBLE_mexErrMsgTxt("Failure to convert the current time.\n");
     }
-    
+
     if (printLevel > 0) {
       mexPrintf(" -- End time:     %s", c_time_string);
     }

--- a/external/fastFVAmex/generateMexFastFVA.m
+++ b/external/fastFVAmex/generateMexFastFVA.m
@@ -31,7 +31,7 @@ end
 compatibleStatus = isCompatible('ibm_cplex', 1);
 
 if compatibleStatus ~= 1
-    warning('As the ibm_cplex interface, the generated MEX file might not be compatible.');
+    warning('As the ibm_cplex interface is not compatible, the generated MEX file might not be compatible.');
 end
 
 if nargin < 1 || isempty(rootPathCPLEX)

--- a/src/analysis/FVA/fastFVA/fastFVA.m
+++ b/src/analysis/FVA/fastFVA/fastFVA.m
@@ -119,7 +119,7 @@ currentDir = pwd;
 cd(CBTDIR);
 
 % determine the printLevel
-if (nargin < 9 || isempty(printLevel))
+if (nargin < 10 || isempty(printLevel))
     printLevel = 1;
 end
 

--- a/test/verifiedTests/analysis/testFVA/testFastFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFastFVA.m
@@ -193,13 +193,15 @@ load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_m
 
     % test distribution strategies
     for strategy = 0:2
-        rxnsList = model.rxns(1:20);
+        for printLevel = 0:1
+            rxnsList = model.rxns(1:20);
 
-        % determine the reaction IDs
-        rxnsIDlist = findRxnIDs(model, rxnsList);
-        [minFluxT, maxFluxT] = fastFVA(model, optPercentage, objective, solverName, rxnsList, matrixAS, [], strategy);
-        assert(norm(minFluxT(rxnsIDlist) - minFluxTref(rxnsIDlist)) < tol);
-        assert(norm(maxFluxT(rxnsIDlist) - maxFluxTref(rxnsIDlist)) < tol);
+            % determine the reaction IDs
+            rxnsIDlist = findRxnIDs(model, rxnsList);
+            [minFluxT, maxFluxT] = fastFVA(model, optPercentage, objective, solverName, rxnsList, matrixAS, [], strategy, [], printLevel);
+            assert(norm(minFluxT(rxnsIDlist) - minFluxTref(rxnsIDlist)) < tol);
+            assert(norm(maxFluxT(rxnsIDlist) - maxFluxTref(rxnsIDlist)) < tol);
+        end
     end
 
     % define the reaction list


### PR DESCRIPTION
printLevel = 0 was added for fastFVA for not printing in the command window

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*

cc: @laurentheirendt - generate the new MEX files for different OS
