### PR TITLE
added solution condition number field

### DIFF
--- a/src/base/solvers/solveCobraLPCPLEX.m
+++ b/src/base/solvers/solveCobraLPCPLEX.m
@@ -344,6 +344,7 @@ switch interface
             solution.origStat   = ILOGcplex.Solution.status;
             solution.solver     = ILOGcplex.Solution.method;
             solution.time       = ILOGcplex.Solution.time;
+            solution.kappa      = ILOGcplex.Solution.quality.kappa.value;
         else
             warning(['IBM CPLEX STATUS = ' int2str(ILOGcplex.Solution.status) ', see: http://www-01.ibm.com/support/knowledgecenter/SSSA5P_12.2.0/ilog.odms.cplex.help/Content/Optimization/Documentation/CPLEX/_pubskel/CPLEX1210.html'])
             solution.origStat   = ILOGcplex.Solution.status;


### PR DESCRIPTION
*Please include a short description of enhancement here*
- I added the solution condition number (kappa) field in the output of solveCobraLPCPLEX.
- This is working with IBM CPLEX now, I couldn't find the equivalent in TOMLAB.
- The value of kappa allows to determine the stability of the solution esp with ill-conditioned programs.
Usually kappa < 1e-7 indicates a stable solution. More here
https://www.ibm.com/support/knowledgecenter/SS9UKU_12.6.1/com.ibm.cplex.zos.help/CPLEX/UsrMan/topics/cont_optim/simplex/20_num_difficulty.html  

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
