### PR TITLE
:bug: Fixing bug for MILP solver using IBM CPLEX

### DIFF
--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -436,11 +436,12 @@ switch solver
         end
         
         % Get results
-        try x = Result.x; catch x=zeros(size(cplexlp.Model.ub)); end %return zeros if infeasible
-        try f = osense*Result.objval; catch f=nan; end %return Nan if infeasible
         stat = Result.status;
         if (stat == 101 || stat == 102 || stat == 1)
             solStat = 1; % Opt integer within tolerance
+            % Return solution if problem is feasible, bounded and optimal
+            x = Result.x;
+            f = osense*Result.objval;
         elseif (stat == 103 || stat == 3)
             solStat = 0; % Integer infeas
         elseif (stat == 118 || stat == 119 || stat == 2)

--- a/src/base/solvers/solveCobraMILP.m
+++ b/src/base/solvers/solveCobraMILP.m
@@ -357,7 +357,11 @@ switch solver
         else
            solStat = -1; % Solution not optimal or solver problem
         end
+        
     case 'ibm_cplex'
+        % Free academic licenses for the IBM CPLEX solver can be obtained from
+        % https://www.ibm.com/developerworks/community/blogs/jfp/entry/CPLEX_Is_Free_For_Students?lang=en
+
         cplexlp = Cplex();
         if (~isempty(csense))
             b_L(csense == 'E') = b(csense == 'E');
@@ -432,8 +436,8 @@ switch solver
         end
         
         % Get results
-        x = Result.x;
-        f = osense*Result.objval;
+        try x = Result.x; catch x=zeros(size(cplexlp.Model.ub)); end %return zeros if infeasible
+        try f = osense*Result.objval; catch f=nan; end %return Nan if infeasible
         stat = Result.status;
         if (stat == 101 || stat == 102 || stat == 1)
             solStat = 1; % Opt integer within tolerance


### PR DESCRIPTION
Whenever I tried to compute an infeasible problem with ibm_cplex using solveCobraMILP, I obtained an error. This error was not produced by GLPK, which returns "nan" as the solution when trying to solve an infeasible problem.

I have included some lines of code to return a solution similar to GLPK when trying to solve an infeasible problem using ibm_cplex.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
