### PR TITLE
ChangecobraSolver Correction

### DIFF
--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -411,7 +411,7 @@ if solverOK
     eval(['CBT_', solverType, '_SOLVER = solverName;']);
     Problem = struct('A',[0 1],'b',0,'c',[1;1],'osense',-1,'F',speye(2),'lb',[0;0],'ub',[0;0],'csense','E','vartype',['C';'I'],'x0',[0;0]);    
     try
-        eval(['solveCobra' solverType '(Problem,''printLevel'', 0);'])
+        evalc(['solveCobra' solverType '(Problem,''printLevel'', 0);']);
     catch ME
         solverOK = false;
         eval(['CBT_', solverType, '_SOLVER = oldval;']);


### PR DESCRIPTION
This PR leads to the surpression of the output of calls the solver test in changeCobraSolver.
It should make initCobraToolbox look nicer again.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
