### PR TITLE
Update BiGG Test to skip if no connection to BiGG possible

### DIFF
--- a/test/verifiedTests/base/testIO/testLoadBiGGModel.m
+++ b/test/verifiedTests/base/testIO/testLoadBiGGModel.m
@@ -10,6 +10,7 @@
 %
 
 global CBTDIR
+global CBT_MISSING_REQUIREMENTS_ERROR_ID
 
 %Check the requirements (a LP solver is necessary)
 solverPkgs = prepareTest('needsLP',true,'requireOneSolverOf',{'gurobi','ibm_cplex','glpk','mosek','quadMinos'});
@@ -32,6 +33,8 @@ modelArr = {'iIT341.xml','iIT341','sbml','BiGGSBML',0,0.692812693473487;...
 % set the tolerance
 tol = 1e-6;
 
+tested = false;
+
 %loop through the models
 for i = 1:size(modelArr,1)
     %reading the models takes quite a bit of time, so only do it once for
@@ -42,7 +45,16 @@ for i = 1:size(modelArr,1)
     % load the model (actually supply the full filename of the path
     % where the model is found)
     model1 = getDistributedModel(modelArr{i,1});
-    model2 = loadBiGGModel(modelArr{i,2},modelArr{i,3});
+    try
+        model2 = loadBiGGModel(modelArr{i,2},modelArr{i,3});
+        tested = true;
+    catch ME
+        if strcmp(ME.identifier,'MATLAB:webservices:Timeout')
+            %Could not load the model, skip.
+            continue;
+        end
+    end
+        
     model3 = readCbModel(modelArr{i,2},'fileType',modelArr{i,4});
     %Check that the direct load is the same
     assert(isSameCobraModel(model1,model2));
@@ -77,6 +89,10 @@ for i = 1:size(modelArr,1)
             fprintf(' Done.\n');
         end
     end
+end
+%This should only ever happen, if the BiGG db could not be contacted.
+if ~tested
+    error(CBT_MISSING_REQUIREMENTS_ERROR_ID,'Could not connect to BiGG Database');
 end
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
Skipping the BiGG test, if we cannot read from the BiGG database, i.e. if webread fails. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
