### PR TITLE
Write sbml improvments

### DIFF
--- a/src/base/io/utilities/SBML/makeSBMLAnnotationString.m
+++ b/src/base/io/utilities/SBML/makeSBMLAnnotationString.m
@@ -79,7 +79,6 @@ for pos = 1:size(fieldentries,1)
             dbstring = strjoin(strcat(dbrdfstring,ids,sprintf('%s\n','"/>')),sprintf('\n'));
             dbnote = [dbnote, dbstring];
         end
-        knownExistentFields = [];
         knownExistentFields = knownFields(ismember(knownFields(:,3),modelFields),:);
         
         for fieldid = 1:size(knownExistentFields,1)

--- a/src/base/io/utilities/SBML/makeSBMLAnnotationString.m
+++ b/src/base/io/utilities/SBML/makeSBMLAnnotationString.m
@@ -79,6 +79,7 @@ for pos = 1:size(fieldentries,1)
             dbstring = strjoin(strcat(dbrdfstring,ids,sprintf('%s\n','"/>')),sprintf('\n'));
             dbnote = [dbnote, dbstring];
         end
+        knownExistentFields = [];
         knownExistentFields = knownFields(ismember(knownFields(:,3),modelFields),:);
         
         for fieldid = 1:size(knownExistentFields,1)

--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -212,7 +212,9 @@ switch format
         end
         %% SBML
     case 'sbml'
-        fileName = strrep(fileName, '~', getenv('HOME'));
+        if (isunix)
+            fileName = strrep(fileName, '~', getenv('HOME'));
+        end
         outmodel = writeSBML(model, fileName, input.compSymbols, input.compNames);
         %% Mat
     case 'mat'

--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -212,8 +212,11 @@ switch format
         end
         %% SBML
     case 'sbml'
-        if (isunix)
-            fileName = strrep(fileName, '~', getenv('HOME'));
+        if (isunix && (strcmp(fileName, '~') || strncmp(fileName, '~/', 2)))
+            if ~isempty(getenv('HOME'))
+                fileName(1) = [];
+                fileName = [getenv('HOME'), fileName];
+            end
         end
         outmodel = writeSBML(model, fileName, input.compSymbols, input.compNames);
         %% Mat

--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -212,6 +212,7 @@ switch format
         end
         %% SBML
     case 'sbml'
+        fileName = strrep(fileName, '~', getenv('HOME'));
         outmodel = writeSBML(model, fileName, input.compSymbols, input.compNames);
         %% Mat
     case 'mat'


### PR DESCRIPTION
It was annoying me that writeSBML can't deal with ~ as home directory, but all other functions can. So I added a quick one-line fix to replace ~ with the environment home directory.  It should not do anything on Windows.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
