### PR TITLE
Enabled reading in KBase files

### DIFF
--- a/src/base/io/readCbModel.m
+++ b/src/base/io/readCbModel.m
@@ -133,7 +133,7 @@ modelDescription = parser.Results.modelDescription;
 compSymbolList = parser.Results.compSymbolList;
 compNameList = parser.Results.compNameList;
 matlabModelName = parser.Results.modelName;
-supportedFileExtensions = {'*.xml;*.sto;*.xls;*.xlsx;*.mat'};
+supportedFileExtensions = {'*.xml;*.sbml;*.sto;*.xls;*.xlsx;*.mat'};
 
 % Open a dialog to select file
 if ~exist('fileType', 'var') || isempty(fileType)


### PR DESCRIPTION
Enabled reading in SBML files from KBase (kbase.us) that have .sbml as the file extension.
@laurentheirendt @GeetaAcharya

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [] with [X] to check the box)*
