### PR TITLE
Fix for temporary files during solveCobraLP (#1030)

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -92,9 +92,10 @@ function initCobraToolbox()
     % retrieve the current directory
     currentDir = pwd;
 
-    % define the root path of The COBRA Toolbox
+    % define the root path of The COBRA Toolbox and change to it.
     CBTDIR = fileparts(which('initCobraToolbox'));
-
+    cd(CBTDIR);
+    
     % add the external install folder
     addpath(genpath([CBTDIR filesep 'external' filesep 'install']));
 

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -376,7 +376,7 @@ switch solver
         % set the temporary path to the DQQ solver
         tmpPath = [CBTDIR filesep 'binary' filesep computer('arch') filesep 'bin' filesep 'DQQ'];
         cd(tmpPath);
-
+        cleanUp = onCleanup(@() DQQCleanup(tmpPath));
         % create the
         if ~exist([tmpPath filesep 'MPS'], 'dir')
             mkdir([tmpPath filesep 'MPS'])
@@ -451,15 +451,6 @@ switch solver
         else
             stat = -1;  % Solution not optimal or solver problem
         end
-        % cleanup
-        rmdir([tmpPath filesep 'results'], 's');
-        fortFiles = [4, 9, 10, 11, 12, 13, 60, 81];
-        for k = 1:length(fortFiles)
-            delete(['fort.', num2str(fortFiles(k))]);
-        end
-
-        % remove the temporary .mps model file
-        rmdir([tmpPath filesep 'MPS'], 's')
 
         % return to original directory
         cd(originalDirectory);
@@ -1768,4 +1759,21 @@ elseif (origStat == 184 || origStat == 6)
     stat = 2; % Unbounded
 else
     stat = -1; % Solution not optimal or solver problem
+end
+
+
+function DQQCleanup(tmpPath)
+% perform cleanup after DQQ.
+try
+% cleanup        
+        rmdir([tmpPath filesep 'results'], 's');
+        fortFiles = [4, 9, 10, 11, 12, 13, 60, 81];
+        for k = 1:length(fortFiles)
+            delete([tmpPath filesep 'fort.', num2str(fortFiles(k))]);
+        end
+catch
+end
+try        % remove the temporary .mps model file
+        rmdir([tmpPath filesep 'MPS'], 's')
+catch
 end

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -384,7 +384,7 @@ switch solver
         tmpPath = [CBTDIR filesep 'binary' filesep computer('arch') filesep 'bin' filesep 'DQQ'];
         cd(tmpPath);
         if ~debug % IF debugging leave the files in case of an error.
-            cleanUp = onCleanup(@() DQQCleanup(tmpPath));
+            cleanUp = onCleanup(@() DQQCleanup(tmpPath,originalDirectory));
         end
         % create the
         if ~exist([tmpPath filesep 'MPS'], 'dir')
@@ -468,6 +468,7 @@ switch solver
         if ~isunix
             error('Minos and quadMinos can only be used on UNIX systems (macOS or Linux).')
         end
+        originalDirectory = pwd;
 
         % input precision
         precision = 'double';  % 'single'
@@ -483,11 +484,10 @@ switch solver
         [dataDirectory, fname] = writeMinosProblem(LPproblem, precision, modelName, dataDirectory, printLevel);
         
         if ~debug % IF debugging leave the files in case of an error.
-            cleanUp = onCleanup(@() minosCleanUp(MINOS_PATH,fname));
+            cleanUp = onCleanup(@() minosCleanUp(MINOS_PATH,fname,originalDirectory));
         end
         
         % change system to testFBA directory
-        originalDirectory = pwd;
         cd([MINOS_PATH]);
 
         % call minos
@@ -1755,7 +1755,7 @@ else
 end
 
 
-function DQQCleanup(tmpPath)
+function DQQCleanup(tmpPath, originalDirectory)
 % perform cleanup after DQQ.
 try
 % cleanup        
@@ -1770,9 +1770,11 @@ try        % remove the temporary .mps model file
         rmdir([tmpPath filesep 'MPS'], 's')
 catch
 end
+cd(originalDirectory);
 
 
-function minosCleanUp(MINOS_PATH,fname)
+
+function minosCleanUp(MINOS_PATH,fname, originalDirectory)
 % CleanUp after Minos Solver.
 
 fileEnding = {'.sol', '.out', '.newbasis', '.basis', '.finalbasis'};
@@ -1796,3 +1798,5 @@ for k = 1:length(fileEnding)
         end
     end
 end
+
+cd(originalDirectory);


### PR DESCRIPTION
Adressing #1030.
Changes solveCobraLP for minos and dqqminos to always clean up the files (even when there is an error).
Added a debug flag, that will leave these files for debugging purposes. 
Also switches to the cobra tolbox directory during init (to avoid git warnings about this not being a git folder and global git configuration problems).


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
