### PR TITLE
Activate the Sampler Test on Windows

### DIFF
--- a/external/sparseNull.m
+++ b/external/sparseNull.m
@@ -1,7 +1,7 @@
-function N = sparseNull(S, tol)
+function [N,rankS] = sparseNull(S, tol)
 % sparseNull returns computes the sparse Null basis of a matrix
 %
-% N = sparseNull(S, tol)
+% [N,rankS] = sparseNull(S, tol)
 % 
 % Computes a basis of the null space for a sparse matrix.  For sparse
 % matrixes this is much faster than using null.  It does however have lower
@@ -11,11 +11,14 @@ function N = sparseNull(S, tol)
 % Jan Schellenberger 10/20/2009 
 % based on this:
 % http://www.mathworks.com/matlabcentral/fileexchange/11120-null-space-of-a-sparse-matrix
+% Modified Tomas Pfau -> The size of the U is exactly the rank of the
+% matrix (up to the tolerance).
 if nargin <2
     tol = 1e-9;
 end
 [SpLeft, SpRight] = spspaces(S,2, tol);
 N = SpRight{1}(:,SpRight{3});
+rankS = numel(SpRight{2});
 N(abs(N) < tol) = 0;
 
 

--- a/src/analysis/subspaces/nullspace/getNullSpace.m
+++ b/src/analysis/subspaces/nullspace/getNullSpace.m
@@ -28,13 +28,26 @@ if m>n & 0%TODO need to check this
 end
 
 gmscale=1;%by default, use geometric mean scaling of S
+archstr = computer('arch');
+archstr = lower(archstr);
+switch archstr
+    case {'win32', 'win64'}        
+        if issparse(S) && any(size(S) > 3000)
+            [Z,rankS] = sparseNull(S);
+            
+        else % for small matrices or those which are full, use the normal matlab functions
+            Z = null(full(S));
+            rankS = rank(full(S));
+        end
+    case {'glnxa64','maci64','glnxa86'}
+        nullS = nullSpaceOperator(S,gmscale,printLevel);        % forms a structure nullS.
+        rankS = nullS.rank;
+        V     = speye(n-rankS,n-rankS);       % is a sparse I of order n-rankS.
+        Z     = nullSpaceOperatorApply(nullS,V); % satisfies S*Z = 0.
 
-nullS = nullSpaceOperator(S,gmscale,printLevel);        % forms a structure nullS.
-rankS = nullS.rank;
-V     = speye(n-rankS,n-rankS);       % is a sparse I of order n-rankS.
-Z     = nullSpaceOperatorApply(nullS,V); % satisfies S*Z = 0.
+        % Check if S*Z = 0.
+end
 
-% Check if S*Z = 0.
 SZ    = S*Z;
 normSZ= norm(SZ,inf);
 

--- a/src/analysis/subspaces/nullspace/getNullSpace.m
+++ b/src/analysis/subspaces/nullspace/getNullSpace.m
@@ -44,10 +44,9 @@ switch archstr
         rankS = nullS.rank;
         V     = speye(n-rankS,n-rankS);       % is a sparse I of order n-rankS.
         Z     = nullSpaceOperatorApply(nullS,V); % satisfies S*Z = 0.
-
-        % Check if S*Z = 0.
 end
 
+% Check if S*Z = 0.
 SZ    = S*Z;
 normSZ= norm(SZ,inf);
 

--- a/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
+++ b/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
@@ -13,84 +13,80 @@ currentDir = pwd;
 fileDir = fileparts(which('testSampleCbModel'));
 cd(fileDir);
 
-if isunix
-    % define the samplers
-    samplers = {'ACHR', 'CHRR'}; %'MFE'
-    
-    % create a parallel pool (if possible)
-    try
-        minWorkers = 2;
-        myCluster = parcluster(parallel.defaultClusterProfile);
+% define the samplers
+samplers = {'ACHR', 'CHRR'}; %'MFE'
 
+% create a parallel pool (if possible)
+try
+    minWorkers = 2;
+    myCluster = parcluster(parallel.defaultClusterProfile);
+    
     if myCluster.NumWorkers >= minWorkers
         poolobj = gcp('nocreate');  % if no pool, do not create new one.
         if isempty(poolobj)
             parpool(minWorkers);  % launch minWorkers workers
         end
     end
-    catch
-            %No pool
-    end
-    % define the solver packages to be used to run this test
-    solverPkgs = {'gurobi6', 'tomlab_cplex'};
-
-    for k = 1:length(solverPkgs)
-        fprintf('   Testing sampleCbModel using %s ... \n', solverPkgs{k});
-
-        % set the solver
-        solverOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
-
-        if solverOK == 1
-
-            % Load model
-            model = getDistributedModel('ecoli_core_model.mat');
-
-            for i = 1:length(samplers)
-
-                samplerName = samplers{i};
-
-                switch samplerName
-                    case 'ACHR'
-                        fprintf('\nTesting the artificial centering hit-and-run (ACHR) sampler\n.');
-
-                        options.nFiles = 4;
-                        options.nStepsPerPoint = 5;
-                        options.nPointsReturned = 20;
-                        options.nPointsPerFile = 5;
-                        options.nFilesSkipped = 0;
-                        options.nWarmupPoints = 200;
-
-                        [modelSampling, samples, volume] = sampleCbModel(model, 'EcoliModelSamples', 'ACHR', options);
-
-                        % check if sample files created
-                        if exist('EcoliModelSamples_1.mat', 'file') == 2 && exist('EcoliModelSamples_2.mat', 'file') == 2 && exist('EcoliModelSamples_3.mat', 'file') == 2 && exist('EcoliModelSamples_4.mat', 'file') == 2
-                            display('Sample files generated');
-                            % check if model reduced and rxns removed
-                            removedRxns = find(~ismember(model.rxns, modelSampling.rxns));
-                            assert(all(removedRxns == [26; 27; 29; 34; 45; 47; 52; 63]))
-                        else
-                            display('Sample files not found');
-                        end
-
-                    case 'CHRR'
-                        fprintf('\nTesting the coordinate hit-and-run with rounding (CHRR) sampler\n.');
-
-                        options.nStepsPerPoint = 1;
-                        options.nPointsReturned = 10;
-
-                        [modelSampling, samples, volume] = sampleCbModel(model, 'EcoliModelSamples', 'CHRR', options);
-
-                        assert(norm(samples) > 0)
-                end
-            end
-
-            % print a line for success of loop i
-            fprintf(' Done.\n');
-        end
-    end
-else
-    fprintf(' > Skipping testSampleCbModel (incompatible operating system).\n');
+catch
+    %No pool
 end
+% define the solver packages to be used to run this test
+solverPkgs = {'gurobi6', 'tomlab_cplex'};
+
+for k = 1:length(solverPkgs)
+    fprintf('   Testing sampleCbModel using %s ... \n', solverPkgs{k});
+    
+    % set the solver
+    solverOK = changeCobraSolver(solverPkgs{k}, 'LP', 0);
+    
+    if solverOK == 1
+        
+        % Load model
+        model = getDistributedModel('ecoli_core_model.mat');
+        
+        for i = 1:length(samplers)
+            
+            samplerName = samplers{i};
+            
+            switch samplerName
+                case 'ACHR'
+                    fprintf('\nTesting the artificial centering hit-and-run (ACHR) sampler\n.');
+                    
+                    options.nFiles = 4;
+                    options.nStepsPerPoint = 5;
+                    options.nPointsReturned = 20;
+                    options.nPointsPerFile = 5;
+                    options.nFilesSkipped = 0;
+                    options.nWarmupPoints = 200;
+                    
+                    [modelSampling, samples, volume] = sampleCbModel(model, 'EcoliModelSamples', 'ACHR', options);
+                    
+                    % check if sample files created
+                    assert(exist('EcoliModelSamples_1.mat', 'file') == 2 && exist('EcoliModelSamples_2.mat', 'file') == 2 && exist('EcoliModelSamples_3.mat', 'file') == 2 && exist('EcoliModelSamples_4.mat', 'file') == 2)
+                    removedRxns = find(~ismember(model.rxns, modelSampling.rxns));
+                    assert(all(removedRxns == [26; 27; 29; 34; 45; 47; 52; 63]))                    
+                    
+                case 'CHRR'
+                    if ~isunix
+                        fprintf('CHRR sampler not compatible with Operating System\n');
+                        continue;
+                    end
+                    fprintf('\nTesting the coordinate hit-and-run with rounding (CHRR) sampler\n.');
+                    
+                    options.nStepsPerPoint = 1;
+                    options.nPointsReturned = 10;
+                    
+                    [modelSampling, samples, volume] = sampleCbModel(model, 'EcoliModelSamples', 'CHRR', options);
+                    
+                    assert(norm(samples) > 0)
+            end
+        end
+        
+        % print a line for success of loop i
+        fprintf(' Done.\n');
+    end
+end
+
 
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
+++ b/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
@@ -31,7 +31,7 @@ catch
     %No pool
 end
 % define the solver packages to be used to run this test
-solverPkgs = {'gurobi6', 'tomlab_cplex'};
+solverPkgs = {'gurobi', 'tomlab_cplex'};
 
 for k = 1:length(solverPkgs)
     fprintf('   Testing sampleCbModel using %s ... \n', solverPkgs{k});

--- a/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
+++ b/test/verifiedTests/analysis/testSampling/testSampleCbModel.m
@@ -67,10 +67,6 @@ for k = 1:length(solverPkgs)
                     assert(all(removedRxns == [26; 27; 29; 34; 45; 47; 52; 63]))                    
                     
                 case 'CHRR'
-                    if ~isunix
-                        fprintf('CHRR sampler not compatible with Operating System\n');
-                        continue;
-                    end
                     fprintf('\nTesting the coordinate hit-and-run with rounding (CHRR) sampler\n.');
                     
                     options.nStepsPerPoint = 1;


### PR DESCRIPTION
sampleCbModel was not tested on Windows systems. 
While it is true, that the CHRR sampler uses linux binaries, and thus can't be used on a Windows OS, ACHR sampling can readily be tested on a Windows OS, and thus should be tested.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
