### PR TITLE
Fixed bug

### DIFF
--- a/src/base/io/writeGDXFromCOBRA.m
+++ b/src/base/io/writeGDXFromCOBRA.m
@@ -38,7 +38,7 @@ if(exist('wgdx') ~= 0)
     matStruct.type = 'parameter';
 
     revStruct.name = 'isRev';
-    revStruct.val = cobraStruct.lb < 0;
+    revStruct.val = double(cobraStruct.lb < 0);
     revStruct.uels = transpose(cobraStruct.rxns);
     revStruct.form = 'full';
     revStruct.type = 'parameter';


### PR DESCRIPTION
wgdx() requires that the .val field has type double

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
