### PR TITLE
Fixing bug with removal of reaction prior consistency check

### DIFF
--- a/src/dataIntegration/transcriptomics/MBA/MBA.m
+++ b/src/dataIntegration/transcriptomics/MBA/MBA.m
@@ -46,9 +46,14 @@ end
         ri = randi([1,numel(NC)],1);
         r = NC{ri};       
             
-        PM = removeRxns(PM, r);
-        [~,fluxConsistentRxnBool] = findFluxConsistentSubset(PM,param);
-        inactive=PM.rxns(fluxConsistentRxnBool==0);
+        PM_temp = removeRxns(PM, r);
+        sol = optimizeCbModel(PM_temp);
+        if sol.stat ~= 1
+            inactive = PM_temp.rxns;
+        else
+            [~,fluxConsistentRxnBool] = findFluxConsistentSubset(PM_temp,param);
+            inactive=[PM_temp.rxns(fluxConsistentRxnBool==0);r];
+        end  
         eH = intersect(inactive, high_set);
         eM = intersect(inactive, medium_set);
         eX = setdiff(inactive,union(high_set,medium_set));


### PR DESCRIPTION
I just saw this mistake in the MBA code.

Modification of the MBA code to ensure that the random reaction selected is removed only if it the system is still solvable after removal and therefore ensure that the consistency check of the model is performed on a "solvable" model. Indeed, in the previous version the random reaction selected was removed in anyway while it could lead to inconsistent model.
