### PR TITLE
fix for FVA non parallel and Update to FVA test

### DIFF
--- a/src/analysis/FVA/fluxVariability.m
+++ b/src/analysis/FVA/fluxVariability.m
@@ -294,10 +294,10 @@ if ~PCT_status && (~exist('parpool') || poolsize == 0)  %aka nothing is active
             LPproblem.osense = -1;
             [maxFlux(i),Vmax(:,i)] = calcSolForEntry(model,rxnNameList,i,LPproblem,0, method, allowLoops,printLevel,minNorm,cpxControl,preCompMaxSols{i});
 
-            if printLevel == 1 && ~parallelMode
+            if printLevel == 1
                 showprogress(i/length(rxnNameList));
             end
-            if printLevel > 1 && ~parallelMode
+            if printLevel > 1
                 fprintf('%4d\t%4.0f\t%10s\t%9.3f\t%9.3f\n',i,100*i/length(rxnNameList),rxnNameList{i},minFlux(i),maxFlux(i));
             end
         end

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -28,102 +28,100 @@ load('Ec_iJR904.mat', 'model');
 load('testFVAData.mat');
 
 % create a parallel pool
-minWorkers = 2;
-myCluster = parcluster(parallel.defaultClusterProfile);
-
-loopToyModel = createToyModelForgapFind();
-
-if myCluster.NumWorkers >= minWorkers
-    poolobj = gcp('nocreate');  % if no pool, do not create new one.
-    if isempty(poolobj)
-        parpool(minWorkers);  % launch minWorkers workers
-    end
-
-    for k = 1:length(solverPkgs)
-
-        % change the COBRA solver (LP)
-        solverLPOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
-        solverQPOK = changeCobraSolver(solverPkgs{k}, 'QP', 0);
-        solverMILPOK = changeCobraSolver(solverPkgs{k}, 'MILP', 0);
-
-        if solverLPOK && solverQPOK && solverMILPOK
-            fprintf('   Testing flux variability analysis using %s ... ', solverPkgs{k});
-
-            rxnNames = {'PGI', 'PFK', 'FBP', 'FBA', 'TPI', 'GAPD', 'PGK', 'PGM', 'ENO', 'PYK', 'PPS', ...
-                        'G6PDH2r', 'PGL', 'GND', 'RPI', 'RPE', 'TKT1', 'TKT2', 'TALA'};
-
-            % launch the flux variability analysis
-            fprintf('    Testing flux variability for the following reactions:\n');
-            disp(rxnNames);
-            [minFluxT, maxFluxT] = fluxVariability(model, 90, 'max', rxnNames);
-
-            % retrieve the IDs of each reaction
-            rxnID = findRxnIDs(model, rxnNames);
-
-            % check if each flux value corresponds to a pre-calculated value
-            for i = 1:size(rxnID)
-                % test the components of the minFlux and maxFlux vectors
-                assert(minFlux(i) - tol <= minFluxT(i))
-                assert(minFluxT(i) <= minFlux(i) + tol)
-
-                assert(maxFlux(i) - tol <= maxFluxT(i))
-                assert(maxFluxT(i) <= maxFlux(i) + tol)
-
-                maxMinusMin = maxFlux(i) - minFlux(i);
-                maxTMinusMinT = maxFluxT(i) - minFluxT(i);
-                assert(maxMinusMin - tol <= maxTMinusMinT)
-                assert(maxTMinusMinT <= maxMinusMin + tol)
-
-                % print the labels
-                printLabeledData(model.rxns(i), [minFlux(i) maxFlux(i) maxFlux(i) - minFlux(i)], true, 3);
-            end
-
-            % Vmin and Vmax test
-            % Since the solution are dependant on solvers and cpus, the test will check the existence of nargout (weak test) over the 4 first reactions
-            rxnNames = {'PGI', 'PFK', 'FBP', 'FBA'};
-
-            % testing default FVA with 2 printLevels
-            for j = 0:1
-                fprintf('    Testing flux variability with printLevel %s:\n', num2str(j));
-                [minFlux, maxFlux, Vmin, Vmax] = fluxVariability(model, 90, 'max', rxnNames, j, 1);
-                assert(~isequal(Vmin, []));
-                assert(~isequal(Vmax, []));
-            end
-
-            % testing various methods
-            testMethods = {'FBA', '0-norm', '1-norm', '2-norm', 'minOrigSol'};
-
-            for j = 1:length(testMethods)
-                fprintf('    Testing flux variability with test method %s:\n', testMethods{j});
-                [minFlux, maxFlux, Vmin, Vmax] = fluxVariability(model, 90, 'max', rxnNames, 1, 1, testMethods{j});
-                assert(~isequal(Vmin, []));
-                assert(~isequal(Vmax, []));
-            end
-
-            % output a success message
-            [minF,maxF] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
-            assert(abs(maxF(2))< tol); %While R4 can carry a flux of 1000, it can't do so without a loop
-            assert(abs(maxF(1) -500) < tol); % Due to downstream reactions which have to carry "double" flux, this reaction can at most carry a flux of 500)
-            assert(abs(minF(1)-5) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
-            assert(abs(minF(2)) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
-            try
-                errored = false;
-                [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
-            catch ME
-                errored = true;
-            end
-            assert(errored);
-            [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0,'FBA');
-            assert(all(minSols(:,1) == maxSols(:,2))); %This is an odd assertion, but since the minimal solution for reaction 1 is the minimal solution of the system, 
-                                                  %it has to be the same as the maximal solution for the second tested
-                                                  %Reaction.
-            fprintf('Done.\n');
+try
+    minWorkers = 2;
+    myCluster = parcluster(parallel.defaultClusterProfile);
+    %No parallel pool
+    if myCluster.NumWorkers >= minWorkers
+        poolobj = gcp('nocreate');  % if no pool, do not create new one.
+        if isempty(poolobj)
+            parpool(minWorkers);  % launch minWorkers workers
         end
     end
-else
-    warning(' > Skipping testFVA as the default parallel pool is not configured for more than 2 workers.');
+catch
+    %No Parallel pool. Thats fine
 end
+loopToyModel = createToyModelForgapFind();
+for k = 1:length(solverPkgs)
 
+    % change the COBRA solver (LP)
+    solverLPOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
+    solverQPOK = changeCobraSolver(solverPkgs{k}, 'QP', 0);
+    solverMILPOK = changeCobraSolver(solverPkgs{k}, 'MILP', 0);
+
+    if solverLPOK && solverQPOK && solverMILPOK
+        fprintf('   Testing flux variability analysis using %s ... ', solverPkgs{k});
+
+        rxnNames = {'PGI', 'PFK', 'FBP', 'FBA', 'TPI', 'GAPD', 'PGK', 'PGM', 'ENO', 'PYK', 'PPS', ...
+            'G6PDH2r', 'PGL', 'GND', 'RPI', 'RPE', 'TKT1', 'TKT2', 'TALA'};
+
+        % launch the flux variability analysis
+        fprintf('    Testing flux variability for the following reactions:\n');
+        disp(rxnNames);
+        [minFluxT, maxFluxT] = fluxVariability(model, 90, 'max', rxnNames);
+
+        % retrieve the IDs of each reaction
+        rxnID = findRxnIDs(model, rxnNames);
+
+        % check if each flux value corresponds to a pre-calculated value
+        for i = 1:size(rxnID)
+            % test the components of the minFlux and maxFlux vectors
+            assert(minFlux(i) - tol <= minFluxT(i))
+            assert(minFluxT(i) <= minFlux(i) + tol)
+            assert(maxFlux(i) - tol <= maxFluxT(i))
+            assert(maxFluxT(i) <= maxFlux(i) + tol)
+
+            maxMinusMin = maxFlux(i) - minFlux(i);
+            maxTMinusMinT = maxFluxT(i) - minFluxT(i);
+            assert(maxMinusMin - tol <= maxTMinusMinT)
+            assert(maxTMinusMinT <= maxMinusMin + tol)
+
+            % print the labels
+            printLabeledData(model.rxns(i), [minFlux(i) maxFlux(i) maxFlux(i) - minFlux(i)], true, 3);
+        end
+
+        % Vmin and Vmax test
+        % Since the solution are dependant on solvers and cpus, the test will check the existence of nargout (weak test) over the 4 first reactions
+        rxnNames = {'PGI', 'PFK', 'FBP', 'FBA'};
+
+        % testing default FVA with 2 printLevels
+        for j = 0:1
+            fprintf('    Testing flux variability with printLevel %s:\n', num2str(j));
+            [minFlux, maxFlux, Vmin, Vmax] = fluxVariability(model, 90, 'max', rxnNames, j, 1);
+            assert(~isequal(Vmin, []));
+            assert(~isequal(Vmax, []));
+        end
+
+        % testing various methods
+        testMethods = {'FBA', '0-norm', '1-norm', '2-norm', 'minOrigSol'};
+
+        for j = 1:length(testMethods)
+            fprintf('    Testing flux variability with test method %s:\n', testMethods{j});
+            [minFlux, maxFlux, Vmin, Vmax] = fluxVariability(model, 90, 'max', rxnNames, 1, 1, testMethods{j});
+            assert(~isequal(Vmin, []));
+            assert(~isequal(Vmax, []));
+        end
+
+        % output a success message
+        [minF,maxF] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
+        assert(abs(maxF(2))< tol); %While R4 can carry a flux of 1000, it can't do so without a loop
+        assert(abs(maxF(1) -500) < tol); % Due to downstream reactions which have to carry "double" flux, this reaction can at most carry a flux of 500)
+        assert(abs(minF(1)-5) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+        assert(abs(minF(2)) < tol); %We require at least a flux of 10 through the objective (1% of 1000). This requires a flux of 5 through R1.
+        try
+            errored = false;
+            [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0);
+        catch ME
+            errored = true;
+        end
+        assert(errored);
+        [minF,maxF,minSols,maxSols] = fluxVariability(loopToyModel,1,'max',{'R1','R4'},0,0,'FBA');
+        assert(all(minSols(:,1) == maxSols(:,2))); %This is an odd assertion, but since the minimal solution for reaction 1 is the minimal solution of the system,
+        %it has to be the same as the maximal solution for the second tested
+        %Reaction.
+        fprintf('Done.\n');
+    end
+end
 
 
 % change the directory


### PR DESCRIPTION
Fix for a bug in non parallel FVA (parallelMode is not set) and not necessary.
Also adjusted the Test to also run without the parallel toolbox installed.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
