### PR TITLE
Fix TheoretMaxProd Test

### DIFF
--- a/src/design/theoretMaxProd.m
+++ b/src/design/theoretMaxProd.m
@@ -12,12 +12,11 @@ function [ExRxns, MaxTheoOut] = theoretMaxProd(model, inputrxn, criterion, norma
 % OPTIONAL INPUT:
 %    criterion:     One of
 %
-%                     * 'pr_mol' (default)
-%                     * 'pr_mw'  (same thing in molecular weight)
-%                     * 'pr_other_mol' (other carbon compounds secretion rate)
-%                     * 'pr_other_mw'  (same thing in molecular weight)
-%                       weight yield)
-%    normalize:     normalize by input flux.  Either the flux rate in mol or
+%                     * 'pr_mol' (default, return the maximal molar fluxes for all exchangers)
+%                     * 'pr_mw'  (return the maximal molecular weight fluxes)
+%                     * 'pr_other_mol' (return the molar fluxes through other carbon Exporters)
+%                     * 'pr_other_mw'  (return the molecular weights exported through other carbon Exporters)
+%    normalize:     normalize by input flux with respect to the input Flux.  Either the flux rate in mol or
 %                   in molecular weight (Default = false)
 %    rxns:          Selection Vector (1 for selected, 0 otherwise)
 %
@@ -85,9 +84,6 @@ elseif( strcmp(criterion, 'pr_other_mol') || strcmp(criterion, 'pr_other_mw'))
         metID = find(model.S(:,rxnID));
         if cmets(metID)>0
             coefficients(rxnID) = mw(metID);
-%             if strcmp(ExRxns(i), 'EX_co2(e)') % get rid of CO2 if required
-%                 coefficients(rxnID) = 0;
-%             end
         end
     end
 
@@ -99,7 +95,6 @@ elseif( strcmp(criterion, 'pr_other_mol') || strcmp(criterion, 'pr_other_mw'))
         model.c = newC;
         % run the LP optimization
         FBAsolution = optimizeCbModel(model);
-%            optimalFlux = FBAsolution.f;
         cf2 = coefficients;
         cf2(inputRxnID) = 0;
         cf2(rxnID) = 0;
@@ -116,7 +111,6 @@ elseif( strcmp(criterion, 'pr_other_mol') || strcmp(criterion, 'pr_other_mw'))
         end
     end
 else
-  x=7
     display('unknown criterion');
     criterion
 end

--- a/test/verifiedTests/design/testTheoretMaxProd.m
+++ b/test/verifiedTests/design/testTheoretMaxProd.m
@@ -17,22 +17,45 @@ cd(fileDir);
 model = getDistributedModel('ecoli_core_model.mat');
 
 % change solver since qpng is unstable - to be changed after installation of gurobi
+% TODO: test this for multiple solvers. 
 changeCobraSolver('pdco', 'QP');
 
-% function calls
-[ExRxns, MaxTheoOut] = theoretMaxProd(model, model.rxns(20)); % 'EX_ac(e)'
-[ExRxns1, MaxTheoOut1] = theoretMaxProd(model, model.rxns(20), '', true, findExcRxns(model,0,0)); % not default options
-[ExRxns2, MaxTheoOut2] = theoretMaxProd(model, model.rxns(20), 'pr_mw');
-[ExRxns3, MaxTheoOut3] = theoretMaxProd(model, model.rxns(20), 'pr_other_mol');
-[ExRxns4, MaxTheoOut4] = theoretMaxProd(model, model.rxns(20), 'pr_other_mw');
-[ExRxns5, MaxTheoOut5] = theoretMaxProd(model, model.rxns(20), 'x'); % bad criterion
+%Get the molecular weights of the compounds in the model.
+[mw,EMatrix,elements] = computeMW(model, [], false);
 
-% tests
+%lets calc a simple optimization
+tempModel = model;
+acExPos = ismember(model.rxns,'EX_ac(e)');
+tempModel.c = double(acExPos);
+FBAsol = optimizeCbModel(tempModel);
+
+% function calls
+[ExRxns, MaxTheoOut] = theoretMaxProd(model, 'EX_glc(e)'); % Max 'EX_ac(e)' flux (unique)
+allExPos = ismember(model.rxns,ExRxns);
+%Determine the Exchangers and their respective exchanged metabolite +
+%Weights
+exWeights = cellfun(@(x) mw(find(model.S(:,ismember(model.rxns,x)))),ExRxns);
+carbEx = cellfun(@(x) EMatrix(find(model.S(:,ismember(model.rxns,x))),ismember(elements,'C')) > 0 ,ExRxns);
+carbExPos = ismember(model.rxns, ExRxns(carbEx));
+acPosInExch = ismember(ExRxns,'EX_ac(e)');
+
+%Alternative calls
+[ExRxns1, MaxTheoOut1] = theoretMaxProd(model, 'EX_glc(e)', '', true, findExcRxns(model,0,0)); % Scaled to 0-1
+[ExRxns2, MaxTheoOut2] = theoretMaxProd(model, 'EX_glc(e)', 'pr_mw'); %Compared to other mw
+[ExRxns3, MaxTheoOut3] = theoretMaxProd(model, 'EX_glc(e)', 'pr_other_mol');
+[ExRxns4, MaxTheoOut4] = theoretMaxProd(model, 'EX_glc(e)', 'pr_other_mw');
+[ExRxns5, MaxTheoOut5] = theoretMaxProd(model, 'EX_glc(e)', 'x'); % bad criterion
+
+% We assume, that the solver is deterministic, i.e. the solution found for
+% the basic call is the same as for all the other calls.
 assert(abs(MaxTheoOut(1) - 20) < 1e-4); % 'EX_ac(e)'
-assert(abs(MaxTheoOut1(1) - 1) < 1e-4); % the same but scaled to 0-1
-assert(abs(MaxTheoOut2(1) - 1180) < 1e-4); % 'EX_ac(e)' in weight
-assert(abs(MaxTheoOut3(1) - 20) < 1e-4); % 'EX_ac(e)'
-assert(abs(MaxTheoOut4(1) - 900) < 1e-4); % 'EX_ac(e)' in weight yield
+assert(abs(MaxTheoOut1(1) - 2) < 1e-4); % the same but scaled to glucose uptake flux (10)
+
+assert(abs(MaxTheoOut2(1) - FBAsol.x(acExPos)*exWeights(1)) < 1e-4); % 'EX_ac(e)' in weight
+%All (molar) exports (>0) without acetate and with 
+assert(abs(MaxTheoOut3(1) - sum(FBAsol.x(allExPos & ~acExPos & FBAsol.x > 0 & carbExPos) )) < 1e-4); % 'EX_ac(e)'
+% Sum of Molecular weights of all Carbon Exporters ( > 0) without Acetate
+assert(abs(MaxTheoOut4(1) - sum(FBAsol.x(allExPos).*(FBAsol.x(allExPos)>0).*exWeights.*carbEx.*~acPosInExch)) < 1e-4); % 'EX_ac(e)' in weight yield
 assert(isequal(MaxTheoOut5, zeros(20, 1))); % bad criterion returns only 0s
 
 % change to old directory


### PR DESCRIPTION
The TheoretMaxProd test was solver dependent and, since the solutions were not unique could fail if a solver did not yield the expected solution.
This was corrected in the new test and the function documentation was updated to better explain the options.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
