### PR TITLE
Fixed various typos in the genes section of removeFieldEntriesForType.m

### DIFF
--- a/src/reconstruction/refinement/removeFieldEntriesForType.m
+++ b/src/reconstruction/refinement/removeFieldEntriesForType.m
@@ -114,6 +114,8 @@ if strcmp(type,'genes')
                 end
             end              
         end
+        % Fix rules that now have more than one continuous "|"
+        model.rules = regexprep(model.rules, '\|{2,}', '|');
         %Now, replace all remaining indices.
         oldIndices = find(~indicesToRemove);
         for i = 1:numel(oldIndices)
@@ -149,7 +151,7 @@ if isfield(model, 'grRules') && exist('modifiedRules','var')
     currentrules = strrep(model.rules(modifiedRules),'&','and');
     currentrules = strrep(currentrules,'|','or');
     getGeneName = @(pos) model.genes{str2num(pos)};
-    currentrules = regexprep(currentrules,'x\(([0-9])\)','${getGeneName($1)}');
+    currentrules = regexprep(currentrules,'x\(([0-9]+)\)','${getGeneName($1)}');
     model.grRules(modifiedRules) = currentrules;
 end
 

--- a/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testDynamicModelFieldModification.m
@@ -24,7 +24,7 @@ model.genes{end+1,1} = 'gene1';
 
 %extend all relevant fields (the original size was 0.
 %get all Model fields for genes
-fprintf('Testing getModelFieldsForType and extendModelFielsForType ...\n');
+fprintf('Testing getModelFieldsForType and extendModelFieldsForType ...\n');
 [matchingGeneFields,dimensions] = getModelFieldsForType(model,'genes','fieldSize',0);
 assert(dimensions == 2);
 assert(isequal(matchingGeneFields,{'rxnGeneMat'}));


### PR DESCRIPTION
I fixed various typos in the genes section of removeFieldEntriesForType that caused
- mistakes with recreating grRules when there were more than 10 genes
- various rules that had repeated | (such as x(1) ||| x(2))

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
