### PR TITLE
Allowing Opdam 2017 to run on vanilla toolbox

### DIFF
--- a/src/dataIntegration/transcriptomics/INIT/INIT.m
+++ b/src/dataIntegration/transcriptomics/INIT/INIT.m
@@ -1,4 +1,4 @@
-function tissueModel = INIT(model, weights, tol, runtime, logfile)
+function tissueModel = INIT(model, weights, tol, runtime, logfile, epsilon)
 % Use the INIT algorithm (`Agren et al., 2012`) to extract a context
 % specific model using data. INIT algorithm find the optimal trade-off
 % between inluding and removing reactions based on their given weights. If
@@ -31,6 +31,9 @@ function tissueModel = INIT(model, weights, tol, runtime, logfile)
 %
 % .. Authors:  - Implementation adapted from the cobra toolbox (createTissueSpecificModel.m) by S. Opdam and A. Richelle, May 2017
 
+if nargin < 6 || isempty(epsilon)
+    epsilon=1;
+end
 if nargin < 5 || isempty(runtime)
     runtime = 7200;
 end
@@ -49,7 +52,6 @@ end
     S = model.S;
     lb = model.lb;
     ub = model.ub;
-    epsilon=1;
 
     % Creating A matrix
     A = sparse(size(S,1)+2*length(RHindex)+2*length(RLindex),size(S,2)+2*length(RHindex)+length(RLindex));

--- a/src/dataIntegration/transcriptomics/INIT/INIT.m
+++ b/src/dataIntegration/transcriptomics/INIT/INIT.m
@@ -21,6 +21,8 @@ function tissueModel = INIT(model, weights, tol, runtime, logfile, epsilon)
 %                         (default 1e-8)
 %    logfile:             name of the file to save the MILP log (string)
 %    runtime:             maximum solve time for the MILP (default value - 7200s)
+%    epsilon:             value added/subtracted to upper/lower bounds
+%                         (default 1)
 %
 % OUTPUTS:
 %    tissueModel:         extracted model

--- a/src/dataIntegration/transcriptomics/MBA/MBA.m
+++ b/src/dataIntegration/transcriptomics/MBA/MBA.m
@@ -47,7 +47,7 @@ end
         r = NC{ri};       
             
         PM = removeRxns(PM, r);
-        [fluxConsistentMetBool,fluxConsistentRxnBool] = findFluxConsistentSubset(PM,param);
+        [~,fluxConsistentRxnBool] = findFluxConsistentSubset(PM,param);
         inactive=PM.rxns(fluxConsistentRxnBool==0);
         eH = intersect(inactive, high_set);
         eM = intersect(inactive, medium_set);

--- a/src/dataIntegration/transcriptomics/createTissueSpecificModel.m
+++ b/src/dataIntegration/transcriptomics/createTissueSpecificModel.m
@@ -137,6 +137,7 @@ else
             if ~isfield(options,'core'),options.core ={};end
             if ~isfield(options,'logfile'),options.logfile ='MILPlog';end
             if ~isfield(options,'runtime'),options.runtime =7200;end
+            if ~isfield(options,'epsilon'),options.epsilon=1;end
         case 'GIMME'
             if ~isfield(options,'expressionRxns') || ~isfield(options,'threshold')
                 error('One of the 2 required option fields for GIMME method is not defined')                
@@ -149,6 +150,7 @@ else
             if ~isfield(options,'tol'),options.tol=1e-8;end
             if ~isfield(options,'logfile'),options.logfile ='MILPlog';end
             if ~isfield(options,'runtime'),options.runtime =7200;end
+            if ~isfield(options,'epsilon'),options.epsilon=1;end
         case 'MBA'
             if ~isfield(options,'medium_set') || ~isfield(options,'high_set')
                 error('One of the 2 required option fields for MBA method is not defined')                
@@ -180,11 +182,11 @@ end
 
 switch options.solver
     case 'iMAT'
-        tissueModel = iMAT(model, options.expressionRxns, options.threshold_lb, options.threshold_ub, options.tol, options.core, options.logfile, options.runtime);
+        tissueModel = iMAT(model, options.expressionRxns, options.threshold_lb, options.threshold_ub, options.tol, options.core, options.logfile, options.runtime, options.epsilon);
     case 'GIMME'
         tissueModel = GIMME(model, options.expressionRxns, options.threshold, options.obj_frac);
     case 'INIT'
-        tissueModel = INIT(model, options.weights, options.tol, options.runtime, options.logfile);
+        tissueModel = INIT(model, options.weights, options.tol, options.runtime, options.logfile, options.epsilon);
     case 'MBA'
         tissueModel = MBA(model, options.medium_set, options.high_set, options.tol);
     case 'mCADRE'

--- a/src/dataIntegration/transcriptomics/iMAT/iMAT.m
+++ b/src/dataIntegration/transcriptomics/iMAT/iMAT.m
@@ -1,4 +1,4 @@
-function tissueModel = iMAT(model, expressionRxns, threshold_lb, threshold_ub, tol, core, logfile, runtime)
+function tissueModel = iMAT(model, expressionRxns, threshold_lb, threshold_ub, tol, core, logfile, runtime, epsilon)
 % Uses the iMAT algorithm (`Zur et al., 2010`) to extract a context
 % specific model using data. iMAT algorithm find the optimal trade-off
 % between inluding high-expression reactions and removing low-expression reactions.
@@ -35,6 +35,9 @@ function tissueModel = iMAT(model, expressionRxns, threshold_lb, threshold_ub, t
 % .. Author: - Implementation adapted from the cobra toolbox
 % (createTissueSpecificModel.m) by S. Opdam and A. Richelle, May 2017
 
+if nargin < 9 || isempty(epsilon)
+    epsilon=1;
+end
 if nargin < 8 || isempty(runtime)
     %runtime = 7200;
     runtime = 60;
@@ -69,7 +72,6 @@ end
     S = model.S;
     lb = model.lb;
     ub = model.ub;
-    epsilon=1;
 
     % Creating A matrix
     A = sparse(size(S,1)+2*length(RHindex)+2*length(RLindex),size(S,2)+2*length(RHindex)+length(RLindex));

--- a/src/dataIntegration/transcriptomics/iMAT/iMAT.m
+++ b/src/dataIntegration/transcriptomics/iMAT/iMAT.m
@@ -26,6 +26,8 @@ function tissueModel = iMAT(model, expressionRxns, threshold_lb, threshold_ub, t
 %                       the high confidence set (default - no core reactions)
 %    logfile:           name of the file to save the MILP log (string)
 %    runtime:           maximum solve time for the MILP (default value - 7200s)
+%    epsilon:           value added/subtracted to upper/lower bounds
+%                       (default 1)
 %
 % OUTPUT:
 %    tissueModel:       extracted model

--- a/src/reconstruction/modelGeneration/fluxConsistency/findFluxConsistentSubset.m
+++ b/src/reconstruction/modelGeneration/fluxConsistency/findFluxConsistentSubset.m
@@ -81,95 +81,98 @@ end
 
 fluxConsistentRxnBoolTemp=false(size(model.S,2),1);
 
-switch method
-    case {'fastcc','null_fastcc'}
-        %fast consistency check code from Nikos Vlassis et al
-        % INPUT
-        % model         cobra model structure containing the fields
-        %   S           m x n stoichiometric matrix
-        %   lb          n x 1 flux lower bound
-        %   ub          n x 1 flux uppper bound
-        %   rxns        n x 1 cell array of reaction abbreviations
-        %
-        % epsilon
-        % printLevel    0 = silent, 1 = summary, 2 = debug
-        [indFluxConsist,~,V0]=fastcc(model,epsilon,printLevel,modeFlag,'original');
-        fluxConsistentRxnBoolTemp(indFluxConsist)=1;
-    case 'nonconvex'
-        [indFluxConsist,V0] = fastcc(model,epsilon,printLevel,modeFlag,'nonconvex');
-        fluxConsistentRxnBoolTemp(indFluxConsist)=1;
-    case 'dc'
-        % DC programming for solving the cardinality optimization problem
-        % The l0 norm is approximated by capped-l1 function.
-        % min       c'(x,y,z) + lambda*||x||_0 - delta*||y||_0
-        % s.t.      A*(x,y,z) <= b
-        %           l <= (x,y,z) <=u
-        %           x in R^p, y in R^q, z in R^r
-        %
-        % solution = optimizeCardinality(problem,params)
-        %
-        %  problem                  Structure containing the following fields describing the problem
-        %       p                   size of vector x
-        %       q                   size of vector y
-        %       r                   size of vector z
-        %       c                   (p+q+r) x 1 linear objective function vector
-        %       lambda              trade-off parameter of ||x||_0
-        %       delta               trade-off parameter of ||y||_0
-        %       A                   s x (p+q+r) LHS matrix
-        %       b                   s x 1 RHS vector
-        %       csense              s x 1 Constraint senses, a string containting the constraint sense for
-        %                           each row in A ('E', equality, 'G' greater than, 'L' less than).
-        %       lb                  (p+q+r) x 1 Lower bound vector
-        %       ub                  (p+q+r) x 1 Upper bound vector
-        %
-        % OPTIONAL INPUTS
-        % params                    parameters structure
-        %       nbMaxIteration      stopping criteria - number maximal of iteration (Defaut value = 1000)
-        %       epsilon             stopping criteria - (Defaut value = 10e-6)
-        %       theta               parameter of the approximation (Defaut value = 2)
-        %
-        % OUTPUT
-        % solution                  Structure containing the following fields
-        %       x                   p x 1 solution vector
-        %       y                   q x 1 solution vector
-        %       z                   r x 1 solution vector
-        %       stat                status
-        %                           1 =  Solution found
-        %                           2 =  Unbounded
-        %                           0 =  Infeasible
-        %                           -1=  Invalid input
-
-        %bound the fluxes finitely
-        if ~isfinite(min(model.lb))
-            model.lb(model.lb<-1/epsilon)=-1/epsilon;
-        end
-        if ~isfinite(min(model.ub))
-            model.ub(model.ub>1/epsilon)=1/epsilon;
-        end
-
-        cardPrb.p       = 0; %size of vector x
-        cardPrb.q       = size(model.S,2); %size of vector y
-        cardPrb.r       = 0; %size of vector z
-        cardPrb.c       = zeros(cardPrb.p+cardPrb.q+cardPrb.r,1);
-        cardPrb.lambda  = 0;
-        cardPrb.delta   = 1;
-        cardPrb.A       = model.S;
-        cardPrb.b       = model.b;
-        cardPrb.csense  = repmat('E',size(model.S,1), 1);
-        cardPrb.lb      = model.lb;
-        cardPrb.ub      = model.ub;
-
-        %Call the cardinality optimisation solver
-        solutionCard = optimizeCardinality(cardPrb);
-        if solutionCard.stat == 1
-            stat   = 1;
-            v = solutionCard.y;
-            fluxConsistentRxnBoolTemp=abs(v)>=epsilon;
-        else
-            fprintf('%s\n','Infeasibility while testing for flux consistency.');
-            stat   = 0;
-            v = [];
-        end
+sol = optimizeCbModel(model);
+if (sol.stat == 1)
+    switch method
+        case {'fastcc','null_fastcc'}
+            %fast consistency check code from Nikos Vlassis et al
+            % INPUT
+            % model         cobra model structure containing the fields
+            %   S           m x n stoichiometric matrix
+            %   lb          n x 1 flux lower bound
+            %   ub          n x 1 flux uppper bound
+            %   rxns        n x 1 cell array of reaction abbreviations
+            %
+            % epsilon
+            % printLevel    0 = silent, 1 = summary, 2 = debug
+            [indFluxConsist,~,V0]=fastcc(model,epsilon,printLevel,modeFlag,'original');
+            fluxConsistentRxnBoolTemp(indFluxConsist)=1;
+        case 'nonconvex'
+            [indFluxConsist,V0] = fastcc(model,epsilon,printLevel,modeFlag,'nonconvex');
+            fluxConsistentRxnBoolTemp(indFluxConsist)=1;
+        case 'dc'
+            % DC programming for solving the cardinality optimization problem
+            % The l0 norm is approximated by capped-l1 function.
+            % min       c'(x,y,z) + lambda*||x||_0 - delta*||y||_0
+            % s.t.      A*(x,y,z) <= b
+            %           l <= (x,y,z) <=u
+            %           x in R^p, y in R^q, z in R^r
+            %
+            % solution = optimizeCardinality(problem,params)
+            %
+            %  problem                  Structure containing the following fields describing the problem
+            %       p                   size of vector x
+            %       q                   size of vector y
+            %       r                   size of vector z
+            %       c                   (p+q+r) x 1 linear objective function vector
+            %       lambda              trade-off parameter of ||x||_0
+            %       delta               trade-off parameter of ||y||_0
+            %       A                   s x (p+q+r) LHS matrix
+            %       b                   s x 1 RHS vector
+            %       csense              s x 1 Constraint senses, a string containting the constraint sense for
+            %                           each row in A ('E', equality, 'G' greater than, 'L' less than).
+            %       lb                  (p+q+r) x 1 Lower bound vector
+            %       ub                  (p+q+r) x 1 Upper bound vector
+            %
+            % OPTIONAL INPUTS
+            % params                    parameters structure
+            %       nbMaxIteration      stopping criteria - number maximal of iteration (Defaut value = 1000)
+            %       epsilon             stopping criteria - (Defaut value = 10e-6)
+            %       theta               parameter of the approximation (Defaut value = 2)
+            %
+            % OUTPUT
+            % solution                  Structure containing the following fields
+            %       x                   p x 1 solution vector
+            %       y                   q x 1 solution vector
+            %       z                   r x 1 solution vector
+            %       stat                status
+            %                           1 =  Solution found
+            %                           2 =  Unbounded
+            %                           0 =  Infeasible
+            %                           -1=  Invalid input
+            
+            %bound the fluxes finitely
+            if ~isfinite(min(model.lb))
+                model.lb(model.lb<-1/epsilon)=-1/epsilon;
+            end
+            if ~isfinite(min(model.ub))
+                model.ub(model.ub>1/epsilon)=1/epsilon;
+            end
+            
+            cardPrb.p       = 0; %size of vector x
+            cardPrb.q       = size(model.S,2); %size of vector y
+            cardPrb.r       = 0; %size of vector z
+            cardPrb.c       = zeros(cardPrb.p+cardPrb.q+cardPrb.r,1);
+            cardPrb.lambda  = 0;
+            cardPrb.delta   = 1;
+            cardPrb.A       = model.S;
+            cardPrb.b       = model.b;
+            cardPrb.csense  = repmat('E',size(model.S,1), 1);
+            cardPrb.lb      = model.lb;
+            cardPrb.ub      = model.ub;
+            
+            %Call the cardinality optimisation solver
+            solutionCard = optimizeCardinality(cardPrb);
+            if solutionCard.stat == 1
+                stat   = 1;
+                v = solutionCard.y;
+                fluxConsistentRxnBoolTemp=abs(v)>=epsilon;
+            else
+                fprintf('%s\n','Infeasibility while testing for flux consistency.');
+                stat   = 0;
+                v = [];
+            end
+    end
 end
 
 %pad out to the original model if it had been reduced
@@ -180,6 +183,7 @@ if strcmp(param.method,'null_fastcc') && any(nullFluxInConsistentRxnBool)
 else
     fluxConsistentRxnBool=fluxConsistentRxnBoolTemp;
 end
+
 
 %metabolites exclusively involved in flux inconsistent reactions are deemed flux inconsistent also
 fluxConsistentMetBool = getCorrespondingRows(model.S,true(size(model.S,1),1),fluxConsistentRxnBool,'exclusive');


### PR DESCRIPTION
I've been trying to run the analysis described in the Opdam 2017 paper on additional models. I've been comparing the results from the published code to the standard toolbox.
GIMME and FASTCORE give different results since the Opdam 2017 uses older code, which has had bugs which were fixed.
mCADRE behaves too different to match up, probably due to different precursor metabolite definition
MBA works fine, but looking at the Opdam code I speeded up consistency Checking a bit. Since MBA removes random reactions, the entire model can become infeasible, and in that case, no need to run through the complete fastcc loops (of whatever variant).
INIT and iMAT work fine and give identical results except for the constrained model, which uses much smaller epsilon than the default (not sure why it needs that to work). I've added the option to give epsilon as a parameter to INIT and iMAT.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)