### PR TITLE
Parse sbml notes improvements

### DIFF
--- a/src/base/io/utilities/parseSBMLNotesField.m
+++ b/src/base/io/utilities/parseSBMLNotesField.m
@@ -46,11 +46,10 @@ else
 end
 
 
-[tmp,fieldList] = regexp(notesField,['<' tag '>.*?</' tag '>'],'tokens','match');
+[fieldTmp,fieldList] = regexp(notesField,['<' tag '>(.*?)</' tag '>'],'tokens','match');
 
 for i = 1:length(fieldList)
-    fieldTmp = regexp(fieldList{i},['<' tag '>(.*)</' tag '>'],'tokens');
-    fieldStr = strtrim(fieldTmp{1}{1});
+    fieldStr = strtrim(fieldTmp{i}{1});
     % Join the remaining string again with the : separator
     strfields = strsplit(fieldStr,':');
     valueStr = strjoin(strfields(2:end), ':');

--- a/src/base/io/utilities/parseSBMLNotesField.m
+++ b/src/base/io/utilities/parseSBMLNotesField.m
@@ -60,14 +60,14 @@ for i = 1:length(fieldList)
         subSystem = valueStr;
         subSystem = strrep(subSystem,'S_','');
         subSystem = strsplit(regexprep(subSystem,'_+',' '),';');
-        
+
     elseif strcmpi(strfields{1},'EC Number') || strcmpi(strfields{1},'EC_Number')
         ecNumber = valueStr;
     elseif strcmpi(strfields{1},'FORMULA')
         formula = valueStr;
     elseif strcmpi(strfields{1},'CHARGE')
         charge = str2num(valueStr);
-    elseif strcmp(strfields{1},'AUTHORS')
+    elseif strcmpi(strfields{1},'AUTHORS')
         if isempty(citation)
             citation = valueStr;
         else
@@ -98,6 +98,6 @@ if ~isempty(notes)
     else
         comment = [notes sprintf('\n') comment];
     end
-    
+
 end
 end

--- a/src/base/io/utilities/parseSBMLNotesField.m
+++ b/src/base/io/utilities/parseSBMLNotesField.m
@@ -50,32 +50,31 @@ end
 
 for i = 1:length(fieldList)
     fieldStr = strtrim(fieldTmp{i}{1});
-    % Join the remaining string again with the : separator
     strfields = strsplit(fieldStr,':');
-    valueStr = strjoin(strfields(2:end), ':');
+    %Remove leading and trailing whitespace , and join the remaining string again with the : separator
+    valueStr = strtrim(strjoin(strfields(2:end), ':'));
     %We have several
     if strcmpi(strfields{1}, 'GENE_ASSOCIATION') || strcmp(strfields{1}, 'GENE ASSOCIATION') || strcmp(strfields{1}, 'GPR_ASSOCIATION')
-        %Remove leading and trailing whitespace 
-        grRule = strtrim(valueStr);
+        grRule = valueStr;
     elseif strcmpi(strfields{1},'SUBSYSTEM')
-        subSystem = strtrim(valueStr);
+        subSystem = valueStr;
         subSystem = strrep(subSystem,'S_','');
         subSystem = strsplit(regexprep(subSystem,'_+',' '),';');
         
     elseif strcmpi(strfields{1},'EC Number') || strcmpi(strfields{1},'EC_Number')
-        ecNumber = strtrim(valueStr);
+        ecNumber = valueStr;
     elseif strcmpi(strfields{1},'FORMULA')
-        formula = strtrim(valueStr);
+        formula = valueStr;
     elseif strcmpi(strfields{1},'CHARGE')
-        charge = str2num(strtrim(valueStr));
+        charge = str2num(valueStr);
     elseif strcmp(strfields{1},'AUTHORS')
         if isempty(citation)
-            citation = strtrim(valueStr);
+            citation = valueStr;
         else
-            citation = strcat(citation,';',strtrim(valueStr));
+            citation = strcat(citation,';',valueStr);
         end
     elseif strcmpi(strfields{1},'Confidence Level') || strcmpi(strfields{1},'Confidence_Level')
-        confidenceScore = str2double(strtrim(valueStr));
+        confidenceScore = str2double(valueStr);
     elseif strcmpi(strfields{1},'NOTES')
         if isempty(notes)
             notes = regexprep(fieldStr,'[\n\r]+',' ');

--- a/src/base/io/utilities/parseSBMLNotesField.m
+++ b/src/base/io/utilities/parseSBMLNotesField.m
@@ -51,39 +51,38 @@ end
 for i = 1:length(fieldList)
     fieldTmp = regexp(fieldList{i},['<' tag '>(.*)</' tag '>'],'tokens');
     fieldStr = strtrim(fieldTmp{1}{1});
+    % Join the remaining string again with the : separator
     strfields = strsplit(fieldStr,':');
+    valueStr = strjoin(strfields(2:end), ':');
     %We have several
-    if strcmp(strfields{1}, 'GENE_ASSOCIATION') || strcmp(strfields{1}, 'GENE ASSOCIATION') || strcmp(strfields{1}, 'GPR_ASSOCIATION')
-        %Remove leading and trailing whitespace, and join the remaining strin again with the : separator
-        grRule = strtrim(strjoin(strfields(2:end),':'));
-    elseif strcmp(strfields{1},'SUBSYSTEM')
-        subSystem = strtrim(strjoin(strfields(2:end),':'));
+    if strcmpi(strfields{1}, 'GENE_ASSOCIATION') || strcmp(strfields{1}, 'GENE ASSOCIATION') || strcmp(strfields{1}, 'GPR_ASSOCIATION')
+        %Remove leading and trailing whitespace 
+        grRule = strtrim(valueStr);
+    elseif strcmpi(strfields{1},'SUBSYSTEM')
+        subSystem = strtrim(valueStr);
         subSystem = strrep(subSystem,'S_','');
         subSystem = strsplit(regexprep(subSystem,'_+',' '),';');
         
-    elseif strcmp(strfields{1},'EC Number') || strcmp(strfields{1},'EC_Number') || strcmp(strfields{1},'EC_NUMBER') || strcmp(strfields{1},'EC NUMBER')
-        ecNumber = strtrim(strjoin(strfields(2:end),':'));
-    elseif strcmp(strfields{1},'FORMULA') || strcmp(strfields{1},'Formula')
-        formula = strtrim(strjoin(strfields(2:end),':'));
-    elseif strcmp(strfields{1},'CHARGE') || strcmp(strfields{1},'Charge')
-        charge = str2num(strtrim(strjoin(strfields(2:end),':')));
+    elseif strcmpi(strfields{1},'EC Number') || strcmpi(strfields{1},'EC_Number')
+        ecNumber = strtrim(valueStr);
+    elseif strcmpi(strfields{1},'FORMULA')
+        formula = strtrim(valueStr);
+    elseif strcmpi(strfields{1},'CHARGE')
+        charge = str2num(strtrim(valueStr));
     elseif strcmp(strfields{1},'AUTHORS')
         if isempty(citation)
-            citation = strtrim(strjoin(strfields(2:end),':'));
+            citation = strtrim(valueStr);
         else
-            citation = strcat(citation,';',strtrim(strjoin(strfields(2:end),':')));
+            citation = strcat(citation,';',strtrim(valueStr));
         end
-    elseif strcmp(strfields{1},'Confidence Level')
-        confidenceScore = str2num(strtrim(strjoin(strfields(2:end),':')));
-        if isempty(confidenceScore)
-            confidenceScore = NaN;
-        end
-    elseif strcmp(strfields{1},'NOTES')
+    elseif strcmpi(strfields{1},'Confidence Level') || strcmpi(strfields{1},'Confidence_Level')
+        confidenceScore = str2double(strtrim(valueStr));
+    elseif strcmpi(strfields{1},'NOTES')
         if isempty(notes)
             notes = regexprep(fieldStr,'[\n\r]+',' ');
         else
-            if ~isempty(strjoin(strfields(2:end),':'))
-                notes = regexprep(strcat(notes,';',strjoin(strfields(2:end),':')),'[\n\r]+',' ');
+            if ~isempty(valueStr)
+                notes = regexprep(strcat(notes,';',valueStr),'[\n\r]+',' ');
             end
         end
     else

--- a/src/base/io/utilities/readSBML.m
+++ b/src/base/io/utilities/readSBML.m
@@ -79,8 +79,6 @@ if modelSBML.SBML_level == 2
         setCharges =  logical([sbmlSpecies.isSetCharge]);
         model.metCharges(setCharges) = charges(setCharges);
     end
-    %here, we would have to manually parse the annotation, and can't use
-    %CVTerms like in SBML3.
 else
     if isfield(modelSBML,'fbc_version') && modelSBML.fbc_version == 2; %This might have to be adjusted to >2 if the fields stay...
         %Update Charges if set in FBC


### PR DESCRIPTION
I added the ability to parse case-insensitive notes, specifically for Confidence Level (Is not all caps in RECON 2.2). I also did some general tidying. I tried separating into multiple commits, since if there is a specific reason to run regexp twice, it is a separate commit and can be ignored.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

