### PR TITLE
[documentation] Add Remark how to clean old cobra toolboxes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,18 +44,18 @@ Installation
 ------------
 
 .. begin-installation-marker
-0. If you have an existing installation of an old COBRA toolbox on your system, please remove 
-   the installation and the path  from your folder. You can skip this step, if you do not have
-   an old cobra toolbox installed.
+0. If you have an existing installation of a legacy COBRA Toolbox on your system, please remove 
+   the installation and the remove the installation directory from your matlab path. 
+   You can skip this step, if you do not have a legacy COBRA Toolbox installed.
 
-   |warning| The following commands will delete your CobraToolboxFolder and all of its contents 
+   |warning| The following commands will delete your ``cobratoolbox`` directory and all of its contents 
 
    .. code-block:: matlab
    
-         >> cobraFolder = fileparts(which('initCobraToolbox'));
-         >> rmpath(genpath(cobraFolder);
-         >> savepath
-         >> delete(cobraFolder,'s')
+         >> CBTDIR = fileparts(which('initCobraToolbox.m')); %Get the Toolbox directory
+         >> rmpath(genpath(CBTDIR)); %remove the directory from the path
+         >> savepath % save the new path
+         >> delete(CBTDIR,'s') %delete the installation directory
 
 
 1. Download this repository (the folder ``./cobratoolbox/`` will be

--- a/README.rst
+++ b/README.rst
@@ -44,23 +44,10 @@ Installation
 ------------
 
 .. begin-installation-marker
-0. If you have an existing installation of a legacy COBRA Toolbox on your system, please remove 
-   the installation and the remove the installation directory from your matlab path. 
-   You can skip this step, if you do not have a legacy COBRA Toolbox installed.
-
-   |warning| The following commands will delete your ``cobratoolbox`` directory and all of its contents 
-
-   .. code-block:: matlab
-   
-         >> CBTDIR = fileparts(which('initCobraToolbox.m')); %Get the Toolbox directory
-         >> rmpath(genpath(CBTDIR)); %remove the directory from the path
-         >> savepath % save the new path
-         >> delete(CBTDIR,'s') %delete the installation directory
-
 
 1. Download this repository (the folder ``./cobratoolbox/`` will be
    created). You can clone the repository using:
-   
+
    .. code-block:: console
 
       $ git clone --depth=1 https://github.com/opencobra/cobratoolbox.git cobratoolbox

--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,23 @@ Installation
 ------------
 
 .. begin-installation-marker
+0. If you have an existing installation of an old COBRA toolbox on your system, please remove 
+   the installation and the path  from your folder. You can skip this step, if you do not have
+   an old cobra toolbox installed.
+
+   |warning| The following commands will delete your CobraToolboxFolder and all of its contents 
+
+   .. code-block:: matlab
+   
+         >> cobraFolder = fileparts(which('initCobraToolbox'));
+         >> rmpath(genpath(cobraFolder);
+         >> savepath
+         >> delete(cobraFolder,'s')
+
 
 1. Download this repository (the folder ``./cobratoolbox/`` will be
    created). You can clone the repository using:
-
+   
    .. code-block:: console
 
       $ git clone --depth=1 https://github.com/opencobra/cobratoolbox.git cobratoolbox

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -3,6 +3,21 @@ Frequently Asked Questions (FAQ)
 
 .. begin-faq-marker
 
+Remove legacy installation
+--------------------------
+
+If you have an existing installation of a legacy COBRA Toolbox on your system,
+please remove the installation directory from your MATLAB path.
+
+|warning| The following commands will delete your ``cobratoolbox`` directory and all of its contents
+
+.. code-block:: matlab
+
+    >> CBTDIR = fileparts(which('initCobraToolbox.m')); % get the directory of the COBRA Toolbox
+    >> rmpath(genpath(CBTDIR)); % remove the directory from the path
+    >> savepath % save the new path
+    >> delete(CBTDIR,'s') % delete the installation directory
+
 Github
 ------
 


### PR DESCRIPTION
Add a remark on how to properly clean old cobra toolboxes from the matlab path and the system.

*Please include a short description of enhancement here*

**I hereby confirm that I have:**

- [] Tested my code on my own machine
- [] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
