### PR TITLE
Ensure tests are reading supplied models.

### DIFF
--- a/docs/source/guides/testGuide.md
+++ b/docs/source/guides/testGuide.md
@@ -37,11 +37,12 @@ The test succeeds if the argument of `assert()` yields a `true` logical conditio
 If you want to test whether your `function1` correctly throws an **error** message, you can test as follows:
 ````Matlab
 % Case 5: test with 2 input and 1 output arguments (2nd input argument is of wrong dimension)
-try
-    output1 = function1(input1, input2');
-catch ME
-    assert(length(ME.message) > 0)
-end
+% There are two options. If a particular error message is to be tested (here, 'Input2 has the wrong dimension'):
+assert(verifyCobraFunctionError(@() function1(input1,input2'),'Input2 has the wrong dimension'));
+
+% If the aim is to test, that the function throws an error at all
+    assert(verifyCobraFunctionError(@() function1(input1,input2')));
+
 ````
 
 If you want to test whether your `function1` correctly throws a **warning** message, you can test as follows:

--- a/docs/source/guides/testTemplate.m
+++ b/docs/source/guides/testTemplate.m
@@ -22,17 +22,31 @@ tol = 1e-8;
 solverPkgs = {'tomlab_cplex', 'glpk', 'gurobi6'};
 
 % load the model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'testModel.mat'], 'model');
+%Either:
+model = getDistributedModel('ecoli_core_model.mat'); %For all models in the test/models folder and subfolders
+%or
+model = readCbModel('testModel.mat','modelName','NameOfTheModelStruct'); %For all models which are part of this particular test.
+
+%Load reference data
 load('testData_functionToBeTested.mat');
 
 %{
 % This is only necessary for tests that test a function that runs in parallel.
 % create a parallel pool
-
-poolobj = gcp('nocreate'); % if no pool, do not create new one.
-if isempty(poolobj)
-    parpool(2); % launch 2 workers
+% This is in try/catch as otherwise the test will error if no parallel
+% toolbox is installed.
+try
+    parTest = true;
+    poolobj = gcp('nocreate'); % if no pool, do not create new one.
+    if isempty(poolobj)
+        parpool(2); % launch 2 workers
+    end
+catch
+    parTest = false;
+    disp('Some info whether the test is not run if no parallel toolbox is present')
 end
+if parTest 
+% if paralell toolbox has to be present (if not, this can be left out).
 %}
 
 for k = 1:length(solverPkgs)
@@ -43,7 +57,7 @@ for k = 1:length(solverPkgs)
     if solverLPOK
         % <your test goes here>
     end
-
+    verifyCobraFunctionError(@() testFile(wrongInput));
     % output a success message
     fprintf('Done.\n');
 end

--- a/docs/source/guides/testTemplate.m
+++ b/docs/source/guides/testTemplate.m
@@ -41,12 +41,12 @@ try
     if isempty(poolobj)
         parpool(2); % launch 2 workers
     end
-catch
+catch ME
     parTest = false;
-    disp('Some info whether the test is not run if no parallel toolbox is present')
+    fprintf('No Parallel Toolbox found. TRying test without Parallel toolbox.\n')
 end
 if parTest 
-% if paralell toolbox has to be present (if not, this can be left out).
+% if parallel toolbox has to be present (if not, this can be left out).
 %}
 
 for k = 1:length(solverPkgs)

--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -250,7 +250,8 @@ function initCobraToolbox()
     end
 
     % define xml test file
-    xmlTestFile = strcat([CBTDIR, filesep, 'test', filesep, 'models', filesep, 'Ec_iAF1260_flux1.xml']);
+    xmlTestModel = 'Ec_iAF1260_flux1.xml';
+    xmlTestFile = [getDistributedModelFolder(xmlTestModel) filesep xmlTestModel];
 
     % save the userpath
     originalUserPath = path;

--- a/src/analysis/parsimoniousFBA/pFBA.m
+++ b/src/analysis/parsimoniousFBA/pFBA.m
@@ -239,23 +239,24 @@ function [ MinimizedFlux modelIrrev]= minimizeModelFlux_local(model,GeneOption)
     if nargin==1
         GeneOption=0;
     end
-
-    if GeneOption==0, % signal that you want to minimize the sum of all gene and non-gene associated fluxes
-        modelIrrev.S(end+1,:) = ones(size(modelIrrev.S(1,:)));
-    elseif GeneOption==1, % signal that you want to minimize the sum of only gene-associated fluxes
+    
+    %Add the metabolite
+    modelIrrev = addMetabolite(modelIrrev,'fluxMeasure');
+    %Then set all the Stoichiometric entries.
+    
+    if GeneOption==0 % signal that you want to minimize the sum of all gene and non-gene associated fluxes        
+        modelIrrev.S(end,:) = ones(size(modelIrrev.S(1,:)));
+    elseif GeneOption==1 % signal that you want to minimize the sum of only gene-associated fluxes
         %find all reactions which are gene associated
         Ind=find(sum(modelIrrev.rxnGeneMat,2)>0);
-        modelIrrev.S(end+1,:) = zeros(size(modelIrrev.S(1,:)));
+        modelIrrev.S(end,:) = zeros(size(modelIrrev.S(1,:)));
         modelIrrev.S(end,Ind) = 1;
-    elseif GeneOption==2, % signal that you want to minimize the sum of only NON gene-associated fluxes
+    elseif GeneOption==2 % signal that you want to minimize the sum of only NON gene-associated fluxes
         %find all reactions which are gene associated
         Ind=find(sum(modelIrrev.rxnGeneMat,2)==0);
-        modelIrrev.S(end+1,:) = zeros(size(modelIrrev.S(1,:)));
+        modelIrrev.S(end,:) = zeros(size(modelIrrev.S(1,:)));
         modelIrrev.S(end,Ind) = 1;
-    end
-
-    modelIrrev.b(end+1) = 0;
-    modelIrrev.mets{end+1} = 'fluxMeasure';
+    end   
 
     % add a pseudo reaction that measures the flux through the network
     modelIrrev = addReaction(modelIrrev,'netFlux',{'fluxMeasure'},[-1],false,0,inf,0,'','');

--- a/src/base/io/readCbModel.m
+++ b/src/base/io/readCbModel.m
@@ -351,6 +351,21 @@ for i = 1:numel(structFields)
                         models{end, 2} = structFields{i};
                         models{end, 3} = true;
                     end
+                else
+                    %There were no missing fields, but something else was
+                    %wrong. lets try to correct it. 
+                    cfield = convertOldStyleModel(cfield,0);
+                                        % if we reach this place, the conversion worked,
+                    % so lets try the test again.
+                    res = verifyModel(cfield, 'silentCheck', true);
+                    if ~isfield(res, 'Errors')
+                        if ~isfield(cfield,'modelID')
+                            cfield.modelID = structFields{i};
+                        end
+                        models{end + 1, 1} = cfield;
+                        models{end, 2} = structFields{i};
+                        models{end, 3} = true;
+                    end
                 end
             end
         catch ME

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -215,3 +215,9 @@ end
 for i = 1:numel(warnstate)
     warning(warnstate(i).state,warnstate(i).identifier)
 end
+
+%check rxnGeneMat. If there are no genes set rxnGeneMat to the correct
+%dimensions.
+if size(model.rxnGeneMat,2) ~= size(model.genes,1) && size(model.genes,1) == 0
+    model.rxnGeneMat = false(size(model.rxns,1),0);
+end

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -223,3 +223,8 @@ if isfield(model,'rxnGeneMat') && isfield(model,'genes')
         model.rxnGeneMat = false(size(model.rxns,1),0);
     end
 end
+
+%Create b field if missing
+if isfield(model,'S') && isfield(model,'mets') && ~isfield(model,'b')
+    model.b = zeros(size(model.mets));
+end

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -228,3 +228,8 @@ end
 if isfield(model,'S') && isfield(model,'mets') && ~isfield(model,'b')
     model.b = zeros(size(model.mets));
 end
+
+%Also, comps could currently be a char array if it is, convert it
+if isfield(model,'comps') && ischar(model.comps)
+    model.comps = columnVector(arrayfun(@(x) {x},model.comps));
+end

--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -218,6 +218,8 @@ end
 
 %check rxnGeneMat. If there are no genes set rxnGeneMat to the correct
 %dimensions.
-if size(model.rxnGeneMat,2) ~= size(model.genes,1) && size(model.genes,1) == 0
-    model.rxnGeneMat = false(size(model.rxns,1),0);
+if isfield(model,'rxnGeneMat') && isfield(model,'genes')
+    if size(model.rxnGeneMat,2) ~= size(model.genes,1) && size(model.genes,1) == 0
+        model.rxnGeneMat = false(size(model.rxns,1),0);
+    end
 end

--- a/src/base/io/utilities/getDistributedModel.m
+++ b/src/base/io/utilities/getDistributedModel.m
@@ -1,0 +1,37 @@
+function  model = getDistributedModel(modelName) 
+% Loads the indicated model from the models submodule.
+%
+% USAGE:
+%
+%    model = getDistributedModel(modelName) 
+%
+% INPUT:
+%    modelName:         The name of the model including the file extension
+%
+% OUTPUTS:
+%    model:             The loaded model from the models submodule (i.e.
+%                       those distributed for the test suite)
+% 
+
+global CBTDIR
+global ENV_VARS
+
+if isempty(CBTDIR)
+    ENV_VARS.printLevel = false;
+    initCobraToolbox;
+    ENV_VARS.printLevel = true;
+end
+
+modelDir = [CBTDIR filesep 'test' filesep 'models'];
+
+[~,~,extension] = fileparts(modelName);
+if strcmp(extension,'.mat')
+    modelDir = [modelDir filesep 'mat'];
+elseif strcmp(extension,'.xml')
+    modelDir = [modelDir filesep 'xml'];
+end
+if exist([modelDir filesep modelName], 'file')
+    model = readCbModel([modelDir filesep modelName]);
+else    
+    error('Requested Model not present in the Model directory.\n This is either due to the model not being downloaded, or not being part of the distributed models.')
+end

--- a/src/base/io/utilities/getDistributedModel.m
+++ b/src/base/io/utilities/getDistributedModel.m
@@ -1,4 +1,4 @@
-function  model = getDistributedModel(modelName) 
+function  model = getDistributedModel(modelName, description) 
 % Loads the indicated model from the models submodule.
 %
 % USAGE:
@@ -7,6 +7,10 @@ function  model = getDistributedModel(modelName)
 %
 % INPUT:
 %    modelName:         The name of the model including the file extension
+%    
+% OPTIONAL INPUTS:
+%    description:       If the model description should be set to a
+%                       specific value
 %
 % OUTPUTS:
 %    model:             The loaded model from the models submodule (i.e.
@@ -22,16 +26,14 @@ if isempty(CBTDIR)
     ENV_VARS.printLevel = true;
 end
 
-modelDir = [CBTDIR filesep 'test' filesep 'models'];
-
-[~,~,extension] = fileparts(modelName);
-if strcmp(extension,'.mat')
-    modelDir = [modelDir filesep 'mat'];
-elseif strcmp(extension,'.xml')
-    modelDir = [modelDir filesep 'xml'];
+if ~exist('description','var')
+    description = modelName;
 end
+
+modelDir = getDistributedModelFolder(modelName);
+
 if exist([modelDir filesep modelName], 'file')
-    model = readCbModel([modelDir filesep modelName]);
+    model = readCbModel([modelDir filesep modelName],'modelDescription',description);
 else    
     error('Requested Model not present in the Model directory.\n This is either due to the model not being downloaded, or not being part of the distributed models.')
 end

--- a/src/base/io/utilities/getDistributedModelFolder.m
+++ b/src/base/io/utilities/getDistributedModelFolder.m
@@ -1,0 +1,33 @@
+function  modelDir = getDistributedModelFolder(modelName) 
+% Identifies the folder a model is to be searched in.
+%
+% USAGE:
+%
+%    modelDir = getDistributedModelFolder(modelName) 
+%
+% INPUT:
+%    modelName:         The name of the model including the file extension
+%    
+%
+% OUTPUTS:
+%    modelDir:          The folder the model should eb located in.
+% 
+
+global CBTDIR
+if isempty(CBTDIR)
+    error('The Toolbox is not initialized. Cannot identfy the Model folder.\nPlease run initCobraToolbox() and try again');
+end
+
+modelDir = [CBTDIR filesep 'test' filesep 'models'];
+
+[~,~,extension] = fileparts(modelName);
+if strcmp(extension,'.mat')
+    modelDir = [modelDir filesep 'mat'];
+elseif strcmp(extension,'.xml')
+    modelDir = [modelDir filesep 'xml'];
+end
+if exist([modelDir filesep modelName], 'file')
+    return
+else    
+    error('Requested Model not present in the model directory.\n This is either due to the model not being downloaded, or not being part of the distributed models.')
+end

--- a/src/base/io/utilities/getDistributedModelFolder.m
+++ b/src/base/io/utilities/getDistributedModelFolder.m
@@ -1,5 +1,6 @@
 function  modelDir = getDistributedModelFolder(modelName) 
-% Identifies the folder a model is to be searched in.
+% Identifies the folder a distributed model is located in.
+% This function only works with models which are part of the models 
 %
 % USAGE:
 %
@@ -10,12 +11,15 @@ function  modelDir = getDistributedModelFolder(modelName)
 %    
 %
 % OUTPUTS:
-%    modelDir:          The folder the model should eb located in.
+%    modelDir:          The folder the model should be located in.
 % 
 
 global CBTDIR
-if isempty(CBTDIR)
-    error('The Toolbox is not initialized. Cannot identfy the Model folder.\nPlease run initCobraToolbox() and try again');
+global ENV_VARS
+if isempty(CBTDIR)    
+    ENV_VARS.printLevel = false;
+    initCobraToolbox;
+    ENV_VARS.printLevel = true;    
 end
 
 modelDir = [CBTDIR filesep 'test' filesep 'models'];

--- a/src/base/io/utilities/outputNetworkCytoscape.m
+++ b/src/base/io/utilities/outputNetworkCytoscape.m
@@ -119,7 +119,7 @@ for i = 1:length(rxnList)
     fprintf(fidNodeType,'%s = rxn\n',model.rxns{rxnNo});
     % Subsystems
     if (isfield(model,'subSystems'))
-        fprintf(fidSubSys,'%s = %s\n',model.rxns{rxnNo},model.subSystems{rxnNo});
+        fprintf(fidSubSys,'%s = %s\n',model.rxns{rxnNo},strjoin(model.subSystems{rxnNo},';'));
     end
     % Gene-reaction associations
     if (isfield(model,'genes'))

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -68,7 +68,7 @@ else
 end
 
 optParamNames = {'printLevel','saveInput'};
-parameters = '';
+parameters = struct();
 if nargin ~=1
     if mod(length(varargin),2)==0
         for i=1:2:length(varargin)-1

--- a/src/reconstruction/modelGeneration/modelVerification/verifyModel.m
+++ b/src/reconstruction/modelGeneration/modelVerification/verifyModel.m
@@ -384,7 +384,15 @@ for i = 1:numel(presentFields)
     checkY = ~isnan(yFieldMatch);
     if checkX
         if ischar(xFieldMatch)
-            x_pres = numel(model.(xFieldMatch));
+            if ~isfield(model,xFieldMatch)
+                x_pres = 0;
+                if ~isfield(results.Errors,'missingFields')
+                    results.Errors.missingFields = {};
+                end
+                results.Errors.missingFields(end+1) = {xFieldMatch};
+            else
+                x_pres = numel(model.(xFieldMatch));
+            end
         elseif isnumeric(xFieldMatch)
             x_pres = xFieldMatch;
         end
@@ -397,7 +405,15 @@ for i = 1:numel(presentFields)
     end
     if checkY
         if ischar(yFieldMatch)
-            y_pres = numel(model.(yFieldMatch));
+            if ~isfield(model,yFieldMatch)
+                y_pres = 0;
+                if ~isfield(results.Errors,'missingFields')
+                    results.Errors.missingFields = {};
+                end
+                results.Errors.missingFields(end+1) = {yFieldMatch};
+            else
+                y_pres = numel(model.(yFieldMatch));
+            end
         elseif isnumeric(yFieldMatch)
             y_pres = yFieldMatch;
         end

--- a/src/reconstruction/rBioNet/inc/model2data.m
+++ b/src/reconstruction/rBioNet/inc/model2data.m
@@ -49,7 +49,7 @@ if ~isfield(model,'grRules')
     model = creategrRulesField(model);
 end
 
-Mandatory = {'rxns','rxnNames', 'rev','grRules', 'lb', 'ub','S','genes'};
+Mandatory = {'rxns','rxnNames','grRules', 'lb', 'ub','S','genes'};
 %Opt numbers: CS = 1, subsystem = 2, citations = 3, comments = 4, ecNumbers = 5,
 % rxnKEGGID = 6, description = 7
 
@@ -116,7 +116,7 @@ for i = 1:length(Optional)
         if ismember('subSystems',names)
             Optional{i} = 'subSystems';
             if ~ischar([handles.model.subSystems{:}])
-                handles.model.subSystems = cellfun(@(x) strjoin(x,';'),handles.model.subSystems);
+                handles.model.subSystems = cellfun(@(x) strjoin(x,';'),handles.model.subSystems,'UniformOutput',0);
             end
             continue;
         end

--- a/test/verifiedTests/analysis/testComputeFluxSplits/testcomputeFluxSplits.m
+++ b/test/verifiedTests/analysis/testComputeFluxSplits/testcomputeFluxSplits.m
@@ -21,8 +21,7 @@ global CBTDIR
 solverPkgs = {'gurobi6', 'tomlab_cplex', 'glpk'};
 
 % load the model 
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'Recon2.0model.mat'])
-model = Recon2model;
+model = getDistributedModel('Recon2.0model.mat');
 
 % define the metabolites of interest
 mets = {'atp[c]','atp[m]', 'atp[e]'};

--- a/test/verifiedTests/analysis/testDeletionStudy/testDeletionStudy.m
+++ b/test/verifiedTests/analysis/testDeletionStudy/testDeletionStudy.m
@@ -24,7 +24,7 @@ cd(fileDir);
 tol = 1e-6;
 
 %load model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % list of solver packages
 solverPkgs = {'tomlab_cplex', 'gurobi6', 'glpk'};

--- a/test/verifiedTests/analysis/testDynamicFBA/testDynamicFBA.m
+++ b/test/verifiedTests/analysis/testDynamicFBA/testDynamicFBA.m
@@ -15,7 +15,8 @@ currentDir = pwd;
 fileDir = fileparts(which('testDynamicFBA'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
+
 load('testData_dynamicFBA.mat');
 
 smi = {'EX_glc(e)' 'EX_ac(e)'}; % exchange reaction for substrate in environment

--- a/test/verifiedTests/analysis/testExploration/testFindRxnsFromGenes.m
+++ b/test/verifiedTests/analysis/testExploration/testFindRxnsFromGenes.m
@@ -17,7 +17,7 @@ fileDir = fileparts(which('testFindRxnsFromGenes'));
 cd(fileDir);
 
 % load model
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 % convert to new style model
 model = convertOldStyleModel(model);

--- a/test/verifiedTests/analysis/testFASTCORE/testFASTCC.m
+++ b/test/verifiedTests/analysis/testFASTCORE/testFASTCC.m
@@ -17,8 +17,7 @@ fileDir = fileparts(which('testFASTCC'));
 cd(fileDir);
 
 %load a model
-load('FastCoreTest.mat')
-model=modelR204;
+model = readCbModel('FastCoreTest.mat','modelName','modelR204');
 
 %randomly pick some reactions
 epsilon = 1e-4;

--- a/test/verifiedTests/analysis/testFASTCORE/testFASTCORE.m
+++ b/test/verifiedTests/analysis/testFASTCORE/testFASTCORE.m
@@ -22,8 +22,8 @@ cd(fileDir);
 solverPkgs = {'ibm_cplex', 'gurobi', 'tomlab_cplex'};
 
 %load a model
-load('FastCoreTest.mat')
-model=ConsistentRecon2;
+model = readCbModel('FastCoreTest.mat','modelName','ConsistentRecon2');
+load('FastCoreTest.mat','coreInd');
 
 k = 1;
 while k < length(solverPkgs)+1 % note: only run with 1 solver, not with all 3

--- a/test/verifiedTests/analysis/testFEA/testFEA.m
+++ b/test/verifiedTests/analysis/testFEA/testFEA.m
@@ -28,7 +28,7 @@ cd(fileDir);
 
 % load the model and reference data
 load('testDataFEA.mat');
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % run FEA
 resultCellFtest = FEA(model, 1:10, 'subSystems');

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -24,7 +24,7 @@ tol = 1e-4;
 solverPkgs = {'tomlab_cplex', 'gurobi'};
 
 % load the model
-load('Ec_iJR904.mat', 'model');
+model = readCbModel('Ec_iJR904.mat');
 load('testFVAData.mat');
 
 % create a parallel pool

--- a/test/verifiedTests/analysis/testFVA/testFastFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFastFVA.m
@@ -34,7 +34,7 @@ nworkers = 2;
 solverName = 'ibm_cplex';
 
 % load the E.coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 if changeCobraSolver(solverName, 'LP', 0)
 
@@ -99,7 +99,7 @@ if changeCobraSolver(solverName, 'LP', 0)
     assert(optsol == referenceToyResults.optsol);
 
     % load the E.coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+    model = getDistributedModel('ecoli_core_model.mat');
 
     optPercentage = 90;  % FVA based on maximum growth
 

--- a/test/verifiedTests/analysis/testFindBlockedReaction/testFindBlockedReaction.m
+++ b/test/verifiedTests/analysis/testFindBlockedReaction/testFindBlockedReaction.m
@@ -19,7 +19,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testfindBlockedReaction'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 ecoli_blckd_rxn = {'EX_fru(e)', 'EX_fum(e)', 'EX_gln_L(e)', 'EX_mal_L(e)', ...
                    'FRUpts2', 'FUMt2_2', 'GLNabc', 'MALt2_2'};

--- a/test/verifiedTests/analysis/testMOMA/testMOMA.m
+++ b/test/verifiedTests/analysis/testMOMA/testMOMA.m
@@ -27,7 +27,7 @@ fileDir = fileparts(which('testMOMA'));
 cd(fileDir);
 
 % load model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % test solver packages
 solverPkgs = {'tomlab_cplex', 'gurobi6'};  %,'ILOGcomplex'};

--- a/test/verifiedTests/analysis/testMultiSpeciesModelling/testCoupleRxnList2Rxn.m
+++ b/test/verifiedTests/analysis/testMultiSpeciesModelling/testCoupleRxnList2Rxn.m
@@ -17,7 +17,7 @@ fileDir = fileparts(which('testCoupleRxnList2Rxn'));
 cd(fileDir);
 
 % test coupling constraints
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % remove ATPM constraint so no infeasible model is generated
 model = changeRxnBounds(model, 'ATPM', 0, 'l');

--- a/test/verifiedTests/analysis/testMultiSpeciesModelling/testCreateMultipleSpeciesModel.m
+++ b/test/verifiedTests/analysis/testMultiSpeciesModelling/testCreateMultipleSpeciesModel.m
@@ -20,7 +20,7 @@ fileDir = fileparts(which('testCreateMultipleSpeciesModel'));
 cd(fileDir);
 
 % load the model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % set the tolerance
 tol = 1e-6;

--- a/test/verifiedTests/analysis/testOptimizeCbModel/testOptimizeCbModel.m
+++ b/test/verifiedTests/analysis/testOptimizeCbModel/testOptimizeCbModel.m
@@ -21,7 +21,7 @@ tol = 1e-6;
 solverPkgs = {'tomlab_cplex', 'glpk'};
 
 % load the model
-load('ecoli_core_model.mat', 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 osenseStr = 'max';
 allowLoops = true;

--- a/test/verifiedTests/analysis/testPrint/testPrintConstraints.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintConstraints.m
@@ -17,7 +17,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testPrintConstraints'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % remove old generated file
 delete('printConstraints.txt');

--- a/test/verifiedTests/analysis/testPrint/testPrintFluxVector.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintFluxVector.m
@@ -17,7 +17,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testPrintFluxVector'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % remove old generated file
 delete('printFluxVector.txt');

--- a/test/verifiedTests/analysis/testPrint/testPrintRxnFormula.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintRxnFormula.m
@@ -17,7 +17,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testPrintRxnFormula'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % remove old generated file
 delete('printRxnFormula.txt');

--- a/test/verifiedTests/analysis/testPrint/testPrintRxnFormula.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintRxnFormula.m
@@ -36,7 +36,6 @@ assert(isequal(text1, text2));
 % remove the generated file
 delete('printRxnFormula.txt');
 
-model = rmfield(model, 'rev');
 diary('printRxnFormula.txt');
 formulas = printRxnFormula(model, model.rxns, true, true, true, 1, true, true);
 diary off

--- a/test/verifiedTests/analysis/testPrint/testPrintUptakeBound.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintUptakeBound.m
@@ -17,7 +17,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testPrintUptakeBound'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % remove old generated file
 delete('printUptakeBound.txt');

--- a/test/verifiedTests/analysis/testPrint/testSurfNet.m
+++ b/test/verifiedTests/analysis/testPrint/testSurfNet.m
@@ -18,7 +18,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testSurfNet'));
 cd(fileDir);
 
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 % generate flux data for testing
 s = optimizeCbModel(model, 'max', 'one');

--- a/test/verifiedTests/analysis/testRank/testRank.m
+++ b/test/verifiedTests/analysis/testRank/testRank.m
@@ -19,7 +19,7 @@ cd(fileDir);
 
 if isunix
     % load the model
-    load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'iAF1260.mat']);
+    iAF1260 = getDistributedModel('iAF1260.mat');
     A = iAF1260.S;
     printLevel = 1;
 

--- a/test/verifiedTests/analysis/testRobustnessAnalysis/testRobustnessAnalysis.m
+++ b/test/verifiedTests/analysis/testRobustnessAnalysis/testRobustnessAnalysis.m
@@ -34,7 +34,7 @@ tol = 1e-3;
 % Testing robustnessAnalysis
 
 % 1. Set input parameters.
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 controlRxn = 'PFK';
 
 % 2. Run robustnessAnalysis.

--- a/test/verifiedTests/analysis/testSampling/testGpSampler.m
+++ b/test/verifiedTests/analysis/testSampling/testGpSampler.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testGpSampler'));
 cd(fileDir);
 
 % load the model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % define the number of sample points
 samplePoints = [5, 190];

--- a/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
+++ b/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
@@ -43,7 +43,7 @@ if isunix
         if solverOK == 1
 
             % Load model
-            load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+            model = getDistributedModel('ecoli_core_model.mat');
 
             for i = 1:length(samplers)
 

--- a/test/verifiedTests/analysis/testSubspaces/testMinSpan.m
+++ b/test/verifiedTests/analysis/testSubspaces/testMinSpan.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testMinSpan'));
 cd(fileDir);
 
 % load the model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % Remove biomass equation for MinSpan calculation
 bmName = {'Biomass_Ecoli_core_w_GAM'};

--- a/test/verifiedTests/analysis/testSubspaces/testSubspaces.m
+++ b/test/verifiedTests/analysis/testSubspaces/testSubspaces.m
@@ -22,7 +22,7 @@ cd(fileDir);
 tol = 1e-6;
 
 % load the model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % find the internal vs exchange/demand/sink reactions.
 model = findSExRxnInd(model);
@@ -76,7 +76,7 @@ assert(norm(v - v_R - v_N) < tol)
 assert(norm(u - u_C - u_L) < tol)
 
 % test for checkScaling
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 precisionEstimate = checkScaling(model);
 
@@ -95,7 +95,7 @@ for i = 1:length(estlevels)
 end
 
 % test a model for which a quad-precision solver is highly recommended
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ME_matrix_GlcAer_WT.mat'], 'modelGlcOAer_WT');
+modelGlcOAer_WT = getDistributedModel('ME_matrix_GlcAer_WT.mat');
 
 [precisionEstimate, solverRecommendation, scalingProperties] = checkScaling(modelGlcOAer_WT);
 assert(strcmp(precisionEstimate, 'quad'));

--- a/test/verifiedTests/analysis/testTopology/testConvertHypergraphToBipartiteGraph/testConvertHypergraph2BipartiteGraph.m
+++ b/test/verifiedTests/analysis/testTopology/testConvertHypergraphToBipartiteGraph/testConvertHypergraph2BipartiteGraph.m
@@ -51,7 +51,7 @@ end
 
 % test with ecoli_core_model
 load('testDataGraph2Hypergraph.mat');
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 for printLevel = 0:1
     [A, B] = convertHypergraphToBipartiteGraph(model.S, printLevel);

--- a/test/verifiedTests/analysis/testpFBA/testpFBA.m
+++ b/test/verifiedTests/analysis/testpFBA/testpFBA.m
@@ -24,7 +24,9 @@ cd(fileDir);
 tol = 1e-8;
 
 % load models and expected results
-load('testpFBAData.mat', 'model_glc', 'model_lac');
+model_glc = readCbModel('testpFBAData.mat','modelName','model_glc');
+model_lac = readCbModel('testpFBAData.mat','modelName','model_lac');
+%load('testpFBAData.mat', 'model_glc', 'model_lac');
 objGenes = load('testpFBAData.mat', 'GeneClasses_glc2', 'GeneClasses_glc1', 'GeneClasses_glc0', 'GeneClasses_lac2', 'GeneClasses_lac1', 'GeneClasses_lac0');
 objRxns = load('testpFBAData.mat', 'RxnClasses_glc2', 'RxnClasses_glc1', 'RxnClasses_glc0', 'RxnClasses_lac2', 'RxnClasses_lac1', 'RxnClasses_lac0');
 objModel = load('testpFBAData.mat', 'modelIrrev_glc2', 'modelIrrev_glc1', 'modelIrrev_glc0', 'modelIrrev_lac2', 'modelIrrev_lac1', 'modelIrrev_lac0');
@@ -47,7 +49,7 @@ catch
     disp('Trying non parallel test')
 end
 for k = 1:length(solverPkgs)
-    fprintf(' -- Running testfindBlockedReaction using the solver interface: %s ... ', solverPkgs{k});
+        fprintf(' -- Running testfindBlockedReaction using the solver interface: %s ... \n', solverPkgs{k});
 
     solverLPOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
 

--- a/test/verifiedTests/analysis/testrFBA/testSolveBooleanRegModel.m
+++ b/test/verifiedTests/analysis/testrFBA/testSolveBooleanRegModel.m
@@ -17,7 +17,7 @@ cd(fileDir);
 solverPkgs = {'tomlab_cplex'};
 
 % load model and test data
-load('modelReg.mat');
+modelReg = getDistributedModel('modelReg.mat');
 load('refData_solveBooleanRegModel.mat');
 
  for k = 1:length(solverPkgs)

--- a/test/verifiedTests/analysis/testrFBA/testdynamicRFBA.m
+++ b/test/verifiedTests/analysis/testrFBA/testdynamicRFBA.m
@@ -14,13 +14,13 @@ fileDir = fileparts(which('testdynamicRFBA'));
 cd(fileDir);
 
 %load model and test data
-load('modelReg.mat');
+modelReg = getDistributedModel('modelReg.mat');
 load('refData_dynamicRFBA.mat');
 
 %Solver packages
-solverPkgs = {'tomlab_cplex'};
+solverPkgs = {'tomlab_cplex','ibm_cplex'};
 %QP solvers
-QPsolverPkgs = {'tomlab_cplex'};
+QPsolverPkgs = {'tomlab_cplex','ibm_cplex'};
 
 for k =1:length(solverPkgs)
 

--- a/test/verifiedTests/analysis/testuFBA/testuFBA.m
+++ b/test/verifiedTests/analysis/testuFBA/testuFBA.m
@@ -32,6 +32,8 @@ cd(fileDir);
 %   time            time points (in days)
 %   uFBAvariables   input for uFBA algorithm
 load([CBTDIR filesep 'tutorials' filesep 'dataIntegration' filesep 'uFBA' filesep 'sample_data.mat']);
+%ensure, that this model is up to date
+model = convertOldStyleModel(model);
 
 % test that data is loaded correctly
 assert(size(met_data, 1) == 80 & size(met_data, 2) == 102, ...

--- a/test/verifiedTests/base/testIO/testConvertCobraToSBML.m
+++ b/test/verifiedTests/base/testIO/testConvertCobraToSBML.m
@@ -18,7 +18,7 @@ sbmlLevel = 0;
 sbmlVersion = 0;
 compSymbolList = '';
 compNameList = '';
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 % function outputs
 warning('off', 'all')

--- a/test/verifiedTests/base/testIO/testConvertModelToEX.m
+++ b/test/verifiedTests/base/testIO/testConvertModelToEX.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testConvertModelToEX'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 filename = 'testData_convertModelToEX.txt';
 rxnzero = 0;
 filename_2 = 'testData_convertModelToEX_2.txt';

--- a/test/verifiedTests/base/testIO/testKEGG/testTransformModel2KEGG.m
+++ b/test/verifiedTests/base/testIO/testKEGG/testTransformModel2KEGG.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testTransformModel2KEGG'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 Dictionary = {'0', '1'; '2', '3'};
 ref_KEGGID = cell(72, 1);
 

--- a/test/verifiedTests/base/testIO/testLoadBiGGModel.m
+++ b/test/verifiedTests/base/testIO/testLoadBiGGModel.m
@@ -44,7 +44,7 @@ for i = 1:size(modelArr,1)
     
     % load the model (actually supply the full filename of the path
     % where the model is found)
-    model1 = readCbModel(which(modelArr{i,1}));
+    model1 = getDistributedModel(modelArr{i,1});
     model2 = loadBiGGModel(modelArr{i,2},modelArr{i,3});
     model3 = readCbModel(modelArr{i,2},'fileType',modelArr{i,4});
     %Check that the direct load is the same

--- a/test/verifiedTests/base/testIO/testReadSBML.m
+++ b/test/verifiedTests/base/testIO/testReadSBML.m
@@ -43,7 +43,7 @@ for i = 1:length(modelArr)
 
     % load the model (actually supply the full filename of the path
     % where the model is found)
-    model = readCbModel(which(modelArr{i}));
+    model = getDistributedModel(modelArr{i});
 
     for k = 1:length(solverPkgs)
 

--- a/test/verifiedTests/base/testIO/testReadWriteCbModel.m
+++ b/test/verifiedTests/base/testIO/testReadWriteCbModel.m
@@ -20,7 +20,7 @@ cd(fileDir);
 tol = 1e-6;
 
 % read in mat model
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 % convert an old style model
 model = convertOldStyleModel(model);

--- a/test/verifiedTests/base/testIO/testUtilities/testOutputHypergraph.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testOutputHypergraph.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testOutputHypergraph'));
 cd(fileDir);
 
 % test variables
-testModel = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+testModel = getDistributedModel('ecoli_core_model.mat');
 testFileName = 'testData_outputHypergraph.txt';
 testWeights = zeros(95);
 

--- a/test/verifiedTests/base/testIO/testUtilities/testOutputNetworkOmix.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testOutputNetworkOmix.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testOutputNetworkOmix'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 model_2 = model;
 model_2.description = struct('name', 'ecoli_core_model_mat');
 

--- a/test/verifiedTests/base/testIO/testUtilities/testPlanariseModel.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testPlanariseModel.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testPlanariseModel'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 % function outputs
 [modelPlane, replicateMetBool, metData, rxnData] = planariseModel(model);

--- a/test/verifiedTests/base/testIO/testUtilities/testRestrictModelsToFields.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testRestrictModelsToFields.m
@@ -14,8 +14,9 @@ fileDir = fileparts(which('testRestrictModelsToFields'));
 cd(fileDir);
 
 % test variables
-models{1} = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
-models{2} = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'xml' filesep 'Abiotrophia_defectiva_ATCC_49176.xml']);
+models{1} = getDistributedModel('ecoli_core_model.mat');
+models{2} = getDistributedModel('Abiotrophia_defectiva_ATCC_49176.xml');
+
 fieldNames = fieldnames(models{1});
 fieldNames2 = fieldnames(models{2});
 

--- a/test/verifiedTests/base/testIO/testUtilities/testWriteCytoscapeEdgeAttributeTable.m
+++ b/test/verifiedTests/base/testIO/testUtilities/testWriteCytoscapeEdgeAttributeTable.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testWriteCytoscapeEdgeAttributeTable'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 [modelPlane, replicateMetBool, metData, rxnData] = planariseModel(model);
 C = cell(95, 1);
 C{1} = '1';

--- a/test/verifiedTests/base/testIO/testWriteCbModel.m
+++ b/test/verifiedTests/base/testIO/testWriteCbModel.m
@@ -66,7 +66,7 @@ end
 % test varargin
 
 % load the model
-load('ecoli_core_model.mat', 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % write out using varargin
 outmodel1 = writeCbModel(model, 'format', 'mat', 'fileName', 'testModel1');

--- a/test/verifiedTests/base/testIO/testWriteCbModel.m
+++ b/test/verifiedTests/base/testIO/testWriteCbModel.m
@@ -21,7 +21,7 @@ if ~verLessThan('matlab', '8.6')
     tol = 1e-6;
 
     % load the model
-    load('ecoli_core_model.mat', 'model');
+    model = getDistributedModel('ecoli_core_model.mat');
 
     % write the model to an xls file
     writeCbModel(model, 'xlsx', 'testData');

--- a/test/verifiedTests/base/testMPS/testMPS.m
+++ b/test/verifiedTests/base/testMPS/testMPS.m
@@ -17,7 +17,8 @@ fileDir = fileparts(which('testMPS'));
 cd(fileDir);
 
 % load the ecoli_core_model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
+
 
 % write the MPS using method 1 (creates a file CobraLPProblem.mps)
 out = writeLPProblem(model);
@@ -113,8 +114,9 @@ assert(~any(~strcmp(strtrim(mpsFileMILP), strtrim(mpsFileMILP_ref))));
 
 clear paramStruct;
 
-% verify another model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'iAF1260.mat'], 'model');
+% verify another model (this is still ecoli, iAF was never used as its name
+% is iAF...
+model = getDistributedModel('ecoli_core_model.mat');
 
 paramStruct.EqtNames = model.mets;
 paramStruct.VarNames = model.rxns;

--- a/test/verifiedTests/base/testOutputNetworkCytoscape/testOutputNetworkCytoscape.m
+++ b/test/verifiedTests/base/testOutputNetworkCytoscape/testOutputNetworkCytoscape.m
@@ -17,7 +17,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testOutputNetworkCytoscape'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 %additional calls to check all options
 notShownMets_cell = cell(9, 1);

--- a/test/verifiedTests/base/testSolvers/testOptimizeCbModelNLP.m
+++ b/test/verifiedTests/base/testSolvers/testOptimizeCbModelNLP.m
@@ -32,7 +32,7 @@ end
 tol = 1e-6;
 
 % load the model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 toymodel = createToyModel(0, 0, 0); % create a toy model
 toymodel.ub(1) = -1; % force uptake, otherwise the default Objective will try to minimize all fluxes...

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -90,7 +90,7 @@ solverPkgs={'cplex_direct', 'glpk', 'gurobi', 'ibm_cplex', 'matlab', 'mosek', ..
             'pdco', 'quadMinos', 'tomlab_cplex', 'mosek_linprog', 'dqqMinos'}; % 'lp_solve': legacy
 
 % load the ecoli_core_model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % set the tolerance
 tol = 1e-6;

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -62,7 +62,9 @@ for k = 1:length(solverPkgs)
 
                 elseif p == 2
                     % solve th ecoli_core_model (csense vector is missing)
-                    load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+                    %This is explicitly a load, to test missing csense
+                    %vector compensation
+                    model = load([getDistributedModelFolder('ecoli_core_model.mat') filesep 'ecoli_core_model.mat'], 'model');
 
                     % solveCobraLP
                     solution_solveCobraLP = solveCobraLP(model);

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -64,7 +64,7 @@ for k = 1:length(solverPkgs)
                     % solve th ecoli_core_model (csense vector is missing)
                     %This is explicitly a load, to test missing csense
                     %vector compensation
-                    model = load([getDistributedModelFolder('ecoli_core_model.mat') filesep 'ecoli_core_model.mat'], 'model');
+                    load([getDistributedModelFolder('ecoli_core_model.mat') filesep 'ecoli_core_model.mat'], 'model');
 
                     % solveCobraLP
                     solution_solveCobraLP = solveCobraLP(model);

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLPCPLEX.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLPCPLEX.m
@@ -25,7 +25,7 @@ fileDir = fileparts(which('testSolveCobraLPCPLEX'));
 cd(fileDir);
 
 load testDataSolveCobraLPCPLEX;
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 tol = 1e-2;%set tolerance
 ecoli_blckd_rxn = {'EX_fru(e)', 'EX_fum(e)', 'EX_gln_L(e)', 'EX_mal_L(e)',...

--- a/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
+++ b/test/verifiedTests/base/testTools/testMergeModelFieldPositions.m
@@ -17,7 +17,7 @@ fileDir = fileparts(which('testMergeModelFieldPositions.m'));
 cd(fileDir);
 
 % load reference data and model
-model = readCbModel([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 
 %Merge two reactions first two reactions which have a non empty rules
 %field. 

--- a/test/verifiedTests/base/testTools/testReporterMets.m
+++ b/test/verifiedTests/base/testTools/testReporterMets.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testReporterMets'));
 cd(fileDir);
 
 % load reference data and model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 load('ref_testReporterMets.mat');
 nRand = 10;

--- a/test/verifiedTests/base/testwritePajekNet/testwritePajekNet.m
+++ b/test/verifiedTests/base/testwritePajekNet/testwritePajekNet.m
@@ -16,7 +16,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testwritePajekNet'));
 cd(fileDir);
 
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 %test solver packages
 solverPkgs = {'tomlab_cplex'};

--- a/test/verifiedTests/dataIntegration/testFitC13Data/testFitC13Data.m
+++ b/test/verifiedTests/dataIntegration/testFitC13Data/testFitC13Data.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testFitC13Data'));
 cd(fileDir);
 
 majorIterationLimit = 10000; % fitting length
-load('model.mat', 'model'); % loads modelWT
+model = readCbModel('model.mat'); % loads modelWT
 load('expdata.mat', 'expdata'); % load data
 load('point.mat', 'v0'); % load initial point
 

--- a/test/verifiedTests/design/testGDLS/testGDLS.m
+++ b/test/verifiedTests/design/testGDLS/testGDLS.m
@@ -17,7 +17,7 @@ fileDir = fileparts(which('testGDLS'));
 cd(fileDir);
 
 % load model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % Set conditions to anaerobic and glucose uptake of 20
 model = changeRxnBounds(model, {'EX_o2(e)', 'EX_glc(e)'}, [0 - 20], 'l');

--- a/test/verifiedTests/design/testOptForce/testOptForce.m
+++ b/test/verifiedTests/design/testOptForce/testOptForce.m
@@ -31,7 +31,7 @@ catch
     parPoolCreated = false;
 end
     
-model = getDistributedModel('ecoli_core_model.mat');
+model = getDistributedModel('AntCore.mat');
 model.c(strcmp(model.rxns, 'R75')) = 1;
 model = changeRxnBounds(model, 'EX_gluc', -100, 'l'); 
 model = changeRxnBounds(model, 'EX_o2', -100, 'l'); 

--- a/test/verifiedTests/design/testOptForce/testOptForce.m
+++ b/test/verifiedTests/design/testOptForce/testOptForce.m
@@ -31,7 +31,7 @@ catch
     parPoolCreated = false;
 end
     
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'AntCore.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 model.c(strcmp(model.rxns, 'R75')) = 1;
 model = changeRxnBounds(model, 'EX_gluc', -100, 'l'); 
 model = changeRxnBounds(model, 'EX_o2', -100, 'l'); 

--- a/test/verifiedTests/design/testOptGene.m
+++ b/test/verifiedTests/design/testOptGene.m
@@ -21,7 +21,7 @@ fileDir = fileparts(which('testOptGene'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 targetRxn = model.rxns{39}; % Succinate
 fructose_substrateRxn = model.rxns{26}; %Fructose, even though this has no incluence whatsoever.
 generxnList = model.rxns(setdiff([1:95],[11,13,26,39])); %Everything besides the ATP Maintenance, The biomass reaction and the substrate and target reactions.

--- a/test/verifiedTests/design/testOptKnock/testOptKnock.m
+++ b/test/verifiedTests/design/testOptKnock/testOptKnock.m
@@ -22,7 +22,7 @@ cd(fileDir);
 tol = 1e-3;
 
 % load model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 model = changeRxnBounds(model, 'EX_o2(e)', 0, 'l'); % anaerobic
 model = changeRxnBounds(model, 'EX_glc(e)', -20, 'l'); % set glucose uptake to 20
 

--- a/test/verifiedTests/design/testSingleProductionEnvelope.m
+++ b/test/verifiedTests/design/testSingleProductionEnvelope.m
@@ -14,7 +14,7 @@ fileDir = fileparts(which('testSingleProductionEnvelope'));
 cd(fileDir);
 
 % test variables
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat']);
+model = getDistributedModel('ecoli_core_model.mat');
 deletions = model.rxns(21); % 'EX_acald(e)'
 deletions2 = model.genes(21);
 product = char(model.rxns(20)); % 'EX_ac(e)' - the created and deleted plot has the name of the reaction

--- a/test/verifiedTests/reconstruction/testFastLeakTest/testFastLeakTest.m
+++ b/test/verifiedTests/reconstruction/testFastLeakTest/testFastLeakTest.m
@@ -20,7 +20,7 @@ cd(fileDir);
 % define the solver packages to be used to run this test
 solverPkgs = {'gurobi6', 'tomlab_cplex', 'glpk'};
 
-model = readCbModel(which('ecoli_core_model.mat'));
+model = getDistributedModel('ecoli_core_model.mat');
 
 %First, we have to remove all flux forcing constraints, because they interfere with leak testing.
 model.lb(model.lb > 0) = 0;

--- a/test/verifiedTests/reconstruction/testModelBorgifier/testModelBorgifier.m
+++ b/test/verifiedTests/reconstruction/testModelBorgifier/testModelBorgifier.m
@@ -23,11 +23,9 @@ cd(fileparts(which('testModelBorgifier.m')));
 
 % load the models as well as comparision information
 fprintf('modelBorgifier: Loading Ecoli core model.\n')
-Cmodel = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], ...
-                     'modelDescription', 'Ecoli_core') ;
+Cmodel = getDistributedModel('ecoli_core_model.mat','Ecoli_core');
 fprintf('modelBorgifier: Loading iIT341 model.\n')
-Tmodel = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'xml' filesep 'iIT341.xml'], ...
-                     'modelDescription', 'iIT341') ;
+Tmodel = getDistributedModel('iIT341.xml','iIT341');
 
 % verify models are appropriate for comparison and test success
 fprintf('modelBorgifier: Testing Cmodel verification... ')

--- a/test/verifiedTests/reconstruction/testModelGeneration/testTest4HumanFctExt.m
+++ b/test/verifiedTests/reconstruction/testModelGeneration/testTest4HumanFctExt.m
@@ -19,7 +19,7 @@ tol = 1e-4;
 
 if solverOK
     fileName= 'Recon1.0model.mat'; % if using Recon 3 model, amend filename.
-    model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep fileName]);
+    model = getDistributedModel(fileName);
     model.csense(1:size(model.S,1),1) = 'E';
 
     % Set the lower bounds on all biomass reactions and sink/demand reactions to zero.

--- a/test/verifiedTests/reconstruction/testModelManipulation/testCheckObjective.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testCheckObjective.m
@@ -13,7 +13,7 @@ fileDir = fileparts(which('testCheckObjective'));
 cd(fileDir);
 
 % load the ecoli core model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 abbr = checkObjective(model);
 

--- a/test/verifiedTests/reconstruction/testModelManipulation/testExtractMetModel.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testExtractMetModel.m
@@ -14,7 +14,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testUpdateGenes'));
 cd(fileDir);
 
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'Recon2.v04.mat']);
+model = getDistributedModel('Recon2.v04.mat');
 load('testExtractMetModel.mat', 'emptyModel', 'atpModel', 'pppg9Level0', 'pppg9Level1');
 
 % Test getting level 0 (just reactions that involve a metaoblite)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -18,7 +18,7 @@ cd(fileDir);
 modelsToTry = {'Acidaminococcus_intestini_RyC_MR95.mat', 'Acidaminococcus_sp_D21.mat', 'Recon1.0model.mat', 'Recon2.v04.mat', 'ecoli_core_model.mat', 'modelReg.mat'};
 
 for i=1:length(modelsToTry)
-    model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep modelsToTry{i}]);
+    model = getDistributedModel(modelsToTry{i});
     fprintf('Beginning model %s\n', modelsToTry{i});
 
     model2 = generateRules(model);

--- a/test/verifiedTests/reconstruction/testModelManipulation/testUpdateGenes.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testUpdateGenes.m
@@ -14,7 +14,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testUpdateGenes'));
 cd(fileDir);
 
-model = readCbModel([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'Recon2.v04.mat']);
+model = getDistributedModel('Recon2.v04.mat');
 
 % Check that updateGenes orders the gene list
 model2 = updateGenes(model);

--- a/test/verifiedTests/reconstruction/testRBioNet/testGPR2Genes.m
+++ b/test/verifiedTests/reconstruction/testRBioNet/testGPR2Genes.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testGPR2Genes'));
 cd(fileDir);
 
 % load E. coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % extract genes from grRules
 Genes = GPR2Genes(model.grRules);

--- a/test/verifiedTests/reconstruction/testRBioNet/testLegalRxnFormula.m
+++ b/test/verifiedTests/reconstruction/testRBioNet/testLegalRxnFormula.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testReactionEq'));
 cd(fileDir);
 
 % load E. coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % check validity of reaction formulas
 formula = printRxnFormula(model, model.rxns(1));

--- a/test/verifiedTests/reconstruction/testRBioNet/testLoadReaction.m
+++ b/test/verifiedTests/reconstruction/testRBioNet/testLoadReaction.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testLoadReaction'));
 cd(fileDir);
 
 % load E. coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % load reaction and metabolite databases
 load([fileDir, filesep 'metab.mat'])

--- a/test/verifiedTests/reconstruction/testRBioNet/testModel2data.m
+++ b/test/verifiedTests/reconstruction/testRBioNet/testModel2data.m
@@ -24,7 +24,7 @@ rxn_path = [fileDir, filesep 'rxn.mat'];
 save([fileDir, filesep 'rBioNetSettingsDB.mat'], 'comp_path', 'met_path', 'rxn_path')
 
 % load E. coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 modelEcore = model;
 
 % model to data

--- a/test/verifiedTests/reconstruction/testRBioNet/testNeighborRxn2data.m
+++ b/test/verifiedTests/reconstruction/testRBioNet/testNeighborRxn2data.m
@@ -18,7 +18,7 @@ fileDir = fileparts(which('testNeighborRxn2data'));
 cd(fileDir);
 
 % load E. coli model
-load([CBTDIR filesep 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % equires EC number field
 model.rxnECNumbers = cell(size(model.rxns));%requires EC number field

--- a/test/verifiedTests/visualization/testPaint4Net/testPaint4Net.m
+++ b/test/verifiedTests/visualization/testPaint4Net/testPaint4Net.m
@@ -23,7 +23,8 @@ cd(fileparts(which('testPaint4Net')))
 solverPkgs = {'glpk'};
 
 % load the model
-load('testPaint4Net.mat');   
+load('testPaint4Net.mat');
+model = readCbModel('testPaint4Net.mat','modelName','model');
 
 for k = 1:length(solverPkgs)
     fprintf('Running Paint4Net using solver %s ... ', solverPkgs{k});

--- a/test/verifiedTests/visualization/testReconMap/testReconMap.m
+++ b/test/verifiedTests/visualization/testReconMap/testReconMap.m
@@ -19,7 +19,7 @@ fileDir = fileparts(which('testReconMap'));
 cd(fileDir);
 
 % load the ecoli core model
-load([CBTDIR, filesep, 'test' filesep 'models' filesep 'mat' filesep 'ecoli_core_model.mat'], 'model');
+model = getDistributedModel('ecoli_core_model.mat');
 
 % Get the minerva structure
 load('minerva.mat');


### PR DESCRIPTION
These changes introduce 2 new functions to obtain the models distributed with the toolbox (i.e. changing these functions should be sufficient when changing the folder structure for the distributed models).
It also fixes a small bug in initCobraToolbox where the model file pointed to is no longer at the referred place (and modifies it to use the aforementioned functions).

Tests were altered to use either readCbModel (if the model is supplied with the test) or getDistributedModel (if the model is part of the distributed models), to ensure, that functions are working on the currently valid model structure, and not rely on old model fields.
In the course of this change a few bugs were detected, where code was not fit for the current model structure, and these have been addressed. 
In addition, readCbModel was made more robust when reading mat files and convertOldStyleModel has a few more changes performed, if a model is missing individual fields.
Simultaneously verifyModel was made more robust when checking field dependencies (if a field depends on another field which is not present, the method no longer errors, but marks the missing field in the result).



**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
