### PR TITLE
Adding CnaCobraInterface submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/Volume-and-Sampling"]
 	path = external/Volume-and-Sampling
 	url = https://github.com/Bounciness/Volume-and-Sampling.git
+[submodule "external/CnaCobraInterface"]
+	path = external/CnaCobraInterface
+	url = https://github.com/SteffKlamt/CnaCobraInterface.git


### PR DESCRIPTION
As discussed, adding the `CnaCobraInterface` submodule.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

cc: @SteffKlamt
