### PR TITLE
BugFix for dual Report from dqq

### DIFF
--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -444,7 +444,10 @@ switch solver
         %        sol.y               m vector: dual variables for Ax - s = 0.
         x = sol.x;
         f = c'* x;
-        y = sol.y;
+        %MPS Considers the objective as additional constraint (first
+        %constraint. therefore it has a suplus dual which needs to be
+        %removed.
+        y = sol.y(2:end);
         w = sol.rc;
         origStat = sol.inform;
 
@@ -535,7 +538,10 @@ switch solver
         x = sol.x;
 
         f = c' * x;
-        y = sol.y;
+        %MPS Considers the objective as additional constraint (first
+        %constraint. therefore it has a suplus dual which needs to be
+        %removed.
+        y = sol.y(2:end);
         w = sol.rc;
         origStat = sol.inform;
 


### PR DESCRIPTION
dqq considers the objective as an additional constraint and adds a dual value to it. 
This is "concealed" in optimizeCbModel (which strips surplus dual variables) but thereby returns the wrong duals as it strips the last and not the first dual variable. 
Fixed this in solveCobraLP.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
