### PR TITLE
Reading CVTERMS in all SBML Levels

### DIFF
--- a/src/base/io/utilities/SBML/convertSBMLID.m
+++ b/src/base/io/utilities/SBML/convertSBMLID.m
@@ -1,4 +1,4 @@
-function [ convertedstr ] = convertSBMLID( str, toSBML )
+function [ convertedstr ] = convertSBMLID( convertedstr, toSBML )
 %CONVERTSBMLID converts the given str to a valid SBML ID 
 % USAGE:
 %
@@ -22,11 +22,22 @@ function [ convertedstr ] = convertSBMLID( str, toSBML )
 if ~exist('toSBML','var')
     toSBML = true;
 end
-if toSBML
-    
+if toSBML    
     convertedstr = regexprep(str,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 else   
     convertedstr = regexprep(str,'__([0-9]+)__','${char(str2num($1))}');
+    %Biomodels specific conversions for Input of Biomodels 
+    convertedstr = strrep(convertedstr,'-DASH-','-');
+    convertedstr = strrep(convertedstr,'_DASH_','-');
+    convertedstr = strrep(convertedstr,'_FSLASH_','/');
+    convertedstr = strrep(convertedstr,'_BSLASH_','\');
+    convertedstr = strrep(convertedstr,'_LPAREN_','(');
+    convertedstr = strrep(convertedstr,'_LSQBKT_','[');
+    convertedstr = strrep(convertedstr,'_RSQBKT_',']');
+    convertedstr = strrep(convertedstr,'_RPAREN_',')');
+    convertedstr = strrep(convertedstr,'_COMMA_',',');
+    convertedstr = strrep(convertedstr,'_PERIOD_','.');
+    convertedstr = strrep(convertedstr,'_APOS_','''');        
 end
 
 end

--- a/src/base/io/utilities/SBML/convertSBMLID.m
+++ b/src/base/io/utilities/SBML/convertSBMLID.m
@@ -1,4 +1,4 @@
-function [ convertedstr ] = convertSBMLID( convertedstr, toSBML )
+function [ convertedstr ] = convertSBMLID( str, toSBML )
 %CONVERTSBMLID converts the given str to a valid SBML ID 
 % USAGE:
 %

--- a/src/base/io/utilities/readSBML.m
+++ b/src/base/io/utilities/readSBML.m
@@ -91,21 +91,23 @@ else
         formulas = extractfield(sbmlSpecies, 'fbc_chemicalFormula');
         setFormulas = ~cellfun(@isempty, formulas);
         model.metFormulas(setFormulas) = formulas(setFormulas);
-    end
-    if isfield(sbmlSpecies,'cvterms')
-        %Extract the cvterms, we will not individually parse annotation
-        %strings that do not adhere to miriam style annotations.
-        cvterms = [sbmlSpecies.cvterms];
-        if isstruct(cvterms)
-            %we need a cell array, but we need to be sure, that its not
-            %empty, i.e. that it actually is the struct we are looking for.
-            cvterms = {sbmlSpecies.cvterms};
-            [databases,identifiers,qualifiers] = cellfun(@parseCVTerms, cvterms,'UniformOutput',0);
-            model = mapAnnotationsToFields(model,databases,identifiers,qualifiers,'met');
-        end
-    end
-    
+    end   
 end
+
+%This is independent on the SBML version. 
+if isfield(sbmlSpecies,'cvterms')
+    %Extract the cvterms, we will not individually parse annotation
+    %strings that do not adhere to miriam style annotations.
+    cvterms = [sbmlSpecies.cvterms];
+    if isstruct(cvterms)
+        %we need a cell array, but we need to be sure, that its not
+        %empty, i.e. that it actually is the struct we are looking for.
+        cvterms = {sbmlSpecies.cvterms};
+        [databases,identifiers,qualifiers] = cellfun(@parseCVTerms, cvterms,'UniformOutput',0);
+        model = mapAnnotationsToFields(model,databases,identifiers,qualifiers,'met');
+    end
+end
+
 model.mets = columnVector(sbmlids);
 model.metNames = columnVector({sbmlSpecies.name});
 if isfield(sbmlSpecies,'sboTerm')


### PR DESCRIPTION
CVTerms specified in standard MIRIAM annotation detailed in the SBML specifications was only read in SBML Level 3+.
Fixed this to read these annotation terms in all SBML Levels.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
