### PR TITLE
Allowing files to fail gracefully

### DIFF
--- a/src/analysis/sparseFBA/sparseFBA.m
+++ b/src/analysis/sparseFBA/sparseFBA.m
@@ -286,8 +286,7 @@ end
 
 %Double check that all inputs are valid:
 if ~(verifyCobraProblem(LPproblem, [], [], false) == 1)
-    warning('invalid problem');
-    return;
+    error('invalid problem');
 end
 
 if nnz(model.c)~=0

--- a/src/analysis/thermo/thermoFBA/addLoopLawConstraints.m
+++ b/src/analysis/thermo/thermoFBA/addLoopLawConstraints.m
@@ -64,6 +64,9 @@ if any(rxnIndex > size(LPproblem.A,2))
     return;
 end
 
+% Perhaps this should be moved before the "different ways of doing this" -
+% line 47, so the function will not crash retuning an undefined value?
+% Either that, or change the display/return to error?
 MILPproblem = LPproblem;
 
 S = model.S;

--- a/src/analysis/topology/extremeRays/optimalRays/greedyExtremePoolBasis.m
+++ b/src/analysis/topology/extremeRays/optimalRays/greedyExtremePoolBasis.m
@@ -17,6 +17,7 @@ function [B, L] = greedyExtremePoolBasis(model)
 [inform,molecularVector]=checkStoichiometricConsistency(model,0); %check stoichiometric consistency
 if inform~=1 %check if positive vector in left nullspace
     B=[];
+    L=[]; % Returning empty vector for left nullspace so if it is expected matlab will keep running
     return;
 end
 

--- a/src/dataIntegration/fluxomics/C13ConfidenceInterval.m
+++ b/src/dataIntegration/fluxomics/C13ConfidenceInterval.m
@@ -55,27 +55,21 @@ else % might be a ratio.  Gotta process strings
             [rxn1,rest] = strtok(directions{i}, '/');
             rxnID = findRxnIDs(model,rxn1);
             if rxnID == 0
-                display('unable to process rxn from list');
-                display(directions{i});
-                return;
+                error('Unable to process rxn from list\n %s', directions{i});
             else
                 isratio(i) = -rxnID;
             end
             rxn2 = rest(2:end);
             rxnID = findRxnIDs(model,rxn2);
             if rxnID == 0
-                display('unable to process rxn from list');
-                display(rest(2:end));
-                return;
+                error('Unable to process rxn from list\n %s', rest(2:end))
             else
                 denom(i) = rxnID;
             end
         else
             rxnID = findRxnIDs(model,directions{i});
             if rxnID == 0
-                display('unable to process rxn from list');
-                display(directions{i});
-                return;
+                error('Unable to process rxn from list\n %s', directions{i});
             else
                 isratio(i) = rxnID;
             end
@@ -213,8 +207,7 @@ end
 
 if ~exist (logdirectory, 'dir')
     if ~mkdir(logdirectory)
-        display('unable to create logdirectory');
-        return;
+        error('unable to create logdirectory');
     end
 end
 clear d

--- a/src/dataIntegration/fluxomics/c13solver/Combination.m
+++ b/src/dataIntegration/fluxomics/c13solver/Combination.m
@@ -16,6 +16,7 @@ function [out] = Combination(n, k)
 
     if (n < 0 || k < 0) % normally n >= k
       disp('Negative parameter in constructor');
+      out = [];
       return
     end
 

--- a/src/dataIntegration/fluxomics/c13solver/idv2mdv.m
+++ b/src/dataIntegration/fluxomics/c13solver/idv2mdv.m
@@ -31,8 +31,7 @@ if nargin == 1
 end
 
 if length(fragment) ~= n
-    display('error in fragment length');
-    return;
+    error('error in fragment length');
 end
 
 ncarbons = sum(fragment)+1;

--- a/src/dataIntegration/fluxomics/compareMultSamp.m
+++ b/src/dataIntegration/fluxomics/compareMultSamp.m
@@ -27,8 +27,7 @@ function [totalz, zscore, mdvs] = compareMultSamp(xglc, model, samps, measuredMe
 % .. Author: - Wing Choi 2/11/08
 
 if (nargin < 3)
-    disp '[totalz,zscore,mdvs] = compareMultSamp(xglc,model,samps,measuredMetabolites)';
-    return;
+    error '[totalz,zscore,mdvs] = compareMultSamp(xglc,model,samps,measuredMetabolites)';
 end
 
 if (nargin < 4)

--- a/src/dataIntegration/fluxomics/compareTwoMDVs.m
+++ b/src/dataIntegration/fluxomics/compareTwoMDVs.m
@@ -22,8 +22,7 @@ function [totalz, zscore] = compareTwoMDVs(mdv1, mdv2)
 
 
 if (nargin < 2)
-    disp '[totalz,zscore] = compareTwoMDVs(mdv1,mdv2)';
-    return;
+    error '[totalz,zscore] = compareTwoMDVs(mdv1,mdv2)';
 end
 
 %Compute the mean and standard deviation of each mdv and then get a z-score

--- a/src/dataIntegration/fluxomics/compareTwoSamp.m
+++ b/src/dataIntegration/fluxomics/compareTwoSamp.m
@@ -27,8 +27,7 @@ function [totalz, zscore, mdv1, mdv2] = compareTwoSamp(xglc, model, samp1, samp2
 % .. Author: - Wing Choi 2/11/08
 
 if (nargin < 4)
-    disp '[totalz,zscore,mdv1,mdv2] = compareTwoSamp(xglc,model,samp1,samp2,measuredMetabolites)';
-    return;
+    error '[totalz,zscore,mdv1,mdv2] = compareTwoSamp(xglc,model,samp1,samp2,measuredMetabolites)';
 end
 
 if (nargin < 5)

--- a/src/dataIntegration/fluxomics/generateRandomSample.m
+++ b/src/dataIntegration/fluxomics/generateRandomSample.m
@@ -1,8 +1,7 @@
 function [output] = generateRandomSample(model, n)
 
 if (nargin < 1)
-    disp 'function [output] = generateRandomSample(model, n)';
-    return;
+    error 'function [output] = generateRandomSample(model, n)';
 end
 if (nargin < 2)
     n = 5000;

--- a/src/dataIntegration/fluxomics/runHiLoExp.m
+++ b/src/dataIntegration/fluxomics/runHiLoExp.m
@@ -58,8 +58,7 @@ function [experiment] = runHiLoExp(experiment)
 % .. Author: - Wing Choi 3/14/08
 
 if (nargin < 1)
-    disp '[experiment] = runHiLoExp(experiment,target,threshold)';
-    return;
+    error '[experiment] = runHiLoExp(experiment,target,threshold)';
 end
 
 runzscore = true;      %binary flag for z-scores

--- a/src/dataIntegration/transcriptomics/FASTCORE/fastcore.m
+++ b/src/dataIntegration/transcriptomics/FASTCORE/fastcore.m
@@ -34,7 +34,6 @@ function tissueModel = fastcore(model, core, epsilon, printlevel)
 %       - Ronan Fleming, commenting of code and inputs/outputs
 %       - Anne Richelle, code adaptation to fit with createTissueSpecificModel
 
-
     if nargin < 4 || ~exist('printLevel','var')
         printlevel = 0;
     end
@@ -68,8 +67,7 @@ function tissueModel = fastcore(model, core, epsilon, printlevel)
     [Supp, basis] = findSparseMode(J, P, singleton, model, epsilon);
     
     if ~isempty(setdiff(J, Supp))
-      fprintf ('fastcore.m Error: Inconsistent irreversible core reactions.\n');
-      return;
+      error ('fastcore.m Error: Inconsistent irreversible core reactions.\n');
     end
     
     A = Supp;
@@ -111,8 +109,7 @@ function tissueModel = fastcore(model, core, epsilon, printlevel)
             end
             if flipped || isempty(JiRev)
                 if singleton
-                    fprintf('\n fastcore.m Error: Global network is not consistent.\n');
-                    return
+                    error('\n fastcore.m Error: Global network is not consistent.\n');
                 else
                   flipped = false;
                   singleton = true;

--- a/src/dataIntegration/transcriptomics/GIMME/GIMME.m
+++ b/src/dataIntegration/transcriptomics/GIMME/GIMME.m
@@ -68,8 +68,7 @@ function tissueModel = GIMME(model, expressionRxns, threshold, obj_frac)
         FBAsolution = optimizeCbModel(modelIrrev);
         if (FBAsolution.stat ~= 1)
             not_solved=1;
-            display('Failed to solve initial FBA problem');
-            return
+            error('Failed to solve initial FBA problem');
         end
         maxObjective(i)=FBAsolution.f;
     end

--- a/src/design/GetOptGeneSol.m
+++ b/src/design/GetOptGeneSol.m
@@ -46,7 +46,7 @@ if sum(x) == 0
             '--sub-',char(substrateRxn),'--KOs-0-no_solution_better_than_WT'...
             ), 'optGeneSol')
     end
-    return;
+    error('No genes or reactions found\n');
 end
 
 % from OptGene

--- a/src/design/optGene.m
+++ b/src/design/optGene.m
@@ -124,12 +124,11 @@ for i = 1:length(generxnList)
     if(~ ismember(generxnList{i}, model.genes)),geneok = 0; end
 end
 if geneok
-    display('assuming list is genes');
+    disp('assuming list is genes');
 elseif rxnok
-    display('assuming list is reactions');
+    disp('assuming list is reactions');
 else
-    display('list appears to be neither genes nor reactions:  aborting');
-    return;
+    error('list appears to be neither genes nor reactions:  aborting');
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Under certain conditions of running fastcore, it reaches a situation where it prints a warning (using fprintf) and returns, since the algorithm can't continue. At that point, it causes an error if fastcore was called returning an output, such as

newModel = fastcore(model, core, epsilon, printlevel)

because the output (tissueModel in fastcore.m) hasn't been defined. I replaced it with an error, so the error message will propagate upwards. It allows running fastcore with try, catch, and understanding why fastcore failed.

I went over the COBRA toolbox and changed instances of using return to have either predefined outputs, or that they return an error. It is possible I made the wrong decisions, but I'd like to raise this issue.

addLoopLawConstraints.m has a comment, since I'm not sure what would make sense.

I ran the tests on my computer, and they worked. I'm going to see if the tests continue working on other OS/Matlab version combinations, and if not, I will attempt to update this branch.


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
