### PR TITLE
Small fix to handle empty formula parts in InChIs

### DIFF
--- a/src/reconstruction/modelGeneration/massBalance/getFormulaFromInChI.m
+++ b/src/reconstruction/modelGeneration/massBalance/getFormulaFromInChI.m
@@ -41,6 +41,10 @@ if (numel(tokens) > 1) || (~isempty(regexp(formula,'(^[0-9]+)'))) || (~isempty(p
     Elements = {};
     Coefficients = [];
     for i = 1:numel(CoefLists)
+        if isempty(CoefLists{i})
+            %This should only happen, if there was no actual formula. 
+            continue
+        end
         currentForm = CoefLists{i};
         Elements = [Elements,setdiff(currentForm(1,:),Elements)];
         current_coefs = cell2mat(currentForm(2,:));


### PR DESCRIPTION
Allowing empty formula parts to be parsed.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
