### PR TITLE
Correction for verifyFunctionError

### DIFF
--- a/docs/source/guides/testTemplate.m
+++ b/docs/source/guides/testTemplate.m
@@ -62,7 +62,8 @@ for k = 1:length(solverPkgs.LP)
     if solverLPOK
         % <your test goes here>
     end
-    verifyCobraFunctionError(@() testFile(wrongInput));
+    wrongInputs = {'FirstArgument',modelForSecondArgument};
+    verifyCobraFunctionError('testFile', 'inputs', wrongInputs);
     % output a success message
     fprintf('Done.\n');
 end

--- a/test/verifiedTests/analysis/testMultiSpeciesModelling/testJoinModelsPairwiseFromList.m
+++ b/test/verifiedTests/analysis/testMultiSpeciesModelling/testJoinModelsPairwiseFromList.m
@@ -46,7 +46,7 @@ for i = 2:size(pairedModelInfo, 1)
 end
 
 % test the diet call without entering any dietary constraints
-assert(verifyCobraFunctionError(@() useDiet(pairedModel,[])))
+assert(verifyCobraFunctionError('useDiet', 'inputs',{pairedModel,[]}))
 
 % change to the current directory
 cd(currentDir)

--- a/test/verifiedTests/analysis/testMultiSpeciesModelling/testMgPipe.m
+++ b/test/verifiedTests/analysis/testMultiSpeciesModelling/testMgPipe.m
@@ -67,16 +67,16 @@ init = initMgPipe(modPath, CBTDIR, resPath, dietFilePath, abunFilePath, objre, f
 assert(init && ~autorun);
 
 % check if error is thrown when running in serial
-assert(verifyCobraFunctionError(@() initMgPipe(modPath, CBTDIR, resPath, dietFilePath, abunFilePath, objre, figForm, 1, autoFix, compMod, patStat, rDiet, extSolve, fvaType, autorun)));
+assert(verifyCobraFunctionError('initMgPipe', 'inputs',{modPath, CBTDIR, resPath, dietFilePath, abunFilePath, objre, figForm, 1, autoFix, compMod, patStat, rDiet, extSolve, fvaType, autorun}));
 
 % test if the function throws an error when no arguments are provided
-assert(verifyCobraFunctionError(@() initMgPipe()))
+assert(verifyCobraFunctionError('initMgPipe'))
 
 % test with only the path to the models (throws an error that the abundance file is missing)
-assert(verifyCobraFunctionError(@() initMgPipe(modPath)));
+assert(verifyCobraFunctionError('initMgPipe', 'inputs',{modPath}));
 
 % test if the path to the models exists (the model directory is set, but it does not exist)
-assert(verifyCobraFunctionError(@() initMgPipe('/tmp/abcdef')))
+assert(verifyCobraFunctionError('initMgPipe','inputs',{'/tmp/abcdef'}))
 
 % turn all warnings off
 warning('off', 'all')

--- a/test/verifiedTests/analysis/testPrint/testPrintGPRForRxns.m
+++ b/test/verifiedTests/analysis/testPrint/testPrintGPRForRxns.m
@@ -55,7 +55,7 @@ gprs = findGPRFromRxns(modelTemp2,modelTemp2.rxns(1:5));
 assert(all(cellfun(@isempty, gprs)));
 
 %Give an error, if a reaction is not present
-verifyCobraFunctionError(@() findGPRFromRxns(model,'A'));
+assert(verifyCobraFunctionError('findGPRFromRxns','inputs',{model,'A'}));
 
 % Finally test, that no output is generated from findGPRFromRxns
 diary findGPR.txt

--- a/test/verifiedTests/analysis/testTopology/testExtremePathways.m
+++ b/test/verifiedTests/analysis/testTopology/testExtremePathways.m
@@ -65,7 +65,7 @@ assert(all(all(refP == P)))
 
 % Change the model to have one non integer entry.
 model.S(1, 1) = 0.5;
-assert(verifyCobraFunctionError(@() extremePathways(model)));
+assert(verifyCobraFunctionError('extremePathways','inputs',{model}));
 
 % delete generated files
 delete('*.ine');

--- a/test/verifiedTests/base/testInstall/testAddKeyToKnownHosts.m
+++ b/test/verifiedTests/base/testInstall/testAddKeyToKnownHosts.m
@@ -13,7 +13,7 @@ global CBTDIR
 currentDir = pwd;
 
 % test for a failure of an unknown host
-assert(verifyCobraFunctionError(@() addKeyToKnownHosts('github123.co')));
+assert(verifyCobraFunctionError('addKeyToKnownHosts','inputs',{'github123.co'}));
 
 % find the keyscan
 [status_keyscan, result_keyscan] = system('ssh-keyscan');

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -37,8 +37,8 @@ assert(verifyModel(modelBatch,'simpleCheck',true));
 assert(isfield(modelBatch,'metKEGGID'));
 
 %Assert duplication check
-assert(verifyCobraFunctionError(@() addMultipleMetabolites(model,model.mets(1:3))))
-assert(verifyCobraFunctionError(@() addMultipleMetabolites(model,{'A','b','A'})))
+assert(verifyCobraFunctionError('addMultipleMetabolites', 'inputs',{model,model.mets(1:3)}))
+assert(verifyCobraFunctionError('addMultipleMetabolites', 'inputs',{model,{'A','b','A'}}))
 
 % For Reactions:
 fprintf('>> Testing Reaction Batch Addition...\n');
@@ -97,12 +97,12 @@ head2 = fp.parseFormula(modelBatch3.rules{ExAPos});
 assert(head1.isequal(head2));
 
 %Now, test duplicate ID fails (duplicate in the reaction list
-assert(verifyCobraFunctionError(@() addMultipleReactions(model,{'ExA','ATob','ExA'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1])));
-assert(verifyCobraFunctionError(@() addMultipleReactions(model,{'ExA','ATob','CS'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1])));
+assert(verifyCobraFunctionError('addMultipleReactions', 'inputs',{model,{'ExA','ATob','ExA'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1]}));
+assert(verifyCobraFunctionError('addMultipleReactions', 'inputs',{model,{'ExA','ATob','CS'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1]}));
 
 %Also assert, that all metabolites are part of the Model (this is necessary
 %for quick addition).
-assert(verifyCobraFunctionError(@() addMultipleReactions(model,{'ExA','ATob','BToC'},{'A','b','ac[c]'},[1 -1 0; 0,1,-1;0,0,1])));
+assert(verifyCobraFunctionError('addMultipleReactions', 'inputs',{model,{'ExA','ATob','BToC'},{'A','b','ac[c]'},[1 -1 0; 0,1,-1;0,0,1]}));
 
 % For Genes
 fprintf('>> Testing Gene Batch Addition...\n');
@@ -130,8 +130,8 @@ assert(isequal(modelWGenes.geneField2(genepos), gField2));
 assert(all(cellfun(@(x) isequal(x,''),modelWGenes.geneField2(~ismember(modelWGenes.genes,genes)))));
 
 %And finally test duplication errors.
-assert(verifyCobraFunctionError(@() addGenes(model,{'b0008','G1'})));
-assert(verifyCobraFunctionError(@() addGenes(model,{'G2','G1','G2'})));
+assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'b0008','G1'}}));
+assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'G2','G1','G2'}}));
                                
                                
 % change the directory

--- a/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testModelManipulation.m
@@ -74,11 +74,11 @@ assert(verifyModel(modelWithFields,'simpleCheck',true,'requiredFields',{}))
 
 %Trying to add a reaction without stoichiometry will fail.
 errorCall = @() addReaction(model,'NoStoich');
-assert(verifyCobraFunctionError(errorCall));
+assert(verifyCobraFunctionError('addReaction', 'inputs',{model,'NoStoich'}));
 
 %Try adding a new reaction with two different stoichiometries
-errorCall = @() addReaction(model, 'reactionFormula', 'A + B -> C','stoichCoeffList',[ -1 2], 'metaboliteList',{'A','C'});
-assert(verifyCobraFunctionError(errorCall));
+
+assert(verifyCobraFunctionError('addReaction', 'inputs', {model, 'reactionFormula', 'A + B -> C','stoichCoeffList',[ -1 2], 'metaboliteList',{'A','C'}}));
 
 %Try having a metabolite twice in the metabolite list or reaction formula
 modelWAddedMet = addReaction(model, 'reactionFormula', 'Alpha + Beta -> Gamma + 2 Beta');
@@ -438,8 +438,8 @@ assert(isequal(modelWGenes.geneField2(genepos), gField2));
 assert(all(cellfun(@(x) isequal(x,''),modelWGenes.geneField2(~ismember(modelWGenes.genes,genes)))));
 
 %And finally test duplication errors.
-assert(verifyCobraFunctionError(@() addGenes(model,{'b0008','G1'})));
-assert(verifyCobraFunctionError(@() addGenes(model,{'G2','G1','G2'})));
+assert(verifyCobraFunctionError('addGenes', 'inputs', {model,{'b0008','G1'}}));
+assert(verifyCobraFunctionError('addGenes', 'inputs', {model,{'G2','G1','G2'}}));
 
 
 

--- a/test/verifyCobraFunctionError.m
+++ b/test/verifyCobraFunctionError.m
@@ -1,4 +1,4 @@
-function success = verifyCobraFunctionError(functionCall, message)
+function success = verifyCobraFunctionError(functionCall, varargin)
 % Tests whether the provided call throws an error and if the error message
 % fits to the message provided
 %
@@ -7,26 +7,51 @@ function success = verifyCobraFunctionError(functionCall, message)
 %    success = verifyCobraFunctionError(functionCall, message)
 %
 % INPUTS:
-%    functionCall:      A function call (to be called by functionCall()).
+%    functionCall:       The name of a function.
 %
 % OPTIONAL INPUTS:
-%    message:           The message that should be thrown in this error. If
-%                       no message is supplied, any thrown error will be
-%                       accepted
+%    
+%    varargin:           Parameter Value pairs for specific options.
+%                         * outputArgCount -     The number of output arguments requested, as this can influence the functionality (Default: 0).
+%                         * testMessage -        The message that should be thrown in this error. If no message is supplied, any thrown error will be accepted
+%                         * inputs -             If the function requires Any inputs, provide them in a cell array.
 %
 % OUTPUTS:
-%    success:           Whether an error was thrown, and the type and
-%                       message match (if provided)
+%    success:            Whether an error was thrown, and the type and
+%                        message match (if provided)
+% EXAMPLES:
+%    %Test whether pow throws an error when using chars
+%    verifyCobraFunctionError('pow','inputs',{'abc','dce'});
+%    %Test, whether initCobraToolbox throws an error
+%    verifyCobraFunctionError('initCobraToolbox');
+%    %Test whether targetFunctions error message is 'blubb'
+%    verifyCobraFunctionError('targetFunctions','message','blubb');
+%    %Test whether fluxvariability throws an error when 5 outputs are defined
+%    verifyCobraFunctionError('fluxVariability','inputs',{model,0},'outputArgCount',10);
 
 testMessage = false;
+parser = inputParser();
+parser.addRequired('functionCall',@ischar)
+parser.addParamValue('inputs',{},@iscell)
+parser.addParamValue('testMessage','',@ischar)
+parser.addParamValue('outputArgCount',0,@(x) isnumeric(x) && mod(x,1) == 0);
 
-if exist('message','var')
-    testMessage = true;
-end
+parser.parse(functionCall,varargin{:});
 
+outputArgcount = parser.Results.outputArgCount;
+testMessage = ~any(ismember('testMessage',parser.UsingDefaults));
+message = parser.Results.testMessage;
+inputs = parser.Results.inputs;
+
+functionCall = str2func(functionCall);
 success = true;
 try   
-    functionCall();
+    if outputArgcount > 0
+        outArgs = cell(outputArgcount,1);
+        [outArgs{:}] = functionCall(inputs{:});
+    else
+        functionCall(inputs{:});
+    end
 catch ME
     if testMessage
         success = strcmp(ME.message,message);


### PR DESCRIPTION
`verifyCobraFunctionError` always returned true if inputs were defined, as those were not present in the verification function. This did not show up, as all errors should give errors and no message tests were performed.
Updated the functionality and corrected all concerned tests.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
