### PR TITLE
Adding Preparsed Flag for further speedup

### DIFF
--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -1,4 +1,4 @@
-function [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, currentGenes)
+function [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, currentGenes, preparsed)
 % Convert a GPR rule in string format to a rule in logic format.
 % We assume the following properties of GPR Rules:
 % 1. There are no genes called "and" or "or" (in any capitalization).
@@ -12,7 +12,7 @@ function [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, curre
 %
 % USAGE:
 %
-%    [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, currentGenes)
+%    [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, currentGenes, preparsed)
 %
 % INPUT:
 %    grRuleString:     The rule string in textual format.
@@ -27,6 +27,10 @@ function [ruleString, totalGeneList, newGeneList] = parseGPR(grRuleString, curre
 %
 % .. Author: -  Thomas Pfau Okt 2017
 
+if nargin < 3 %This is faster than checking exist)
+    preparsed = false;
+end
+
 newGeneList = {};
 if isempty(grRuleString) || ~isempty(regexp(grRuleString,'^[\s\(\{\[\}\]\)]*$'))
     %If the provided string is empty or consists only of whitespaces or
@@ -37,7 +41,7 @@ if isempty(grRuleString) || ~isempty(regexp(grRuleString,'^[\s\(\{\[\}\]\)]*$'))
 end
 
 % preparse all model.grRules
-if ~iscell(grRuleString)
+if ~preparsed
     grRuleString = preparseGPR(grRuleString);
 end
 

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -28,7 +28,7 @@ function [model] = generateRules(model)
     % loop through all the grRules
     for i = 1:nRules
         if ~isempty(preParsedGrRules{i})
-            [rule,~,newGenes] = parseGPR(preParsedGrRules{i}, model.genes);
+            [rule,~,newGenes] = parseGPR(preParsedGrRules{i}, model.genes,true);
             if ~isempty(newGenes)
                 warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
                 model.genes = [model.genes ; newGenes];


### PR DESCRIPTION
Further speed increase (albeit less pronounced), and explicitly allowing preparsed grRules strings (i.e. those with replace and/ors to be used by parseGPR. This was done before by generateRules but not explicitly specified in parseGPR, which could lead to problems in the future if code of parseGPR gets adjusted according to the documentation. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
