### PR TITLE
Fix change to addReaction and Test for it

### DIFF
--- a/src/reconstruction/refinement/addReaction.m
+++ b/src/reconstruction/refinement/addReaction.m
@@ -259,11 +259,10 @@ if ~any(ismember(parser.UsingDefaults,'subSystem'))
         model.subSystems(:) = {{''}};
     end
 end
-
-% 
 if (isfield(model,'subSystems'))
-    model.subSystems(rxnPos,1) = subSystem;
+    model.subSystems{rxnPos,1} = subSystem;
 end
+
 %This will have to be modified once the model structure is set.
 
 

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -50,6 +50,15 @@ model = addReaction(model, 'EX_glc', model.mets, sc, 0, 0, 20);
 % adding a reaction to the model (test only)
 model = addReaction(model, 'ABC_def', model.mets, 2 * sc, 0, -5, 10);
 
+%Now, add some fields by an extensive addReaction call
+modelWithFields = addReaction(model,'TestReaction','reactionFormula','A + B -> C','subSystem','Some Sub','geneRule','GeneA or GeneB');
+assert(verifyModel(modelWithFields,'simpleCheck',true,'requiredFields',{}))
+
+%And test this also with a different input of subSystems:
+modelWithFields = addReaction(model,'TestReaction','reactionFormula','A + B -> C','subSystem',{'Some Sub', 'And another sub'},'geneRule','GeneA or GeneB');
+assert(verifyModel(modelWithFields,'simpleCheck',true,'requiredFields',{}))
+
+
 %Trying to add a reaction without stoichiometry will fail.
 errorCall = @() addReaction(model,'NoStoich');
 assert(verifyCobraFunctionError(errorCall));


### PR DESCRIPTION
Unfortunately df51b559fe230aafe0a427ee69a93708520a73c3 was invalid. The change modified addReaction such that the properties of subSystems were no longer correct (no longer cell arrays of cell arrays of strings).
This PR reverts the change and adds a test that this does not happen in the future. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
