### PR TITLE
Fix for output in initCobraToolbox on macOS

### DIFF
--- a/src/base/install/adaptMacPath.m
+++ b/src/base/install/adaptMacPath.m
@@ -5,10 +5,11 @@ function adaptMacPath()
 % USAGE:
 %     adaptMacPath();
 %
+
 global CBTDIR;
 oldMac = false;
 
-[status,macVer] = system('sw_vers')
+[status,macVer] = system('sw_vers');
 if status ~= 0
     oldMac = true;
 else
@@ -27,8 +28,8 @@ end
 
 macBinaryPath = [CBTDIR filesep 'binary' filesep 'maci64' filesep 'bin'];
 
-%Set the current and remove the other path. 
-if oldMac    
+% set the current and remove the other path.
+if oldMac
     addpath([macBinaryPath filesep 'preSierra']);
     rmpath([macBinaryPath filesep 'postSierra']);
 else


### PR DESCRIPTION
Suppresses the output of the version check on macOS.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)
