### PR TITLE
Batch Addition of Reactions/Metabolites/Genes

### DIFF
--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -1,42 +1,46 @@
-Model Field	Xdim	Ydim	Evaluator	databaseid	qualifier	referenced Field	Default Value	DBPatterns	Property Description	Field Description	FBABasicField
-S	mets	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	The stoichiometric matrix containing the model structure (for large models a sparse format is suggested)	'true(1)'
-mets	mets	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['M' num2str(i)]		Column Cell Array of Strings	Identifiers of the metabolites	'true(1)'
-b	mets	1	isnumeric(x)				0		Column Vector of Doubles	The coefficients of the constraints of the metabolites.	'true(1)'
-csense	mets	1	ischar(x)				E		Column Vector of Chars	The sense of the constraints represented by b, each row is either E (equality), L(less than) or G(greater than)	'true(1)'
-rxns	rxns	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['R' num2str(i)]		Column Cell Array of Strings	Identifiers for the reactions.	'true(1)'
-lb	rxns	1	isnumeric(x)				-1000		Column Vector of Doubles	The lower bounds for fluxes through the reactions.	'true(1)'
-ub	rxns	1	isnumeric(x)				1000		Column Vector of Doubles	The upper bounds for fluxes through the reactions.	'true(1)'
-c	rxns	1	isnumeric(x)				0		Column Vector of Doubles	The objective coefficient of the reactions.	'true(1)'
-osense	1	1	isnumeric(x)				-1		Double	The objective sense either -1 for maximisation or 1 for minimisation	'true(1)'
-genes	genes	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['G' num2str(i)]		Column Cell Array of Strings	Identifiers of the genes in the model	'true(1)'
-rules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	GPR rules in evaluateable format for each reaction ( e.g. "x(1) &#124; x(2) & x(3)", would indicate the first gene or both the second and third gene are necessary for the respective reaction to carry flux	'true(1)'
-geneNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))		is	genes	model.genes{i}		Column Cell Array of Strings	Full names of each corresponding genes.	'false(1)'
-compNames	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.comps{i}		Column Cell Array of Strings	Descriptions of the Compartments (compNames(m) is associated with comps(m))	'false(1)'
-comps	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['C' num2str{i}]		Column Cell Array of Strings	Symbols for compartments, can include Tissue information	'false(1)'
-proteinNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.proteins{i}		Column Cell Array of Strings	Full Name for each Protein	'false(1)'
-proteins	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['COBRAProtein' num2str(i)]		Column Cell Array of Strings	Proteins associated with each gene.	'false(1)'
-metCharges	mets	1	isnumeric(x)				NaN		Column Vector of Double	The charge of the respective metabolite (NaN if unknown)	'false(1)'
-metFormulas	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Elemental formula for each metabolite.	'false(1)'
-metSmiles	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Formula for each metabolite in SMILES Format	'false(1)'
-metNames	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.mets{i}		Column Cell Array of Strings	Full name of each corresponding metabolite.	'false(1)'
-metNotes	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Additional Notes for the respective metabolite.	'false(1)'
-metHMDBID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	hmdb	is	mets	''	^HMDB\d{5}$	Column Cell Array of Strings	HMDB ID of the metabolite.	'false(1)'
-metInChIString	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	inchi	is	mets	''	^InChI\=1S?\/[A-Za-z0-9]+(\+[0-9]+)?(\/[cnpqbtmsih][A-Za-z0-9\-\+\(\)\,\/]+)*$	Column Cell Array of Strings	Formula for each metabolite in the InCHI strings format.	'false(1)'
-metKEGGID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.compound;kegg	is	mets	''	^C\d+$	Column Cell Array of Strings	KEGG ID of the metabolite.	'false(1)'
-metChEBIID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	chebi;obo.chebi	is	mets	''	^CHEBI:\d+$	Column Cell Array of Strings	ChEBI ID of the metabolite.	'false(1)'
-metPubChemID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubchem.compound	is	mets	''	^\d+$	Column Cell Array of Strings	PubChem ID of each metabolite	'false(1)'
-metMetaNetXID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.chemical	is	mets	''	^MNXM\d+$	Column Cell Array of Strings	MetaNetX identifier of the metabolite	'false(1)'
-metSBOTerms	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	mets	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the metabolite	'false(1)'
-description	NaN	NaN	ischar(x) || isstruct(x)				struct()		String or Struct	Name of a file the model is loaded from.	'false(1)'
-modelVersion	NaN	NaN	isstruct(x)				struct()		Struct	Information on the model version	'false(1)'
-geneEntrezID	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ncbigene	is;isEncodedBy	genes	''	^\d+$	Column Cell Array of Strings	Entrez IDs of genes	'false(1)'
-grRules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	A string representation of the GPR rules defined in a readable format.	'false(1)'
-rxnGeneMat	rxns	genes	issparse(x) || isnumeric(x) || islogical(x)				0		Sparse or Full Matrix of Double or Boolean	Matrix with rows corresponding to reactions and columns corresponding to genes.	'false(1)'
-rxnConfidenceScores	rxns	1	isnumeric(x) || iscell(x) && isnumeric(cellfun(str2num,x))				0		Column Vector of double	Confidence scores for reaction presence (0-5, with 5 being the highest confidence)	'false(1)'
-rxnNames	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.rxns{i}		Column Cell Array of Strings	Full name of each corresponding reaction.	'false(1)'
-rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Description of each corresponding reaction.	'false(1)'
-rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is;isVersionOf	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.	'false(1)'
-rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.	'false(1)'
-rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'
-rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	rxns	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'
-subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(strjoin([y(:)],';')) , x))				{''}		Column Cell Array of Cell Arrays of Strings	subSystem assignment for each reaction	'false(1)'
+Model Field	Xdim	Ydim	Evaluator	databaseid	qualifier	referenced Field	Default Value	DBPatterns	Property Description	Field Description	FBABasicField	FieldBasisType
+S	mets	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	The stoichiometric matrix containing the model structure (for large models a sparse format is suggested)	'true(1)'	sparse
+mets	mets	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['M' num2str(i)]		Column Cell Array of Strings	Identifiers of the metabolites	'true(1)'	cell
+b	mets	1	isnumeric(x)				0		Column Vector of Doubles	The coefficients of the constraints of the metabolites.	'true(1)'	numeric
+csense	mets	1	ischar(x)				E		Column Vector of Chars	The sense of the constraints represented by b, each row is either E (equality), L(less than) or G(greater than)	'true(1)'	char
+rxns	rxns	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['R' num2str(i)]		Column Cell Array of Strings	Identifiers for the reactions.	'true(1)'	cell
+lb	rxns	1	isnumeric(x)				-1000		Column Vector of Doubles	The lower bounds for fluxes through the reactions.	'true(1)'	numeric
+ub	rxns	1	isnumeric(x)				1000		Column Vector of Doubles	The upper bounds for fluxes through the reactions.	'true(1)'	numeric
+c	rxns	1	isnumeric(x)				0		Column Vector of Doubles	The objective coefficient of the reactions.	'true(1)'	numeric
+osense	1	1	isnumeric(x)				-1		Double	The objective sense either -1 for maximisation or 1 for minimisation	'true(1)'	numeric
+genes	genes	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['G' num2str(i)]		Column Cell Array of Strings	Identifiers of the genes in the model	'true(1)'	cell
+rules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	GPR rules in evaluateable format for each reaction ( e.g. "x(1) &#124; x(2) & x(3)", would indicate the first gene or both the second and third gene are necessary for the respective reaction to carry flux	'true(1)'	cell
+geneNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))		is	genes	model.genes{i}		Column Cell Array of Strings	Full names of each corresponding genes.	'false(1)'	cell
+compNames	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.comps{i}		Column Cell Array of Strings	Descriptions of the Compartments (compNames(m) is associated with comps(m))	'false(1)'	cell
+comps	comps	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['C' num2str{i}]		Column Cell Array of Strings	Symbols for compartments, can include Tissue information	'false(1)'	cell
+proteinNames	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.proteins{i}		Column Cell Array of Strings	Full Name for each Protein	'false(1)'	cell
+proteins	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				['COBRAProtein' num2str(i)]		Column Cell Array of Strings	Proteins associated with each gene.	'false(1)'	cell
+metCharges	mets	1	isnumeric(x)				NaN		Column Vector of Double	The charge of the respective metabolite (NaN if unknown)	'false(1)'	numeric
+metFormulas	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Elemental formula for each metabolite.	'false(1)'	cell
+metSmiles	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Formula for each metabolite in SMILES Format	'false(1)'	cell
+metNames	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.mets{i}		Column Cell Array of Strings	Full name of each corresponding metabolite.	'false(1)'	cell
+metNotes	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Additional Notes for the respective metabolite.	'false(1)'	cell
+metHMDBID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	hmdb	is	mets	''	^HMDB\d{5}$	Column Cell Array of Strings	HMDB ID of the metabolite.	'false(1)'	cell
+metInChIString	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	inchi	is	mets	''	^InChI\=1S?\/[A-Za-z0-9]+(\+[0-9]+)?(\/[cnpqbtmsih][A-Za-z0-9\-\+\(\)\,\/]+)*$	Column Cell Array of Strings	Formula for each metabolite in the InCHI strings format.	'false(1)'	cell
+metKEGGID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.compound;kegg	is	mets	''	^C\d+$	Column Cell Array of Strings	KEGG ID of the metabolite.	'false(1)'	cell
+metChEBIID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	chebi;obo.chebi	is	mets	''	^CHEBI:\d+$	Column Cell Array of Strings	ChEBI ID of the metabolite.	'false(1)'	cell
+metPubChemID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubchem.compound	is	mets	''	^\d+$	Column Cell Array of Strings	PubChem ID of each metabolite	'false(1)'	cell
+metMetaNetXID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.chemical	is	mets	''	^MNXM\d+$	Column Cell Array of Strings	MetaNetX identifier of the metabolite	'false(1)'	cell
+metSBOTerms	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	mets	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the metabolite	'false(1)'	cell
+description	NaN	NaN	ischar(x) || isstruct(x)				struct()		String or Struct	Name of a file the model is loaded from.	'false(1)'	char
+modelVersion	NaN	NaN	isstruct(x)				struct()		Struct	Information on the model version	'false(1)'	struct
+geneEntrezID	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ncbigene	is;isEncodedBy	genes	''	^\d+$	Column Cell Array of Strings	Entrez IDs of genes	'false(1)'	cell
+grRules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	A string representation of the GPR rules defined in a readable format.	'false(1)'	cell
+rxnGeneMat	rxns	genes	issparse(x) || isnumeric(x) || islogical(x)				0		Sparse or Full Matrix of Double or Boolean	Matrix with rows corresponding to reactions and columns corresponding to genes.	'false(1)'	sparselogical
+rxnConfidenceScores	rxns	1	isnumeric(x) || iscell(x) && isnumeric(cellfun(str2num,x))				0		Column Vector of double	Confidence scores for reaction presence (0-5, with 5 being the highest confidence)	'false(1)'	numeric
+rxnNames	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				model.rxns{i}		Column Cell Array of Strings	Full name of each corresponding reaction.	'false(1)'	cell
+rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	Description of each corresponding reaction.	'false(1)'	cell
+rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is;isVersionOf	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.	'false(1)'	cell
+rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.	'false(1)'	cell
+rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'	cell
+rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	rxns	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'	cell
+subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(strjoin([y(:)],';')) , x))				{''}		Column Cell Array of Cell Arrays of Strings	subSystem assignment for each reaction	'false(1)'	cell
+ctrs	ctrs	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['Constraint' num2str(i)]		Column Cell Array of Strings	Names for non metabolic constraints (e.g. coupling constraints)	'false(1)'	cell
+C	ctrs	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	Coefficients of the non metabolic constraints	'false(1)'	sparse
+d	ctrs	1	isnumeric(x)				0		Column Vector of Doubles	Right hand side of the non metabolic constraints	'false(1)'	numeric
+dsense	ctrs	1	ischar(x)				E		Column Vector of Chars	Sense of the non metabolic constraints.	'false(1)'	char

--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -40,7 +40,3 @@ rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDesc
 rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'	cell
 rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	rxns	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'	cell
 subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(strjoin([y(:)],';')) , x))				{''}		Column Cell Array of Cell Arrays of Strings	subSystem assignment for each reaction	'false(1)'	cell
-ctrs	ctrs	1	iscell(x) && ~any(cellfun(@isempty, x)) && all(cellfun(@(y) ischar(y) , x))				['Constraint' num2str(i)]		Column Cell Array of Strings	Names for non metabolic constraints (e.g. coupling constraints)	'false(1)'	cell
-C	ctrs	rxns	isnumeric(x) || issparse(x)				0		Sparse or Full Matrix of Double	Coefficients of the non metabolic constraints	'false(1)'	sparse
-d	ctrs	1	isnumeric(x)				0		Column Vector of Doubles	Right hand side of the non metabolic constraints	'false(1)'	numeric
-dsense	ctrs	1	ischar(x)				E		Column Vector of Chars	Sense of the non metabolic constraints.	'false(1)'	char

--- a/src/base/io/utilities/createEmptyFields.m
+++ b/src/base/io/utilities/createEmptyFields.m
@@ -72,9 +72,13 @@ for field = 1:length(fieldNames)
             model.(fieldNames{field}) = sparse(xdim,ydim);            
         case 'cell'
             model.(fieldNames{field}) =cell(xdim,ydim);
-            for i = 1:xdim
-                eval(['currentvalue = ' defaultValue ]);
-                model.(fieldNames{field}){i} = currentvalue;
+            if strcmp(eval(defaultValue),'')
+                model.(fieldNames{field})(:) = {''};
+            else
+                for i = 1:xdim
+                    eval(['currentvalue = ' defaultValue ';' ]);
+                    model.(fieldNames{field}){i} = currentvalue;
+                end
             end
         case 'numeric'
             model.(fieldNames{field}) = repmat(defaultValue,xdim,ydim);            

--- a/src/base/io/utilities/createEmptyFields.m
+++ b/src/base/io/utilities/createEmptyFields.m
@@ -1,0 +1,86 @@
+function model = createEmptyFields(model,fieldNames, fieldDefinitions)
+%Create the specified model field with its default values. Works only for
+%fields defined in the toolbox if fieldDefinitions are not supplied.
+%
+% USAGE:
+%    model = createEmptyFields(model,fieldName, fieldDefinitions)
+%
+% INPUTS:
+%
+%    model:                 The model to add a field to
+%    fieldNames:            The names of the fields to add.
+%
+% OPTIONAL INPUTS:
+%    fieldDefinitions:      The Specifications of the field. Only necessary
+%                           if a field which is not defined yet should be
+%                           added.
+%
+% OUTPUTS:
+%
+%    model:                 The original model struct with the specified
+%                           field added.
+%
+% Author:
+%    Thomas Pfau Nov 2017
+
+if ischar(fieldNames)
+    fieldNames = {fieldNames};
+end
+
+if ~exist('fieldDefinitions','var') || isempty(fieldDefinitions)
+    fieldDefinitions = getDefinedFieldProperties('SpecificFields',fieldNames);
+end
+
+if isempty(fieldDefinitions)
+    error('Supplied Field name invalid.')
+end
+for field = 1:length(fieldNames)
+    %Get the dimensions
+    xdim = fieldDefinitions{field,2};
+    ydim = fieldDefinitions{field,3};
+    
+    %And adjust if necessary
+    if isnan(xdim)
+        xdim = 1;
+    end
+    
+    if ischar(xdim)
+        if isfield(model,xdim)
+            xdim = size(model.(xdim),1);
+        else
+            xdim = 0;
+        end
+    end
+    
+    if isnan(ydim)
+        ydim = 1;
+    end
+    
+    if ischar(ydim)
+        if isfield(model,ydim)
+            ydim = size(model.(ydim),1);
+        else
+            ydim = 0;
+        end
+    end
+    
+    fieldType = fieldDefinitions{field,7};
+    defaultValue = fieldDefinitions{field,5};
+    
+    switch fieldType
+        case 'sparse'
+            model.(fieldNames{field}) = sparse(xdim,ydim);            
+        case 'cell'
+            model.(fieldNames{field}) =cell(xdim,ydim);
+            for i = 1:xdim
+                eval(['currentvalue = ' defaultValue ]);
+                model.(fieldNames{field}){i} = currentvalue;
+            end
+        case 'numeric'
+            model.(fieldNames{field}) = repmat(defaultValue,xdim,ydim);            
+        case 'sparselogical'
+            model.(fieldNames{field}) = sparse(repmat(logical(defaultValue),xdim,ydim));            
+        case 'char'
+            model.(fieldNames{field}) = repmat(defaultValue,xdim,ydim);            
+    end
+end

--- a/src/base/io/utilities/getDefinedFieldProperties.m
+++ b/src/base/io/utilities/getDefinedFieldProperties.m
@@ -54,7 +54,6 @@ persistent CBT_PROG_FIELD_PROPS
 persistent CBT_DESC_FIELD_PROPS
 persistent CBT_DB_FIELD_PROPS
 
-
 parser = inputParser();
 parser.addParamValue('Descriptions',false,@(x) isnumeric(x) | islogical(x))
 parser.addParamValue('SpecificFields',{},@iscell)
@@ -143,8 +142,8 @@ if isempty(CBT_PROG_FIELD_PROPS)
      end
     %Get the indices for database, qualifier and reference.
     relrows = cellfun(@(x) ischar(x) && ~isempty(x),raw.Model_Field);
-    relarray = [raw.Model_Field(relrows),raw.Xdim(relrows),raw.Ydim(relrows),raw.Evaluator(relrows),raw.Default_Value(relrows),raw.FBABasicField(relrows)];
-    progInfo = cell(0,6);
+    relarray = [raw.Model_Field(relrows),raw.Xdim(relrows),raw.Ydim(relrows),raw.Evaluator(relrows),raw.Default_Value(relrows),raw.FBABasicField(relrows),raw.FieldBasisType];
+    progInfo = cell(0,7);
     for i = 1:size(relarray)
         xval = relarray{i,2};
         if ~isnumeric(xval)
@@ -167,12 +166,17 @@ if isempty(CBT_PROG_FIELD_PROPS)
             end
         end
         fbaReq = eval(eval(relarray{i,6}));        
-        progInfo(i,:) = { relarray{i,1},xval,yval,relarray{i,4}, default,fbaReq};
+        FieldType = relarray{i,7};  
+        progInfo(i,:) = { relarray{i,1},xval,yval,relarray{i,4}, default,fbaReq,FieldType};
     end
     CBT_PROG_FIELD_PROPS = progInfo;
 end
 fields = CBT_PROG_FIELD_PROPS;
 
 if ~isempty(spec)
-    fields = fields(ismember(fields(:,1),spec),:);
+    [fieldPres,fieldpos] = ismember(spec,fields(:,1));
+    if ~all(fieldPres)
+        error('The following requesteds fields have no Specifications:\n%s\n',strjoin(spec(~fieldPres),',\n'));
+    end
+    fields = fields(fieldpos(fieldPres),:);
 end

--- a/src/reconstruction/refinement/addGeneBatch.m
+++ b/src/reconstruction/refinement/addGeneBatch.m
@@ -2,7 +2,7 @@ function newmodel = addGeneBatch(model,geneIDs,varargin)
 %Add a batch of genes to the model.
 % USAGE:
 %
-%    model = addMetaboliteBatch(model,metIDs,varargin)
+%    model = addMetaboliteBatch(model,geneIDs,varargin)
 %
 % INPUTS:
 %    model:             The model to add the Metabolite batch to.
@@ -18,9 +18,11 @@ function newmodel = addGeneBatch(model,geneIDs,varargin)
 %
 % EXAMPLE:
 %
-%    To add metabolites, with charges, formulas and KEGG ids:
-%    model = addMetaboliteBatch(model,{'A','b','c'},'metCharges', [ -1 1
-%    0], 'metFormulas', {'C','CO2','H2OKOPF'}, 'metKEGGID',{'C000012','C000023','C000055'})
+%    To add genes with specific fields use:
+%    model = addGeneBatch(model,{'G1','Gene2','InterestingGene'}, 'proteins',{'Protein1','Protein B','Protein Alpha'}, 'geneField2',{'D','E','F')
+%    note, that all fields (geneField1/geneField2) have to be present in
+%    the model, or defined in the field definitions, otherwise they are
+%    ignored.
 %    
 
 
@@ -42,7 +44,7 @@ modelGeneFields = getModelFieldsForType(model,'genes');
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
     if any(ismember({'rxnGeneMat'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelGeneFields,cfield)))        
-        warning('Field %s is excluded.');
+        warning('Field %s is excluded.',cfield);
         continue;
     end    
     if ~isfield(model,cfield)

--- a/src/reconstruction/refinement/addGeneBatch.m
+++ b/src/reconstruction/refinement/addGeneBatch.m
@@ -1,0 +1,54 @@
+function newmodel = addGeneBatch(model,geneIDs,varargin)
+%Add a batch of genes to the model.
+% USAGE:
+%
+%    model = addMetaboliteBatch(model,metIDs,varargin)
+%
+% INPUTS:
+%    model:             The model to add the Metabolite batch to.
+%    geneIDs:           The IDs of the genes that shall be added.
+%    varargin:          fieldName, Value pairs. The given fields will be set
+%                       according to the values. Only defined COBRA fields may be
+%                       used. The following fields will be ignored (as they
+%                       are dependent on the existing model structure):
+%                       rxnGeneMat - The size will be extended, but no associations will be set. 
+% OUTPUTS:
+%
+%    newmodel:     The model structure with the additional reactions.
+%
+% EXAMPLE:
+%
+%    To add metabolites, with charges, formulas and KEGG ids:
+%    model = addMetaboliteBatch(model,{'A','b','c'},'metCharges', [ -1 1
+%    0], 'metFormulas', {'C','CO2','H2OKOPF'}, 'metKEGGID',{'C000012','C000023','C000055'})
+%    
+
+
+if (isfield(model,'genes') && any(ismember(model.genes,geneIDs))) || numel(unique(geneIDs)) < numel(geneIDs)
+    error('Duplicate Reaction ID detected.');
+end
+
+if ~isfield(model,'genes') % Should not happen but if, lets add it.
+    model.genes = cell(0,1);
+end  
+
+nGenes = numel(model.genes);
+
+%We have make sure, that the new fields are in sync, so we create those
+%first.
+fieldDefs = getDefinedFieldProperties();
+fieldDefs = fieldDefs(cellfun(@(x) strcmp(x,'genes'), fieldDefs(:,2)) | cellfun(@(x) strcmp(x,'genes'), fieldDefs(:,3)));
+modelGeneFields = getModelFieldsForType(model,'genes');
+for field = 1:2:numel(varargin)
+    cfield = varargin{field};
+    if any(ismember({'rxnGeneMat'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelGeneFields,cfield)))        
+        warning('Field %s is excluded.');
+        continue;
+    end    
+    if ~isfield(model,cfield)
+        model = createEmptyFields(model,cfield);    
+    end    
+    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];    
+end
+model.genes = [model.genes;columnVector(geneIDs)];
+newmodel = extendModelFieldsForType(model,'genes','originalSize',nGenes);

--- a/src/reconstruction/refinement/addMetaboliteBatch.m
+++ b/src/reconstruction/refinement/addMetaboliteBatch.m
@@ -11,6 +11,8 @@ function newmodel = addMetaboliteBatch(model,metIDs,varargin)
 %               according to the values. Only defined COBRA fields may be
 %               used. The S matrix will always be extended by the number of
 %               metabolites, but cannot be updated in this function.
+%               Varargin can also contain the parameter/Value pair
+%               "checkDuplicate", with value true or false.
 %
 % OUTPUTS:
 %
@@ -24,8 +26,19 @@ function newmodel = addMetaboliteBatch(model,metIDs,varargin)
 %    
 
 
+if numel(varargin) > 0 
+    if any(ismember(varargin(1:2:end),'checkDuplicate'))
+        checkDupPos = 2 * find(ismember(varargin(1:2:end),'checkDuplicate'));
+        checkDuplicate = varargin{checkDupPos};
+        varargin([checkDupPos-1,checkDupPos]) = []; %Remove the values.
+    end   
+end
   
-if any(ismember(model.mets,metIDs)) || numel(unique(metIDs)) < numel(metIDs)
+if ~exist('checkDuplicate','var')
+    checkDuplicate = true;
+end
+
+if checkDuplicate && (any(ismember(model.mets,metIDs)) || numel(unique(metIDs)) < numel(metIDs))
     error('Duplicate Metabolite ID detected.');
 end
 

--- a/src/reconstruction/refinement/addMetaboliteBatch.m
+++ b/src/reconstruction/refinement/addMetaboliteBatch.m
@@ -1,0 +1,53 @@
+function newmodel = addMetaboliteBatch(model,metIDs,varargin)
+%Add a batch of metabolites to the model.
+% USAGE:
+%
+%    model = addMetaboliteBatch(model,metIDs,varargin)
+%
+% INPUTS:
+%    model:     The model to add the Metabolite batch to.
+%    metIDs:    The metabolite IDs to add
+%    varargin:  fieldName, Value pairs. the given fields will be set
+%               according to the values. Only defined COBRA fields may be
+%               used. The S matrix will always be extended by the number of
+%               metabolites, but cannot be updated in this function.
+%
+% OUTPUTS:
+%
+%    newmodel:     The model structure with the additional metabolites.
+%
+% EXAMPLE:
+%
+%    To add metabolites, with charges, formulas and KEGG ids:
+%    model = addMetaboliteBatch(model,{'A','b','c'},'metCharges', [ -1 1
+%    0], 'metFormulas', {'C','CO2','H2OKOPF'}, 'metKEGGID',{'C000012','C000023','C000055'})
+%    
+
+
+  
+if any(ismember(model.mets,metIDs)) || numel(unique(metIDs)) < numel(metIDs)
+    error('Duplicate Metabolite ID detected.');
+end
+
+nMets = numel(model.mets);
+
+%We have make sure, that the new fields are in sync, so we create those
+%first.
+fieldDefs = getDefinedFieldProperties();
+
+for field = 1:2:numel(varargin)
+    cfield = varargin{field};
+    if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~isfield(model,cfield))
+        warning('Field %s is excluded');
+        continue;
+    end
+    if ~isfield(model,cfield)
+        model = createEmptyFields(model,cfield);    
+    end    
+    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];    
+end       
+model.mets = [model.mets;columnVector(metIDs)];
+
+newmodel = extendModelFieldsForType(model,'mets','originalSize',nMets);
+
+    

--- a/src/reconstruction/refinement/addMetaboliteBatch.m
+++ b/src/reconstruction/refinement/addMetaboliteBatch.m
@@ -34,10 +34,11 @@ nMets = numel(model.mets);
 %We have make sure, that the new fields are in sync, so we create those
 %first.
 fieldDefs = getDefinedFieldProperties();
-
+fieldDefs = fieldDefs(cellfun(@(x) strcmp(x,'mets'), fieldDefs(:,2)) | cellfun(@(x) strcmp(x,'mets'), fieldDefs(:,3)));
+modelMetFields = getModelFieldsForType(model,'mets');
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
-    if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~isfield(model,cfield))
+    if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelMetFields,cfield)))
         warning('Field %s is excluded');
         continue;
     end

--- a/src/reconstruction/refinement/addMetaboliteBatch.m
+++ b/src/reconstruction/refinement/addMetaboliteBatch.m
@@ -52,7 +52,7 @@ modelMetFields = getModelFieldsForType(model,'mets');
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
     if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelMetFields,cfield)))
-        warning('Field %s is excluded');
+        warning('Field %s is excluded',cfield);
         continue;
     end
     if ~isfield(model,cfield)

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -145,11 +145,13 @@ if any(ismember(varargin(1:2:end),'rules'))
     %create the grRules
     rulesToUpdate = nRxns + find(~cellfun(@isempty, model.rules(nRxns+1:end)));
     if ~isempty(rulesToUpdate)
-        cGrRules = newmodel.grRules(nRxns+1:end);
-        cGrRules = strrep(cGrRules,'|','or');
-        cGrRules = strrep(cGrRules,'&','and');
-        cGrRules = regexprep(cGrRules,'x\(([0-9]+)\)','${model.genes{str2num($1)}}');
-        newmodel.grRules(nRxns+1:end) = cGrRules;
+        if isfield(newmodel,'grRules')
+            cGrRules = newmodel.grRules(nRxns+1:end);
+            cGrRules = strrep(cGrRules,'|','or');
+            cGrRules = strrep(cGrRules,'&','and');
+            cGrRules = regexprep(cGrRules,'x\(([0-9]+)\)','${model.genes{str2num($1)}}');
+            newmodel.grRules(nRxns+1:end) = cGrRules;
+        end
         %Also update the rxnGeneMat, if present
         if isfield(model,'rxnGeneMat')
             nGenes = length(newmodel.genes);

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -76,7 +76,7 @@ modelRxnFields = getModelFieldsForType(model,'rxns');
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
     if any(ismember({'S','rxnGeneMat','rules','genes'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelRxnFields,cfield)))
-        warning('Field %s is excluded.');
+        warning('Field %s is excluded.',cfield);
         continue;
     end
     if ~isfield(model,cfield)

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -1,0 +1,63 @@
+function newmodel = addReactionBatch(model,rxnIDs,metList,Stoichiometries,varargin)
+%Add a batch of metabolites to the model.
+% USAGE:
+%
+%    model = addMetaboliteBatch(model,metIDs,varargin)
+%
+% INPUTS:
+%    model:             The model to add the Metabolite batch to.
+%    rxnIDs:            The IDs of the reactions that shall be added.
+%    metList:           A list of metabolites for which stoichiometric coefficients are given
+%    Stoichiometries:   A Stoichiometric matrix of dimension
+%                       numel(metList) x numel(rxnID). 
+%    varargin:          fieldName, Value pairs. The given fields will be set
+%                       according to the values. Only defined COBRA fields may be
+%                       used. The S Matrix may not be given.
+%
+% OUTPUTS:
+%
+%    newmodel:     The model structure with the additional reactions.
+%
+% EXAMPLE:
+%
+%    To add metabolites, with charges, formulas and KEGG ids:
+%    model = addMetaboliteBatch(model,{'A','b','c'},'metCharges', [ -1 1
+%    0], 'metFormulas', {'C','CO2','H2OKOPF'}, 'metKEGGID',{'C000012','C000023','C000055'})
+%    
+
+[metPres,metPos] = ismember(metList,model.mets);
+if any(metPos == 0)
+    error('The following Metabolites are not part of the model:\n%s',strjoin(metList(metPos==0)));
+end
+ 
+if any(ismember(model.rxns,rxnIDs)) || numel(unique(rxnIDs)) < numel(rxnIDs)
+    error('Duplicate Reaction ID detected.');
+end
+
+if numel(unique(metList)) < numel(metList)
+    error('Duplicate Metabolite ID detected.');
+end
+
+nRxns = numel(model.rxns);
+
+%We have make sure, that the new fields are in sync, so we create those
+%first.
+fieldDefs = getDefinedFieldProperties();
+
+for field = 1:2:numel(varargin)
+    cfield = varargin{field};
+    if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~isfield(model,cfield))
+        warning('Field %s is excluded');
+        continue;
+    end
+    if ~isfield(model,cfield)
+        model = createEmptyFields(model,cfield);    
+    end    
+    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];    
+end
+model.rxns= [model.rxns;columnVector(rxnIDs)];
+newmodel = extendModelFieldsForType(model,'rxns','originalSize',nRxns);
+%Now, we have extended the S matrix. So lets fill it.
+newmodel.S(metPos,(nRxns+1):end) = Stoichiometries;
+    
+

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -124,7 +124,7 @@ if any(ismember(varargin(1:2:end),'rules'))
         %Find all genes (and their positions) which are already in the model.
         [genePres,genePos] = ismember(genes,newmodel.genes);
         additionalGenes = sum(~genePres);
-        newmodel.genes = addGeneBatch(model,genes(~genePres));
+        newmodel = addGeneBatch(model,genes(~genePres));
         genePos(~genePres) = nGenes+(1:additionalGenes);
         %now, replace the ids.
         genePos = cellfun(@(x) strcat('x(', num2str(x),')'), num2cell(genePos),'Uniformoutput',false);

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -24,8 +24,7 @@ function newmodel = addReactionBatch(model,rxnIDs,metList,Stoichiometries,vararg
 %                       corresponding rules field
 %                       3. By providing a rules field, that directly refers
 %                       to the genes in the model.
-%                       If a rules field and a grRules field are provided,
-%                       the rules field will take precedence.
+%                       
 %
 % OUTPUTS:
 %
@@ -100,7 +99,7 @@ if isfield(model,'grRules') && ~any(ismember(varargin(1:2:end),'rules')) %There 
         %We have non Empty grRules in the input. Parse them.
         newgrRules = nRxns + find(rulesToUpdate);
         for i = 1:numel(newgrRules)
-            newmodel = changeGeneAssociation(newmodel,newmodel.rxns(newgrRules(i)),newmodel.grRules(newgrRules(i)));
+            newmodel = changeGeneAssociation(newmodel,newmodel.rxns{newgrRules(i)},newmodel.grRules{newgrRules(i)});
         end
     end
 end

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -1,18 +1,31 @@
 function newmodel = addReactionBatch(model,rxnIDs,metList,Stoichiometries,varargin)
-%Add a batch of metabolites to the model.
+%Add a batch of reactions to the model.
 % USAGE:
 %
-%    model = addMetaboliteBatch(model,metIDs,varargin)
+%    newmodel = addReactionBatch(model,rxnIDs,metList,Stoichiometries,varargin)
 %
 % INPUTS:
 %    model:             The model to add the Metabolite batch to.
 %    rxnIDs:            The IDs of the reactions that shall be added.
 %    metList:           A list of metabolites for which stoichiometric coefficients are given
 %    Stoichiometries:   A Stoichiometric matrix of dimension
-%                       numel(metList) x numel(rxnID). 
+%                       numel(metList) x numel(rxnID).
 %    varargin:          fieldName, Value pairs. The given fields will be set
 %                       according to the values. Only defined COBRA fields may be
-%                       used. The S Matrix may not be given.
+%                       used. The following fields will be ignored (as they
+%                       are dependent on the existing model structure):
+%                       S - this is being resolved by the
+%                       metList/Stoichiometries combination
+%                       rxnGeneMat - This depends on the original model structure, and is thus nor considered.
+%                       You can provide GPR rules in different ways to
+%                       this function:
+%                       1. By providing a grRules array in the varargin
+%                       2. By providing a genes field in the varargin and a
+%                       corresponding rules field
+%                       3. By providing a rules field, that directly refers
+%                       to the genes in the model.
+%                       If a rules field and a grRules field are provided,
+%                       the rules field will take precedence.
 %
 % OUTPUTS:
 %
@@ -20,16 +33,31 @@ function newmodel = addReactionBatch(model,rxnIDs,metList,Stoichiometries,vararg
 %
 % EXAMPLE:
 %
-%    To add metabolites, with charges, formulas and KEGG ids:
-%    model = addMetaboliteBatch(model,{'A','b','c'},'metCharges', [ -1 1
-%    0], 'metFormulas', {'C','CO2','H2OKOPF'}, 'metKEGGID',{'C000012','C000023','C000055'})
-%    
+%    To add the following reactions, with lower and upper bounds:
+%    ExA: A <-> ; ATob: A <-> B ; BToC: B <-> C
+%    model = addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+%                                   'lb',[-50,30,1],'ub',[0,60,15])
+%    To add them with GPRs in text form:
+%    ExA: A <-> ; ATob: A <-> B ; BToC: B <-> C
+%    model = addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+%                                   'grRules',{'G1 or G2', 'G3 and G4',''})
+%
+%
+%    To add them with the same GPRs in logical format assuming that model.genes is {'G1';'G2';'G3';'G4'}:
+%    ExA: A <-> ; ATob: A <-> B ; BToC: B <-> C
+%    model = addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+%                                   'rules',{'x(1) | x(2)', 'x(3) and x(4)',''})
+%    To add them with the same GPRs in logical format without assuming anything for the model:
+%    ExA: A <-> ; ATob: A <-> B ; BToC: B <-> C
+%    model = addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+%                                   'rules',{'x(3) | x(2)', 'x(4) & x(1)',''}, 'genes', {'G4';'G2';'G1';'G3'})
+%
 
 [metPres,metPos] = ismember(metList,model.mets);
 if any(metPos == 0)
     error('The following Metabolites are not part of the model:\n%s',strjoin(metList(metPos==0)));
 end
- 
+
 if any(ismember(model.rxns,rxnIDs)) || numel(unique(rxnIDs)) < numel(rxnIDs)
     error('Duplicate Reaction ID detected.');
 end
@@ -43,21 +71,98 @@ nRxns = numel(model.rxns);
 %We have make sure, that the new fields are in sync, so we create those
 %first.
 fieldDefs = getDefinedFieldProperties();
+fieldDefs = fieldDefs(cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,2)) | cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,3)));
+modelRxnFields = getModelFieldsForType(model,'rxns');
 
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
-    if strcmp('S',cfield) || (~any(ismember(fieldDefs(:,1),cfield)) && ~isfield(model,cfield))
-        warning('Field %s is excluded');
+    if any(ismember({'S','rxnGeneMat','rules','genes'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelRxnFields,cfield)))
+        warning('Field %s is excluded.');
         continue;
     end
     if ~isfield(model,cfield)
-        model = createEmptyFields(model,cfield);    
+        model = createEmptyFields(model,cfield);
     end    
-    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];    
+    if ~any(size(varargin{field+1}) == numel(rxnIDs)) %something must fit
+        error('Size of field %s does not fit to the rxnList size', varargin{field});
+    end
+    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];
 end
 model.rxns= [model.rxns;columnVector(rxnIDs)];
 newmodel = extendModelFieldsForType(model,'rxns','originalSize',nRxns);
 %Now, we have extended the S matrix. So lets fill it.
 newmodel.S(metPos,(nRxns+1):end) = Stoichiometries;
-    
 
+
+if isfield(model,'grRules') && ~any(ismember(varargin(1:2:end),'rules')) %There is a grRules field, and no Rules are provided.
+    rulesToUpdate = ~cellfun(@isempty, model.grRules(nRxns+1:end));
+    if any(rulesToUpdate)
+        %We have non Empty grRules in the input. Parse them.
+        newgrRules = nRxns + find(rulesToUpdate);
+        for i = 1:numel(newgrRules)
+            newmodel = changeGeneAssociation(newmodel,newmodel.rxns(newgrRules(i)),newmodel.grRules(newgrRules(i)));
+        end
+    end
+end
+
+if any(ismember(varargin(1:2:end),'rules'))
+    %We have a rules field. First, reset any grRules
+    if isfield(model,'grRules')
+        newmodel.grRules(nRxns+1:end) = {''};
+    end
+    %Now, we have to check, if there is a gene list provided:
+    if any(ismember(varargin(1:2:end),'genes'))
+        %If genes are provided, we have to A: find the overlap, be
+        %merge the genes and C adjust the rules.
+        nGenes = length(newmodel.genes);
+        genePos = 2 * find(ismember(varargin(1:2:end),'genes'));
+        rulesPos = 2 * find(ismember(varargin(1:2:end),'rules'));
+        genes = varargin{genePos};
+        rules = varargin{rulesPos};
+        if ~any(size(rules) == numel(rxnIDs)) %something must fit
+            error('Size of field rules does not fit to the rxnList size');
+        end
+        %Find all genes (and their positions) which are already in the model.
+        [genePres,genePos] = ismember(genes,newmodel.genes);
+        additionalGenes = sum(~genePres);
+        newmodel.genes = addGeneBatch(model,genes(~genePres));
+        genePos(~genePres) = nGenes+(1:additionalGenes);
+        %now, replace the ids.
+        genePos = cellfun(@(x) strcat('x(', num2str(x),')'), num2cell(genePos),'Uniformoutput',false);
+        rules = regexprep(rules,'x\(([0-9]+)\)','${genePos{str2num($1)}}');
+        newmodel.rules(nRxns+1:length(model.rxns)) = rules;
+    else
+        rulesPos = 2 * find(ismember(varargin(1:2:end),'rules'));
+        if ~isfield(newmodel,'rules') %If rules does not exist, create it.
+            newmodel = generateRules(newmodel);
+        end
+        if ~any(size(varargin{rulesPos}) == numel(rxnIDs)) %something must fit
+            error('Size of field rules does not fit to the rxnList size');
+        end
+        newmodel.rules = [newmodel.rules; columnVector(varargin{rulesPos})];
+    end
+    
+    %Update the corresponding grRules fields and rxnGeneMat fields.
+    %create the grRules
+    rulesToUpdate = nRxns + find(~cellfun(@isempty, model.rules(nRxns+1:end)));
+    if ~isempty(rulesToUpdate)
+        cGrRules = newmodel.grRules(nRxns+1:end);
+        cGrRules = strrep(cGrRules,'|','or');
+        cGrRules = strrep(cGrRules,'&','and');
+        cGrRules = regexprep(cGrRules,'x\(([0-9]+)\)','${model.genes{str2num($1)}}');
+        newmodel.grRules(nRxns+1:end) = cGrRules;
+        %Also update the rxnGeneMat, if present
+        if isfield(model,'rxnGeneMat')
+            nGenes = length(newmodel.genes);
+            for i = 1:numel(rulesToUpdate)
+                assoc = false(1,nGenes);
+                %get all gene positions
+                pos = regexp(newmodel.rules{rulesToUpdate(i)},'x\((?<pos>[0-9]+)\)','names');
+                genePos = cellfun(@str2num, {pos.pos});
+                assoc(genePos) = true;
+                newmodel.rxnGeneMat(rulesToUpdate(i),:) = assoc;
+            end
+        end
+    end
+
+end

--- a/src/reconstruction/refinement/addReactionBatch.m
+++ b/src/reconstruction/refinement/addReactionBatch.m
@@ -138,7 +138,7 @@ if any(ismember(varargin(1:2:end),'rules'))
         if ~any(size(varargin{rulesPos}) == numel(rxnIDs)) %something must fit
             error('Size of field rules does not fit to the rxnList size');
         end
-        newmodel.rules = [newmodel.rules; columnVector(varargin{rulesPos})];
+        newmodel.rules((nRxns+1):end) = columnVector(varargin{rulesPos});
     end
     
     %Update the corresponding grRules fields and rxnGeneMat fields.

--- a/src/reconstruction/refinement/extendModelFieldsForType.m
+++ b/src/reconstruction/refinement/extendModelFieldsForType.m
@@ -8,7 +8,7 @@ function model = extendModelFieldsForType(model, type, varargin)
 %
 %    model:              the model to update
 %    type:               the Type of field to update one of 
-%                        ('rxns','mets','comps','genes','ctrs')
+%                        ('rxns','mets','comps','genes')
 %
 % OPTIONAL INPUTS:
 %    varargin:        Additional Options as 'ParameterName', Value pairs. Options are:
@@ -38,7 +38,7 @@ function model = extendModelFieldsForType(model, type, varargin)
 %                   - Thomas Pfau June 2017, adapted to merge all fields.
 
 
-PossibleTypes = {'rxns','mets','comps','genes','ctrs'}';
+PossibleTypes = {'rxns','mets','comps','genes'}';
 
 
 parser = inputParser();

--- a/src/reconstruction/refinement/extendModelFieldsForType.m
+++ b/src/reconstruction/refinement/extendModelFieldsForType.m
@@ -8,7 +8,7 @@ function model = extendModelFieldsForType(model, type, varargin)
 %
 %    model:              the model to update
 %    type:               the Type of field to update one of 
-%                        ('rxns','mets','comps','genes')
+%                        ('rxns','mets','comps','genes','ctrs')
 %
 % OPTIONAL INPUTS:
 %    varargin:        Additional Options as 'ParameterName', Value pairs. Options are:
@@ -38,7 +38,7 @@ function model = extendModelFieldsForType(model, type, varargin)
 %                   - Thomas Pfau June 2017, adapted to merge all fields.
 
 
-PossibleTypes = {'rxns','mets','comps','genes'}';
+PossibleTypes = {'rxns','mets','comps','genes','ctrs'}';
 
 
 parser = inputParser();
@@ -55,44 +55,119 @@ originalSize = parser.Results.originalSize;
 targetSize = parser.Results.targetSize;
 excludeFields = parser.Results.excludeFields;
 
-fields = getModelFieldsForType(model, type, originalSize);
-
+[originalFields,dimensions] = getModelFieldsForType(model, type, originalSize);
+fields = originalFields;
 fields = setdiff(fields,excludeFields);
 
-fieldDefinitions = getDefinedFieldProperties('SpecificFields',fields);
+fieldDefinitions = getDefinedFieldProperties();
 %fields, dependent on two dimensions (different) should always be handled
 %separately. Currently, those are: S and rxnGeneMat.
-fields = setdiff(fields,{'S','rxnGeneMat'});
+%fields = setdiff(fields,{'S','rxnGeneMat'});
+
 fields = [intersect(PossibleTypes,fields);setdiff(fields,PossibleTypes)];
+[Pres,Pos] = ismember(fields,originalFields);
+dimensions = dimensions(Pos(Pres));
+
 for field = 1:numel(fields)
-    fieldPos = ismember(fieldDefinitions(:,1),fields{field});
-    if any(fieldPos)        
-        %If we have a definition for this field, use the default value.
-        if iscell(model.(fields{field}))
-            for i = (originalSize+1):targetSize                
-                eval(['model.(fields{field}){i,1} = ' fieldDefinitions{fieldPos,5} ';']);
-            end
-        elseif isnumeric(model.(fields{field})) || ischar(model.(fields{field}))            
-                model.(fields{field})((originalSize+1):targetSize,1) = fieldDefinitions{fieldPos,5};
-        elseif islogical(model.(fields{field}))
-                model.(fields{field})(originalSize+1:targetSize,1) = logical(fieldDefinitions{fieldPos,5});
+    cfield = fields{field,1};
+    cfieldDef = fieldDefinitions(ismember(fieldDefinitions(:,1),cfield),:);
+    if isempty(cfieldDef)
+        %this indicates, that no clear field Definition exists. So lets
+        %make some assumptions:
+        fieldType = 'numeric';
+        defaultValue = 0;
+        if ischar(model.(cfield))
+            fieldType = 'char';
+            defaultValue = ' ';
         end
-    else        
-        %We don't have definitions. we will assume, that cell arrays are
-        %annotations (i.e. default ''), number defaults are NaN -> this most likely will notify wrong things
-        %and that we don't have additional char arrays. logicals are 0 by
-        %default.
-        if iscell(model.(fields{field}))
-                model.(fields{field})(originalSize+1:targetSize,1) = {''};
-        elseif isnumeric(model.(fields{field})) 
-                model.(fields{field})(originalSize+1:targetSize,1) = NaN;
-        elseif islogical(model.(fields{field}))
-                model.(fields{field})(originalSize+1:targetSize,1) = false;
+        if iscell(model.(cfield))
+            fieldType = 'cell';
+            defaultValue = ''''''; %Assume this to be an empty string
+        end
+        if isnumeric(model.(cfield))
+            fieldType = 'numeric';
+            defaultValue = 0;
+        end
+        if islogical(model.(cfield))
+            fieldType = 'sparselogical';
+            defaultvalue = false;
+        end                
+    else
+        fieldType = cfieldDef{7};
+        defaultValue = cfieldDef{5};
+    end
+    cdim = dimensions(field);
+    fieldDims = size(model.(cfield));    
+    %Matlab will screw up multi-dimensional arrays when the are of size 1
+    %or zero in a dimension... So for now, we only handle two dimensional
+    %arrays.
+    %We need to handle completely empty arrays differently.
+    if(all(fieldDims == 0))
+        %This can only ever happen with numeric, logical or character fields!
+        %However, it is only relevant for numeric fields...
+        if isnumeric(model.(cfield))
+            if issparse(model.(cfield))
+                if cdim == 1
+                    model.(cfield) = sparse(targetSize,0);
+                else
+                    model.(cfield) = sparse(0,targetSize);
+                end
+            else
+                if cdim == 1
+                    model.(cfield) = zeros(targetSize,0);
+                else
+                    model.(cfield) = zeros(0,targetSize);
+                end
+            end
+            continue;
         end
     end
+    switch fieldType
+        case 'sparse'
+            model.(cfield) = extendIndicesInDimenion(model.(cfield),cdim,defaultValue, targetSize-originalSize);
+        case 'cell'
+            newValues = cell(0,1);
+            for i = originalSize+1:targetSize
+                eval(['currentvalue = ' defaultValue ';']);
+                newValues{end+1,1} = currentvalue;
+            end
+            model.(cfield) = extendIndicesInDimenion(model.(cfield),cdim,newValues, targetSize-originalSize);
+        case 'sparselogical'            
+            model.(cfield) = extendIndicesInDimenion(model.(cfield),cdim,logical(defaultValue), targetSize-originalSize);                        
+        case 'numeric'
+            model.(cfield) = extendIndicesInDimenion(model.(cfield),cdim,defaultValue, targetSize-originalSize);
+        case 'char'
+            model.(cfield) = extendIndicesInDimenion(model.(cfield),cdim,defaultValue, targetSize-originalSize);
+    end
 end
-
 end
 
         
         
+
+function added = extendIndicesInDimenion(input,dimension,value, sizeIncrease)
+% Remove the indices in a specified field in the given dimension
+% USAGE:
+%    added = extendIndicesInDimenion(input,dimension,indices)
+%
+% INPUTS:
+%
+%    input:              The input matrix or array
+%    dimension:          The dimension in which to add values for the given
+%                        indices
+%    value:              The value to append in the given dimension.
+%    sizeIncrease:       How many entries to add.
+%
+% OUTPUT:
+%    added:              The Array/Matrix with the given indices set to the
+%                        default values.
+%
+% .. Authors: 
+%                   - Thomas Pfau Sept 2017, adapted to merge all fields.
+
+inputDimensions = ndims(input);
+S.subs = repmat({':'},1,inputDimensions);
+S.subs{dimension} = (size(input,dimension)+1):(size(input,dimension)+sizeIncrease);
+S.type = '()';
+added = subsasgn(input,S,value);
+end

--- a/src/reconstruction/refinement/getModelFieldsForType.m
+++ b/src/reconstruction/refinement/getModelFieldsForType.m
@@ -32,7 +32,7 @@ function [matchingFields,dimensions] = getModelFieldsForType(model, type, vararg
 
 
 
-PossibleTypes = {'rxns','mets','comps','genes','ctrs'};
+PossibleTypes = {'rxns','mets','comps','genes'};
 
 parser = inputParser();
 parser.addRequired('model',@(x) isfield(x,type));

--- a/src/reconstruction/refinement/getModelFieldsForType.m
+++ b/src/reconstruction/refinement/getModelFieldsForType.m
@@ -32,7 +32,7 @@ function [matchingFields,dimensions] = getModelFieldsForType(model, type, vararg
 
 
 
-PossibleTypes = {'rxns','mets','comps','genes'};
+PossibleTypes = {'rxns','mets','comps','genes','ctrs'};
 
 parser = inputParser();
 parser.addRequired('model',@(x) isfield(x,type));
@@ -104,6 +104,15 @@ if fieldSize == 1 || fieldSize == 0
     possibleFields = possibleFields(posFields);
     dimensions = dimensions(posFields);
 else
+    knownfields = getDefinedFieldProperties();
+    firstdim = cellfun(@(x,y) isequal(x,type) && isfield(model,y) && (size(model.(y),1) == fieldSize),knownfields(:,2), knownfields(:,1));
+    seconddim = cellfun(@(x,y) isequal(x,type) && isfield(model,y) && (size(model.(y),2) == fieldSize),knownfields(:,3), knownfields(:,1));
+    %Remove the known fields.
+    unknownModelFields = setdiff(modelFields,knownfields(:,1));
+    %And get all matching fields
+    knownMatchingFields = knownfields((firstdim|seconddim),1);
+    %Only look at known fields which are defined, or undefined fields
+    modelFields = union(unknownModelFields,knownMatchingFields);
     for i = 1:numel(modelFields)
         matchingsizes = size(model.(modelFields{i})) == fieldSize;
         if any(matchingsizes) && ~(sum(matchingsizes) > 1) %A size > 1 should only happen if we have conflicting field sizes...
@@ -136,18 +145,22 @@ end
 if sameSizeExists
     %we restrict the possibleFields to those which start with the
     %indicator, along with those fields, which are part of the defined
-    %fields.
-    
+    %fields.    
     fields = getDefinedFieldProperties();
-    firstdim = cellfun(@(x) isequal(x,type),fields(:,2));
-    seconddim = cellfun(@(x) isequal(x,type),fields(:,3));
-    fields = fields( firstdim | seconddim ,1);
+    firstdim = cellfun(@(x,y) isequal(x,type) && isfield(model,y) && (size(model.(y),1) == fieldSize),fields(:,2), fields(:,1));
+    seconddim = cellfun(@(x,y) isequal(x,type) && isfield(model,y) && (size(model.(y),2) == fieldSize),fields(:,3), fields(:,1));        
     definedFieldDims = ones(numel(fields),1);
-    definedFieldDims(seconddim) = 2;
-    definedPossibles = ismember(fields,possibleFields);
+    definedFieldDims(seconddim) = 2;    
+    fields = fields( firstdim | seconddim ,1);
+    definedFieldDims = definedFieldDims(firstdim | seconddim);
+    definedPossibles = ismember(fields,possibleFields);    
     %Reduce the fields to those which match the size AND are defined.
     definedFieldDims = definedFieldDims(definedPossibles);    
     fields = fields(definedPossibles);        
+    %Now, check again the if the sizes fit...
+    actualFieldDimsMatch = arrayfun(@(x) size(model.(fields{x}),definedFieldDims(x)) == fieldSize, 1:numel(fields));
+    definedFieldDims = definedFieldDims(actualFieldDimsMatch);
+    fields = fields(actualFieldDimsMatch);        
     %Now check the relevant field positions in the possible fields, i.e.
     %those starting with the respective id (e.g. rxn).
     relevantPossibles = cellfun(@(x) strncmp(x,type,length(type)-1),possibleFields);    
@@ -163,3 +176,4 @@ if sameSizeExists
 end
 
 matchingFields = possibleFields;
+end

--- a/src/reconstruction/refinement/getModelFieldsForType.m
+++ b/src/reconstruction/refinement/getModelFieldsForType.m
@@ -101,7 +101,7 @@ if fieldSize == 1 || fieldSize == 0
     fields = getDefinedFieldProperties();
     fields = fields(cellfun(@(x) isequal(x,type),fields(:,3)) | cellfun(@(x) isequal(x,type),fields(:,2)),1);
     %modelFields with the "correct" startingID
-    relModelFields = modelFields(cellfun(@(x) strncmp(x,type,3),modelFields));
+    relModelFields = modelFields(cellfun(@(x) strncmp(x,type,length(type-1)),modelFields)); %Remove the s from the type for this
     fields = columnVector(union(fields,relModelFields));    
     posFields = ismember(possibleFields,fields);
     possibleFields = possibleFields(posFields);

--- a/src/reconstruction/refinement/getModelFieldsForType.m
+++ b/src/reconstruction/refinement/getModelFieldsForType.m
@@ -69,24 +69,24 @@ dimensions = [];
 if fieldSize == 1 || fieldSize == 0
     %This is special. We will only check the first dimension in this
     %instance, and we will check the field properties of S and
-    %rxnGeneMat, Also, we will ONLY return defined fields...
+    %rxnGeneMat, Also, we will ONLY return defined fields, or fields with a clear starting ID...
     if isfield(model, 'rxnGeneMat') 
         if (strcmp(type,'genes') && size(model.rxnGeneMat,2) == fieldSize) 
-            possibleFields{end+1} = 'rxnGeneMat';
+            possibleFields{end+1,1} = 'rxnGeneMat';
             dimensions(end+1,1) = 2;
         end
         if (strcmp(type,'rxns') && size(model.rxnGeneMat,1) == fieldSize)
-            possibleFields{end+1} = 'rxnGeneMat';
+            possibleFields{end+1,1} = 'rxnGeneMat';
             dimensions(end+1,1) = 1;
         end
     end
     if isfield(model, 'S') 
         if (strcmp(type,'mets') && size(model.S,1) == fieldSize) 
-            possibleFields{end+1} = 'S';
+            possibleFields{end+1,1} = 'S';
             dimensions(end+1,1) = 1;
         end
         if (strcmp(type,'rxns') && size(model.S,2) == fieldSize)
-            possibleFields{end+1} = 'S';
+            possibleFields{end+1,1} = 'S';
             dimensions(end+1,1) = 2;
         end        
     end
@@ -100,6 +100,9 @@ if fieldSize == 1 || fieldSize == 0
     %This is a New empty model, we only look at defined fields.
     fields = getDefinedFieldProperties();
     fields = fields(cellfun(@(x) isequal(x,type),fields(:,3)) | cellfun(@(x) isequal(x,type),fields(:,2)),1);
+    %modelFields with the "correct" startingID
+    relModelFields = modelFields(cellfun(@(x) strncmp(x,type,3),modelFields));
+    fields = columnVector(union(fields,relModelFields));    
     posFields = ismember(possibleFields,fields);
     possibleFields = possibleFields(posFields);
     dimensions = dimensions(posFields);

--- a/src/reconstruction/refinement/mergeModelFieldPositions.m
+++ b/src/reconstruction/refinement/mergeModelFieldPositions.m
@@ -47,7 +47,11 @@ if ~exist('mergeFunctions','var')
     mergeFunctions = basicFunctions;
 else
     toRemove = ismember(basicFunctions(:,1),mergeFunctions(:,1));
-    mergeFunctions=[basicFunctions(~toRemove,:),mergeFunctions(:,:)];
+    if all(toRemove)        
+        mergeFunctions=mergeFunctions(:,:);
+    else
+        mergeFunctions=[basicFunctions(~toRemove,:);mergeFunctions(:,:)];
+    end
 end
 
               

--- a/src/reconstruction/refinement/removeFieldEntriesForType.m
+++ b/src/reconstruction/refinement/removeFieldEntriesForType.m
@@ -9,7 +9,7 @@ function model = removeFieldEntriesForType(model, indicesToRemove, type, fieldSi
 %    model:              the model to update
 %    indicesToRemove:    indices which should be removed (either a logical array or double indices)
 %    type:               the Type of field to update. one of 
-%                        ('rxns','mets','comps','genes','ctrs')
+%                        ('rxns','mets','comps','genes')
 %    fieldSize:          The size of the original field before
 %                        modification. This is necessary to identify fields
 %                        from which entries have to be removed.
@@ -32,7 +32,7 @@ function model = removeFieldEntriesForType(model, indicesToRemove, type, fieldSi
 % .. Authors: 
 %                   - Thomas Pfau June 2017, adapted to merge all fields.
 
-PossibleTypes = {'rxns','mets','comps','genes','ctrs'};
+PossibleTypes = {'rxns','mets','comps','genes'};
 
 
 parser = inputParser();

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -1,0 +1,108 @@
+% The COBRAToolbox: testBatchAddition.m
+%
+% Purpose:
+%     - testBatchAddition tests addReactionBatch, addMEtaboliteBatch and
+%       addGeneBatch based on E.coli Core. 
+%
+% Authors:
+%     - Thomas Pfau Dec 2017
+
+
+
+% save the current path
+currentDir = pwd;
+
+% initialize the test
+fileDir = fileparts(which('testBatchAddition.m'));
+cd(fileDir);
+
+% Test with non-empty model
+fprintf('>> Starting Batch Addition Test:\n');
+
+%Load a test model.
+model = getDistributedModel('ecoli_core_model.mat');
+
+%Test batch addition
+%For Mets
+fprintf('>> Testing Metabolite Batch Addition...\n');
+metNames = {'A','b','c'};
+metFormulas = {'C','CO2','H2OKOPF'};
+modelBatch = addMetaboliteBatch(model,metNames,'metCharges', [ -1 1 0],...
+    'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
+assert(all(ismember(metNames,modelBatch.mets)));
+[pres,pos] = ismember(metNames,modelBatch.mets);
+assert(isequal(modelBatch.metFormulas(pos(pres)),columnVector(metFormulas)));
+assert(isequal(modelBatch.metCharges(pos(pres)),[-1; 1;0]));
+assert(verifyModel(modelBatch,'simpleCheck',true));
+
+
+%For Reactions:
+fprintf('>> Testing Reaction Batch Addition...\n');
+rxnIDs = {'ExA','ATob','BToC'};
+modelBatch2 = addReactionBatch(modelBatch,rxnIDs,{'A','b','ac[c]'},[1 -1 0; 0,-2,-1;0,0,1],...
+                                   'lb',[-50,30,1],'ub',[0,60,15]);
+%Check that the reactions are in.                               
+assert(all(ismember(rxnIDs,modelBatch2.rxns)));
+%Check that lbs/ubs are properly updated.
+assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'ExA'})) == -50);
+assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'BToC'})) == 1);
+assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'ATob'})) == 60);
+assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'BToC'})) == 15);
+%Check that the metabolites were correctly assigned.
+assert(modelBatch2.mets{find(modelBatch2.S(:,ismember(modelBatch2.rxns,'ExA')))} == 'A');
+assert(isempty(setxor(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'BToC')))),{'b','ac[c]'})));
+%Check the stoichiometry is correct
+assert(modelBatch2.S(ismember(modelBatch2.mets,'A'),ismember(modelBatch2.rxns,'ExA')) == 1);
+assert(modelBatch2.S(ismember(modelBatch2.mets,'b'),ismember(modelBatch2.rxns,'ATob')) == -2);
+
+
+%Now check proper addition of grRules (and updated fields).
+modelBatch3 = addReactionBatch(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+                                   'grRules',{'G1 or b0721', 'b0008 and G4',''});
+assert(numel(modelBatch3.genes) == numel(model.genes)+2); %Only two genes were added, the others already existed.
+%Since the model has a rules field, we will test the equality of the rules.
+fp = FormulaParser();
+%Assert all correct genes are there.
+assert(all(ismember(union(model.genes,{'G1','G4'}),modelBatch3.genes)));
+%we will use ExA to test.
+ExAPos = ismember(modelBatch3.rxns,'ExA');
+G1pos = find(ismember(modelBatch3.genes,'G1'));
+b0721pos = find(ismember(modelBatch3.genes,'b0721'));
+Formula = ['x(' num2str(G1pos) ,') | x(' num2str(b0721pos) ')'];
+head1 = fp.parseFormula(Formula);
+head2 = fp.parseFormula(modelBatch3.rules{ExAPos});
+assert(head1.isequal(head2));
+
+%Also check logical format addition:              
+modelBatch3 = addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+                                   'rules',{'x(3) | x(2)', 'x(4) & x(1)',''}, 'genes', {'G4';'b0002';'G1';'b0008'})
+%The same addition as above but a different
+%format, so test the same things.
+assert(numel(modelBatch3.genes) == numel(model.genes)+2); %Only two genes were added, the others already existed.
+%Since the model has a rules field, we will test the equality of the rules.
+fp = FormulaParser();
+%Assert all correct genes are there.
+assert(all(ismember(union(model.genes,{'G1','G4'}),modelBatch3.genes)));
+%we will use ExA to test.
+ExAPos = ismember(modelBatch3.rxns,'ExA');
+G1pos = find(ismember(modelBatch3.genes,'G1'));
+b0002pos = find(ismember(modelBatch3.genes,'G1'));
+head1 = fp.parseFormula(Formula);
+head2 = fp.parseFormula(model.rules{ExAPos});
+assert(head1.isequal(head2));
+
+%Now, test duplicate ID fails (duplicate in the reaction list
+verifyCobraFunctionError(@() addReactionBatch(model,{'ExA','ATob','ExA'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1]));
+verifyCobraFunctionError(@() addReactionBatch(model,{'ExA','ATob','CS'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1]));
+
+%Also assert, that all metabolites are part of the Model (this is necessary
+%for quick addition).
+verifyCobraFunctionError(@() addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','ac[c]'},[1 -1 0; 0,1,-1;0,0,1]))
+
+
+
+                               
+                               
+                               
+% change the directory
+cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -23,7 +23,7 @@ fprintf('>> Starting Batch Addition Test:\n');
 model = getDistributedModel('ecoli_core_model.mat');
 
 %Test batch addition
-%% For Mets
+% For Mets
 fprintf('>> Testing Metabolite Batch Addition...\n');
 metNames = {'A','b','c'};
 metFormulas = {'C','CO2','H2OKOPF'};
@@ -40,7 +40,7 @@ assert(isfield(modelBatch,'metKEGGID'));
 assert(verifyCobraFunctionError(@() addMetaboliteBatch(model,model.mets(1:3))))
 assert(verifyCobraFunctionError(@() addMetaboliteBatch(model,{'A','b','A'})))
 
-%% For Reactions:
+% For Reactions:
 fprintf('>> Testing Reaction Batch Addition...\n');
 rxnIDs = {'ExA','ATob','BToC'};
 modelBatch2 = addReactionBatch(modelBatch,rxnIDs,{'A','b','ac[c]'},[1 -1 0; 0,-2,-1;0,0,1],...
@@ -104,7 +104,7 @@ assert(verifyCobraFunctionError(@() addReactionBatch(model,{'ExA','ATob','CS'},{
 %for quick addition).
 assert(verifyCobraFunctionError(@() addReactionBatch(model,{'ExA','ATob','BToC'},{'A','b','ac[c]'},[1 -1 0; 0,1,-1;0,0,1])));
 
-%% For Genes
+% For Genes
 fprintf('>> Testing Gene Batch Addition...\n');
 
 genes = {'G1','Gene2','InterestingGene'}';

--- a/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
@@ -24,6 +24,7 @@ model.genes{end+1,1} = 'gene1';
 
 %extend all relevant fields (the original size was 0.
 %get all Model fields for genes
+fprintf('Testing getModelFieldsForType and extendModelFielsForType ...\n');
 [matchingGeneFields,dimensions] = getModelFieldsForType(model,'genes','fieldSize',0);
 assert(dimensions == 2);
 assert(isequal(matchingGeneFields,{'rxnGeneMat'}));
@@ -106,6 +107,7 @@ model = extendModelFieldsForType(model,'mets');
 assert(isempty(setxor(matchingMetFields,{'mets','b','metNames','csense','S'})) && numel(matchingMetFields) == 5);
 assert(length(model.something) == 8) %This field was not modified, as it could not be clearly associated with mets.
 
+fprintf('Testing removeFieldEntriesForType ...\n');
 %Also, test the removeFieldEntries method now
 %To be able to check whether the right fields are removed, we will create a
 %random s matrix:

--- a/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
@@ -1,0 +1,168 @@
+% The COBRAToolbox: testDynamicModelFieldModification.m
+%
+% Purpose:
+%     - Test functionality in removeFieldEntriesForType, extendModelFields,
+%     getModelFieldsForType
+%
+% Author:
+%     - Original file: Thomas Pfau
+
+global CBTDIR
+
+% save the current path
+currentDir = pwd;
+
+% initialize the test
+fileDir = fileparts(which('testDynamicModelFieldModification.m'));
+cd(fileDir);
+
+%Lets create an empty model.
+model = createModel();
+
+%Lets add a gene:
+model.genes{end+1,1} = 'gene1';
+
+%extend all relevant fields (the original size was 0.
+%get all Model fields for genes
+[matchingGeneFields,dimensions] = getModelFieldsForType(model,'genes','fieldSize',0);
+assert(dimensions == 2);
+assert(isequal(matchingGeneFields,{'rxnGeneMat'}));
+model = extendModelFieldsForType(model,'genes');
+%This should result in an empty rxnGEneMatrix of size 0x1
+assert(all(size(model.rxnGeneMat) == [0,1]));
+
+%Recreate the model.
+model = createModel();
+
+%lets add a couple of reactions
+Reactions = {'R1',{'A','B'},[-1 1],0,1000;...
+             'R2',{'B','C'},[-1 2],0,1000;...
+             'R3',{'C','D'},[-1 1],0,1000;...
+             'R4',{'E','F'},[-1 1],0,1000;...
+             'R5',{'F','G'},[-1 1],0,1000;...
+             'R6',{'G','E'},[-1 1],0,1000;...
+             'R7',{'G','D'},[-1 1],0,1000;...
+             'R8',{'H','C'},[-1 1],0,1000};
+%Add Reactions
+for i = 1:size(Reactions,1)
+    %All reactions are irreversible
+    model = addReaction(model,Reactions{i,1},'metaboliteList',Reactions{i,2},...
+          'stoichCoeffList',Reactions{i,3},'lowerBound',Reactions{i,4},'upperBound',Reactions{i,5},...
+          'printLevel',-1);
+end
+%Now, the size of model.mets is exactly the same as model.rxns (which could
+%be a problematic situation).
+%so, lets see, which fields we get for mets:
+[matchingMetFields,dimensions] = getModelFieldsForType(model,'mets');
+%This should be:
+assert(isempty(setxor(matchingMetFields,{'mets','b','metNames','csense','S'})) && numel(matchingMetFields) == 5); %No duplicates!
+%And S should have dimension 1, and only 1.
+assert(all(dimensions(ismember(matchingMetFields,'S')) == 1)); %all to make sure that duplicate appearences are covered. 
+
+%Lets also check this for reactions
+[matchingRxnFields,dimensions] = getModelFieldsForType(model,'rxns');
+assert(isempty(setxor(matchingRxnFields,{'rxns','lb','ub','c','rxnGeneMat','rules','grRules','S'})) && numel(matchingRxnFields) == 8); %No duplicates!
+%And S should have dimension 1, and only 1.
+assert(all(dimensions(ismember(matchingRxnFields,'S')) == 2)); %all to make sure that duplicate appearences are covered. 
+
+%Finally for genes:
+[matchingGeneFields,dimensions] = getModelFieldsForType(model,'genes');
+assert(isempty(setxor(matchingGeneFields,{'genes','rxnGeneMat'})) && numel(matchingGeneFields) == 2); %No duplicates!
+%And S should have dimension 1, and only 1.
+assert(all(dimensions(ismember(matchingGeneFields,'rxnGeneMat')) == 2)); %all to make sure that duplicate appearences are covered. 
+
+
+%Now, add a metabolite
+model.mets{end+1,1} = 'NewMet';
+%and see, which fields we get when asking for all met fields one smaller
+%than mets
+[matchingMetFields,dimensions] = getModelFieldsForType(model,'mets','fieldSize',length(model.mets)-1);
+%This should be all except mets:
+assert(isempty(setxor(matchingMetFields,{'b','metNames','csense','S'})) && numel(matchingMetFields) == 4); %No duplicates!
+%And S should have dimension 1, and only 1.
+assert(all(dimensions(ismember(matchingMetFields,'S')) == 1)); %all to make sure that duplicate appearences are covered. 
+
+%now, lets add an unknown field
+model.something = zeros(8,1); %This field will not be returned, as there are other fields (rxns) of the same size, so its unclear, what it belongs to.
+[matchingMetFields,dimensions] = getModelFieldsForType(model,'mets','fieldSize',length(model.mets)-1);
+assert(~any(ismember(matchingMetFields,'something')));
+
+%If this would be size 9, it should be returned if all equal sized fields
+%are requested:
+model.something = zeros(1,9); %This field will not be returned, as there are other fields (rxns) of the same size, so its unclear, what it belongs to.
+[matchingMetFields,dimensions] = getModelFieldsForType(model,'mets');
+assert(any(ismember(matchingMetFields,'something')));
+assert(dimensions(ismember(matchingMetFields,'something')) == 2);
+
+% As a size 8 field it woudl be returned as a rxn field:
+model.something = zeros(8,1); %This field will not be returned, as there are other fields (rxns) of the same size, so its unclear, what it belongs to.
+[matchingRxnFields,dimensions] = getModelFieldsForType(model,'rxns');
+assert(any(ismember(matchingRxnFields,'something')));
+assert(dimensions(ismember(matchingRxnFields,'something')) == 1);
+
+%So, lets extend the model to update all of those metabolite derived fields
+model = extendModelFieldsForType(model,'mets');
+[matchingMetFields,dimensions] = getModelFieldsForType(model,'mets');
+assert(isempty(setxor(matchingMetFields,{'mets','b','metNames','csense','S'})) && numel(matchingMetFields) == 5);
+assert(length(model.something) == 8) %This field was not modified, as it could not be clearly associated with mets.
+
+%Also, test the removeFieldEntries method now
+%To be able to check whether the right fields are removed, we will create a
+%random s matrix:
+model.S = rand(size(model.S));
+removedMets = [3 4 5 6];
+model2 = removeFieldEntriesForType(model,removedMets,'mets', length(model.mets));
+reducedSMatrix = model.S;
+reducedSMatrix(removedMets,:) = [];
+assert(isequal(model2.S, reducedSMatrix));
+%Assert that the right mets are removed and that the others are retained.
+assert(isempty(intersect(model2.mets,model.mets(removedMets))) && isempty(setxor(setdiff(model.mets,model.mets(removedMets)),model2.mets)))
+
+%Now, remove a metabolite
+model = removeMetabolites(model,model.mets{end});
+% and try this again (same sized rxns and mets)
+model2 = removeFieldEntriesForType(model,removedMets,'mets', length(model.mets));
+reducedSMatrix = model.S;
+reducedSMatrix(removedMets,:) = [];
+assert(isequal(model2.S, reducedSMatrix));
+%Assert that the right mets are removed and that the others are retained.
+assert(isempty(intersect(model2.mets,model.mets(removedMets))) && isempty(setxor(setdiff(model.mets,model.mets(removedMets)),model2.mets)))
+
+%Also give it a try with reactions:
+% and try this again (same sized rxns and mets)
+removedRxns = [3 4 5];
+%Also modify lb, ub and rules for this case
+model.lb = rand(size(model.rxns));
+model.ub = rand(size(model.rxns));
+model = changeGeneAssociation(model,model.rxns{1},'A or B');
+model = changeGeneAssociation(model,model.rxns{3},'B and C');
+model = changeGeneAssociation(model,model.rxns{6},'D or E');
+model2 = removeFieldEntriesForType(model,removedRxns,'rxns', length(model.rxns));
+[rxnPres,rxnPos] = ismember(model2.rxns,model.rxns);
+assert(isequal(model2.S, model.S(:,rxnPos(rxnPres))));
+%Assert that the right mets are removed and that the others are retained.
+assert(isempty(intersect(model2.rxns,model.rxns(removedRxns))) && isempty(setxor(setdiff(model.rxns,model.rxns(removedRxns)),model2.rxns)))
+assert(all(cellfun(@(x,y) isequal(x,y), model2.rules, model.rules(rxnPos(rxnPres)))));
+assert(all(model2.lb == model.lb(rxnPos(rxnPres))));
+assert(all(model2.ub == model.ub(rxnPos(rxnPres))));
+
+%And finally give ti a try for genes:
+%First create the GR rules.
+model = creategrRulesField(model);
+removedGenes = [2 3];
+model2 = removeFieldEntriesForType(model,removedGenes,'genes', length(model.genes));
+assert(isempty(model2.rules{3})); % Both genes got removed.
+assert(isequal(model2.grRules{1},'A')); % B got removed, so only A is retained.
+assert(isequal(model2.rules{6},'x(2) | x(3)')); % The gene positions got changed.
+
+%And test remobval of gene 4
+model2 = removeFieldEntriesForType(model,4,'genes', length(model.genes));
+assert(isequal(model2.rules{6},'x(4)')); % 4 got removed, and 5 renamed
+[e] = parseBoolean(model2.grRules{6});
+[e2] = parseBoolean('E');
+assert(isequal(e,e2));
+%Compare irrespective of actual format.
+
+
+%Switch back
+cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -399,41 +399,6 @@ newRuleBool = ['x(', num2str(find(ismember(model2.genes,'Gene1'))), ') | x(',...
 head = fp.parseFormula(newRuleBool);
 head2 = fp.parseFormula(model2.rules{20});
 assert(head.isequal(head2)); % We can't make a string comparison so we parse the two formulas and see if they are equal.
-%Test batch addition
-%For Mets
-metNames = {'A','b','c'};
-metFormulas = {'C','CO2','H2OKOPF'};
-modelBatch = addMetaboliteBatch(model,metNames,'metCharges', [ -1 1 0],...
-    'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
-assert(all(ismember(metNames,modelBatch.mets)));
-[pres,pos] = ismember(metNames,modelBatch.mets);
-assert(isequal(modelBatch.metFormulas(pos(pres)),columnVector(metFormulas)));
-assert(isequal(modelBatch.metCharges(pos(pres)),[-1; 1;0]));
-assert(verifyModel(modelBatch,'simpleCheck',true));
-
-
-%For Reactions:
-rxnIDs = {'ExA','ATob','BToC'};
-modelBatch2 = addReactionBatch(modelBatch,rxnIDs,{'A','b','c'},[1 -1 0; 0,-2,-1;0,0,1],...
-                                   'lb',[-50,30,1],'ub',[0,60,15]);
-%Check that the reactions are in.                               
-assert(all(ismember(rxnIDs,modelBatch2.rxns)));
-%Check that lbs/ubs are properly updated.
-assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'ExA'})) == -50);
-assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'BToC'})) == 1);
-assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'ATob'})) == 60);
-assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'BToC'})) == 15);
-%Check that the metabolites were correctly assigned.
-assert(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'ExA')))) == 'A');
-assert(isempty(setxor(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'BToC')))),{'b','c'})));
-%Check the stoichiometry is correct
-assert(modelBatch2.S(ismember(modelBatch2.mets,'A'),ismember(modelBatch2.rxns,'ExA')) == 1);
-assert(modelBatch2.S(ismember(modelBatch2.mets,'b'),ismember(modelBatch2.rxns,'ATob')) == -2);
-
-%Now check proper addition of grRules (and updated fields).
-modelBatch3 = addReactionBatch(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
-                                   'grRules',{'b0002 or G2', 'b0008 and G4',''});
 assert(numel(modelBatch3.genes) == numel(model.genes)+2)
-
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -398,6 +398,40 @@ newRuleBool = ['x(', num2str(find(ismember(model2.genes,'Gene1'))), ') | x(',...
 head = fp.parseFormula(newRuleBool);
 head2 = fp.parseFormula(model2.rules{20});
 assert(head.isequal(head2)); % We can't make a string comparison so we parse the two formulas and see if they are equal.
+%Test batch addition
+%For Mets
+metNames = {'A','b','c'};
+metFormulas = {'C','CO2','H2OKOPF'};
+modelBatch = addMetaboliteBatch(model,metNames,'metCharges', [ -1 1 0],...
+    'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
+assert(all(ismember(metNames,modelBatch.mets)));
+[pres,pos] = ismember(metNames,modelBatch.mets);
+assert(isequal(modelBatch.metFormulas(pos(pres)),columnVector(metFormulas)));
+assert(isequal(modelBatch.metCharges(pos(pres)),[-1; 1;0]));
+assert(verifyModel(modelBatch,'simpleCheck',true));
+
+
+%For Reactions:
+rxnIDs = {'ExA','ATob','BToC'};
+modelBatch2 = addReactionBatch(modelBatch,rxnIDs,{'A','b','c'},[1 -1 0; 0,-2,-1;0,0,1],...
+                                   'lb',[-50,30,1],'ub',[0,60,15]);
+%Check that the reactions are in.                               
+assert(all(ismember(rxnIDs,modelBatch2.rxns)));
+%Check that lbs/ubs are properly updated.
+assert(modelBatch2.lb(ismember({'ExA'})) == -50);
+assert(modelBatch2.lb(ismember({'BToC'})) == 1);
+assert(modelBatch2.ub(ismember({'AToB'})) == 60);
+assert(modelBatch2.ub(ismember({'BToC'})) == 15);
+%Check that the metabolites were correctly assigned.
+assert(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'ExA')))) == 'A');
+assert(isempty(setxor(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'BToC')))),{'b','c'})));
+%Check the stoichiometry is correct
+assert(modelBatch2.S(ismember(modelBatch2.mets,'A'),ismember(modelBatch2.rxns,'ExA')) == 1);
+assert(modelBatch2.S(ismember(modelBatch2.mets,'B'),ismember(modelBatch2.rxns,'Atob')) == -2);
+
+%Now check proper addition of grRules (and updated fields).
+modelBatch3 = addReactionBatch(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+                                   'grRules',{'G1 or G2', 'G3 and G4',''})
 
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -12,6 +12,7 @@
 %     - Joseph Kang 04/16/09
 %     - Richard Que (12/16/09) Added testing of convertToIrrevsible/Reversible
 %     - CI integration: Laurent Heirendt January 2017
+%     - Batch addition Tests:  Thomas Pfau Dec 2017
 
 % save the current path
 currentDir = pwd;
@@ -418,20 +419,21 @@ modelBatch2 = addReactionBatch(modelBatch,rxnIDs,{'A','b','c'},[1 -1 0; 0,-2,-1;
 %Check that the reactions are in.                               
 assert(all(ismember(rxnIDs,modelBatch2.rxns)));
 %Check that lbs/ubs are properly updated.
-assert(modelBatch2.lb(ismember({'ExA'})) == -50);
-assert(modelBatch2.lb(ismember({'BToC'})) == 1);
-assert(modelBatch2.ub(ismember({'AToB'})) == 60);
-assert(modelBatch2.ub(ismember({'BToC'})) == 15);
+assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'ExA'})) == -50);
+assert(modelBatch2.lb(ismember(modelBatch2.rxns,{'BToC'})) == 1);
+assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'ATob'})) == 60);
+assert(modelBatch2.ub(ismember(modelBatch2.rxns,{'BToC'})) == 15);
 %Check that the metabolites were correctly assigned.
 assert(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'ExA')))) == 'A');
 assert(isempty(setxor(modelBatch2.mets(find(modelBatch2.S(:,ismember(modelBatch2.rxns,'BToC')))),{'b','c'})));
 %Check the stoichiometry is correct
 assert(modelBatch2.S(ismember(modelBatch2.mets,'A'),ismember(modelBatch2.rxns,'ExA')) == 1);
-assert(modelBatch2.S(ismember(modelBatch2.mets,'B'),ismember(modelBatch2.rxns,'Atob')) == -2);
+assert(modelBatch2.S(ismember(modelBatch2.mets,'b'),ismember(modelBatch2.rxns,'ATob')) == -2);
 
 %Now check proper addition of grRules (and updated fields).
 modelBatch3 = addReactionBatch(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
-                                   'grRules',{'G1 or G2', 'G3 and G4',''})
+                                   'grRules',{'b0002 or G2', 'b0008 and G4',''});
+assert(numel(modelBatch3.genes) == numel(model.genes)+2)
 
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -12,7 +12,6 @@
 %     - Joseph Kang 04/16/09
 %     - Richard Que (12/16/09) Added testing of convertToIrrevsible/Reversible
 %     - CI integration: Laurent Heirendt January 2017
-%     - Batch addition Tests:  Thomas Pfau Dec 2017
 
 % save the current path
 currentDir = pwd;
@@ -399,6 +398,5 @@ newRuleBool = ['x(', num2str(find(ismember(model2.genes,'Gene1'))), ') | x(',...
 head = fp.parseFormula(newRuleBool);
 head2 = fp.parseFormula(model2.rules{20});
 assert(head.isequal(head2)); % We can't make a string comparison so we parse the two formulas and see if they are equal.
-assert(numel(modelBatch3.genes) == numel(model.genes)+2)
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
This pr introduces batch addition of reactions/metabolites and genes.
The provided functions can potentially speed up the process of adding multiple reactions quite a bit as it is no longer necessary to adapt fields multiple times when reactions are added.
The functions all provide a very simplistic method to provide information for additional fields, by just matching the fields and the name/value pairs in `varargin` (see the examples in the functions).

The pr also adds information on the type of each field, thus allowing fields to be properly initialised by the new `createEmptyField` method.
Further `getModelFieldsForType` will now properly return empty fields which can clearly be associated with one of the basic model fields (rxns, mets, genes) if it starts with the the field name without s.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
