### PR TITLE
Confidence Scores are numeric, cannot otherwise be added to data

### DIFF
--- a/src/reconstruction/rBioNet/model2data.m
+++ b/src/reconstruction/rBioNet/model2data.m
@@ -147,7 +147,12 @@ end
 %ecNumbers = 5, rxnKEGGID = 6, description = 7
 for i = 1:length(Optional)-1
     if isfield(model,Optional{i})
-        data(:,i+7) = handles.model.(Optional{i});
+        if isnumeric(handles.model.(Optional{i}))
+            %Confidence Scores are numeric values....
+            data(:,i+7) = num2cell(handles.model.(Optional{i}));
+        else
+            data(:,i+7) = handles.model.(Optional{i});
+        end
     else %data missing
         data(:,i+7) = cell(S1(1),1);
     end


### PR DESCRIPTION
Addressing #1115 

model2data treated Confidence scores as a cell array while it is a numeric array by definition.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
