### PR TITLE
Checking requirements

### DIFF
--- a/test/verifiedTests/analysis/testMultiSpeciesModelling/testMgPipe.m
+++ b/test/verifiedTests/analysis/testMultiSpeciesModelling/testMgPipe.m
@@ -12,6 +12,9 @@ global CBTDIR
 % define the features required to run the test
 requiredToolboxes = { 'distrib_computing_toolbox' };
 
+% test Requirements
+prepareTest('requiredToolboxes',requiredToolboxes);
+
 % save the current path
 currentDir = pwd;
 


### PR DESCRIPTION
Skip the test, if the Parallel toolbox is not installed.
Currently, the test indicates a fail if no parallel toolbox is installed. now it will be skipped due to missing requirements.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
