### PR TITLE
Fix for rxnConfidenceScores

### DIFF
--- a/src/base/io/utilities/xls2model.m
+++ b/src/base/io/utilities/xls2model.m
@@ -253,8 +253,14 @@ end
 model = createModel(rxnAbrList,rxnNameList,rxnList,revFlagList,lowerBoundList,upperBoundList,subSystemList,grRuleList);
 
 if ~isempty(strmatch('Confidence Score',rxnHeaders,'exact'))
-    model.confidenceScores = cell2mat(rxnInfo(2:end,strmatch('Confidence Score',rxnHeaders,'exact')));
-    model.confidenceScores(isnan(model.confidenceScores)) = 0;
+    confidenceScores = rxnInfo(2:end,strmatch('Confidence Score',rxnHeaders,'exact'));
+    if any(~cellfun(@isnumeric, confidenceScores))
+        %replace any non numeric elements by their numbers.
+        confidenceScores = cellfun(@str2num,confidenceScores,'UniformOutput',0);
+    end
+    confidenceScores(cellfun(@isempty,confidenceScores)) = {NaN}; %Replace empty by nan.
+    model.rxnConfidenceScores = cell2mat(confidenceScores);    
+    model.rxnConfidenceScores(isnan(model.rxnConfidenceScores)) = 0;
 end
 if ~isempty(strmatch('EC Number',rxnHeaders,'exact'))
     %This needs to be changed to the new annotation scheme and putting the


### PR DESCRIPTION
Fixing IO of rxnConfidenceScores. These, under some circumstances where still cell arrays of strings.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
