### PR TITLE
Fixed poropagation of arguments into findElementaryMoietyVectors

### DIFF
--- a/src/reconstruction/modelGeneration/massBalance/computeMetFormulae.m
+++ b/src/reconstruction/modelGeneration/massBalance/computeMetFormulae.m
@@ -728,7 +728,11 @@ if ~calcMetMwRange
         findCM = 'efmtool';
     end
     if ischar(findCM) && ~CMfound
-        N = findElementaryMoietyVectors(model, 'method', findCM, 'deadCMs', deadCM, varargin{:});
+         cargin = varargin;
+        if numel(varargin > 0) && isstruct(varargin{1})           
+            cargin(1) = []; % remove the first element
+        end
+        N = findElementaryMoietyVectors(model, 'method', findCM, 'deadCMs', deadCM, cargin{:});
         CMfound = true;
     end
     if CMfound

--- a/src/reconstruction/modelGeneration/massBalance/computeMetFormulae.m
+++ b/src/reconstruction/modelGeneration/massBalance/computeMetFormulae.m
@@ -729,7 +729,7 @@ if ~calcMetMwRange
     end
     if ischar(findCM) && ~CMfound
          cargin = varargin;
-        if numel(varargin > 0) && isstruct(varargin{1})           
+        if numel(varargin) > 0 && isstruct(varargin{1})           
             cargin(1) = []; % remove the first element
         end
         N = findElementaryMoietyVectors(model, 'method', findCM, 'deadCMs', deadCM, cargin{:});


### PR DESCRIPTION
`computeMetFormula` passed on the whole `varargin` array which might not be a valid struct for `findElementaryMoietyVectors`.
This PR removes the first element from the varargin vector if it is a struct before passing on additional arguments.

**I hereby confirm that I have:**

- [] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
