### PR TITLE
Update testSteadyCom for robustness

### DIFF
--- a/test/verifiedTests/analysis/testSteadyCom/testSteadyCom.m
+++ b/test/verifiedTests/analysis/testSteadyCom/testSteadyCom.m
@@ -152,7 +152,8 @@ for jTest = 1:2
                 feasTol = 1e-4;  % feasibility tolerance
                 tol = 1e-2;  % tolerance for comparing results
         end
-
+        tolPercent = 0.05;  % tolerance for percentage difference
+        
         % TEST SteadyCom
         % test different algoirthms
         data = load('refData_SteadyCom', 'result');
@@ -244,7 +245,7 @@ for jTest = 1:2
         diary off;
         % check max. growth rate and sum of absolute fluxes
         assert(abs(resultNVarg.GRmax - 0.142857) < tol);
-        assert(abs(sum(abs(resultNVarg.flux)) - 53.6493) / 53.6493 < tol)
+        assert(abs(sum(abs(resultNVarg.flux)) - 53.6493) / 53.6493 < tolPercent)
         % check that nothing is printed
         text1 = importdata('SteadyCom_saveModel.txt');
         assert(isempty(text1));
@@ -286,9 +287,9 @@ for jTest = 1:2
         data = load('refData_SteadyComFVA', 'minFlux', 'maxFlux', 'GRvector');
 
         % Different solvers may give slightly different results. Give a percentage tolerance
-        assert(max(max(abs(minFlux - data.minFlux) ./ data.minFlux)) < tol)
-        assert(max(max(abs(maxFlux - data.maxFlux) ./ data.maxFlux)) < tol)
-        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tol)
+        assert(max(max(abs(minFlux - data.minFlux) ./ data.minFlux)) < tolPercent)
+        assert(max(max(abs(maxFlux - data.maxFlux) ./ data.maxFlux)) < tolPercent)
+        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tolPercent)
         
         % test with an infeasible model
         [minFlux, maxFlux, ~, ~, GRvector] = SteadyComFVA(modelTest);
@@ -299,21 +300,21 @@ for jTest = 1:2
         [minFlux, maxFlux] = SteadyComFVA(modelJoint, options, 'feasTol', feasTol);
         minFluxRef = [0.2856653; 0.3749391];
         maxFluxRef = [0.6250234; 0.7143061];
-        assert(max(max(abs([minFlux, maxFlux] - [minFluxRef, maxFluxRef]) ./ [minFluxRef, maxFluxRef])) < tol)
+        assert(max(max(abs([minFlux, maxFlux] - [minFluxRef, maxFluxRef]) ./ [minFluxRef, maxFluxRef])) < tolPercent)
         
         % test the sub-function without given growth rate
         [minFlux, maxFlux, ~, ~, ~, gr] = SteadyComFVAgr(modelJoint, struct('GRtol', 1e-6), [], 'feasTol', feasTol);
-        assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tol)
+        assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tolPercent)
         assert(abs(gr - 0.142857) < tol)
         
         % test loading Cplex model
         if jTest == 1
             options = struct('GRtol', 1e-6, 'loadModel', 'testSteadyComSaveModel', 'GRmax', 0.142857, 'optGRpercent', 100);
             [minFlux, maxFlux] = SteadyComFVA(modelJoint, options, 'feasTol', feasTol);
-            assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tol)
+            assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tolPercent)
             options = struct('GRtol', 1e-6, 'loadModel', 'testSteadyComSaveModel', 'GR', 0.142857);
             [minFlux, maxFlux] = SteadyComFVAgr(modelJoint, options, [], 'feasTol', feasTol);
-            assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tol)
+            assert(max(max(abs([minFlux, maxFlux] - [data.minFlux(:, 1), data.maxFlux(:, 1)]) ./ [data.minFlux(:, 1), data.maxFlux(:, 1)])) < tolPercent)
         end
         
         % test saving results
@@ -336,7 +337,7 @@ for jTest = 1:2
                     if abs(vRef(j3)) < 1e-5
                         assert(abs(vRef(j3) - v(j3)) < 1e-5)
                     else
-                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tol)
+                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tolPercent)
                     end
                 end
             end
@@ -360,7 +361,7 @@ for jTest = 1:2
                     if abs(vRef(j3)) < 1e-5
                         assert(abs(vRef(j3) - v(j3)) < 1e-5)
                     else
-                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tol)
+                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tolPercent)
                     end
                 end
             end
@@ -400,7 +401,7 @@ for jTest = 1:2
                     if abs(vRef(j3)) < 1e-5
                         assert(abs(vRef(j3) - v(j3)) < 1e-5)
                     else
-                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tol)
+                        assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tolPercent)
                     end
                 end
             end
@@ -438,7 +439,7 @@ for jTest = 1:2
                             if abs(vRef(j3)) < 1e-5
                                 assert(abs(vRef(j3) - v(j3)) < 1e-5)
                             else
-                                assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tol)
+                                assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tolPercent)
                             end
                         end
                     end
@@ -470,7 +471,7 @@ for jTest = 1:2
                             if abs(vRef(j3)) < 1e-5
                                 assert(abs(vRef(j3) - v(j3)) < 1e-5)
                             else
-                                assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tol)
+                                assert(abs(vRef(j3) - v(j3)) / abs(vRef(j3)) < tolPercent)
                             end
                         end
                     end
@@ -505,10 +506,10 @@ for jTest = 1:2
                 end
             end
         end
-        assert(devPOA < tol)
-        assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tol)
+        assert(devPOA < tolPercent)
+        assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tolPercent)
         assert(devSt < tol)
-        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tol)
+        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tolPercent)
         
         % test loading Cplex model
         if jTest == 1
@@ -535,11 +536,11 @@ for jTest = 1:2
                     end
                 end
             end
-            assert(devPOA2 < tol)
-            assert(max(max(max(abs(fluxRange2 - data.fluxRange(:, :, 1)) ./ abs(data.fluxRange(:, :, 1))))) < tol)
+            assert(devPOA2 < tolPercent)
+            assert(max(max(max(abs(fluxRange2 - data.fluxRange(:, :, 1)) ./ abs(data.fluxRange(:, :, 1))))) < tolPercent)
             assert(devSt2 < tol)
-            assert(devPOA3 < tol)
-            assert(max(max(max(abs(fluxRange3 - data.fluxRange(:,:, 1)) ./ abs(data.fluxRange(:, :, 1))))) < tol)
+            assert(devPOA3 < tolPercent)
+            assert(max(max(max(abs(fluxRange3 - data.fluxRange(:,:, 1)) ./ abs(data.fluxRange(:, :, 1))))) < tolPercent)
             assert(devSt3 < tol)
             delete('testSteadyComSaveModel.bas', 'testSteadyComSaveModel.mps', 'testSteadyComSaveModel.prm') 
         end
@@ -566,10 +567,10 @@ for jTest = 1:2
                 end
             end
         end
-        assert(devPOA < tol)
-        assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tol)
+        assert(devPOA < tolPercent)
+        assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tolPercent)
         assert(devSt < tol)
-        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tol)
+        assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tolPercent)
         
         % test parallel computation        
         rmdir([pwd filesep 'testSteadyComPOA'], 's')
@@ -587,10 +588,10 @@ for jTest = 1:2
                     end
                 end
             end
-            assert(devPOA < tol)
-            assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tol)
+            assert(devPOA < tolPercent)
+            assert(max(max(max(abs(fluxRange - data.fluxRange) ./ abs(data.fluxRange)))) < tolPercent)
             assert(devSt < tol)
-            assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tol)
+            assert(max(abs(GRvector - data.GRvector) ./ data.GRvector) < tolPercent)
             % delete created files
             rmdir([pwd filesep 'testSteadyComPOA'], 's')
         else


### PR DESCRIPTION
testSteadyCom: relax the percentage difference tolerance when comparing results

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
