### PR TITLE
resolving some curl/libcurl conflicts on Linux

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -612,6 +612,9 @@ function [status_curl, result_curl] = checkCurlAndRemote(throwError)
     if ENV_VARS.printLevel
         fprintf(' > Checking if curl is installed ... ')
     end
+    
+    origLD = getenv('LD_LIBRARY_PATH');
+    setenv('LD_LIBRARY_PATH', '');
 
     % check if curl is properly installed
     [status_curl, result_curl] = system('curl --version');
@@ -659,4 +662,6 @@ function [status_curl, result_curl] = checkCurlAndRemote(throwError)
             end
         end
     end
+    
+    setenv('LD_LIBRARY_PATH', origLD);
 end


### PR DESCRIPTION
It seems that on some Linux systems (including the one my university cluster uses), there is a conflict between the system curl and libcurl, see https://www.mathworks.com/matlabcentral/answers/313138-annoying-warning-messages

The curl installed on the cluster is 7.53, but the library distributed with matlab is 7.37, which causes conflict.

I've resolved it by momentarily zeroing out LD_LIBRARY_PATH

**I hereby confirm that I have:**

- [X ] Tested my code on my own machine
- [ X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
