### PR TITLE
Rephrased error message if first parameter name is invalid

### DIFF
--- a/src/reconstruction/refinement/addReaction.m
+++ b/src/reconstruction/refinement/addReaction.m
@@ -70,6 +70,9 @@ oldOptionalOrder = {'metaboliteList','stoichCoeffList',...
     'reversible','lowerBound','upperBound',...
     'objectiveCoef','subSystem','geneRule','geneNameList','systNameList','checkDuplicate','printLevel'};
 oldStyle = false;
+
+origargin = varargin;
+
 if (numel(varargin) > 0 && (~ischar(varargin{1}) || ~any(ismember(varargin{1},optionalParameters)))) || iscell(rxnID)
     %We have an old style thing....
     %Now, we need to check, whether this is a formula, or a complex setup
@@ -153,7 +156,7 @@ parser.addRequired('model',@isstruct) % we only check, whether its a struct, no 
 parser.addRequired('rxnID',@ischar)
 parser.addParamValue('reactionName',defaultReactionName,@ischar)
 parser.addParamValue('metaboliteList',defaultMetaboliteList, @iscell);
-parser.addParamValue('stoichCoeffList',defaultStoichCoefList, @isnumeric);
+parser.addParamValue('stoichCoeffList',defaultStoichCoefList, @(x) isnumeric(x) || isempty(x));
 parser.addParamValue('reactionFormula','', @ischar);
 parser.addParamValue('reversible',defaultReversibility, @(x) islogical(x) || isnumeric(x) );
 parser.addParamValue('lowerBound',defaultLowerBound, @(x) isempty(x) || isnumeric(x));
@@ -167,8 +170,19 @@ parser.addParamValue('notes','', @ischar );
 parser.addParamValue('systNameList',defaultGeneNameList, @(x) isempty(x) || iscell(x));
 parser.addParamValue('geneNameList',defaultSystNameList, @(x) isempty(x) || iscell(x));
 
-parser.parse(model,rxnID,varargin{:});
-
+try
+    parser.parse(model,rxnID,varargin{:});
+catch ME
+    if oldStyle
+        if ischar(origargin{1}) || isstring(origargin{1})
+            if ~any(ismember(origargin{1},optionalParameters))
+                error('''%s'' is not a valid parameter name or it does not fit to the deprecated signature of addReaction.',origargin{1});
+            end
+        end    
+    else
+        rethrow(ME)
+    end
+end
 printLevel = parser.Results.printLevel;
 metaboliteList = parser.Results.metaboliteList;
 reactionFormula = parser.Results.reactionFormula;


### PR DESCRIPTION
When the first parameter name provided is invalid, the error message is misleading. 
This patch adjusts the error message in this instance to better indicate the problem.
This is a pr in response to #989 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
