### PR TITLE
Build rxnGeneMat field if not present

### DIFF
--- a/src/analysis/exploration/findGenesFromRxns.m
+++ b/src/analysis/exploration/findGenesFromRxns.m
@@ -25,6 +25,12 @@ if ~isempty(RxnNotInModel)
 end
 rxnInd(RxnNotInModel) = [];
 reactions(RxnNotInModel) = [];
+
+%Create the rxnGeneMat field if not present
+if ~isfield(model,'rxnGeneMat')
+    model = buildRxnGeneMat(model);
+end
+
 %Initialize geneList, as non associated reactions otherwise throw an error.
 geneList = {};
 for i = 1:length(rxnInd)


### PR DESCRIPTION
Building the rxnGeneMat field if it is not present (otherwise the function fails).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
