### PR TITLE
fix: Issue 1200, consistent use of osense

### DIFF
--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -587,7 +587,7 @@ switch solver
             %Ronan: I changed the signs of the dual variables to make it
             %consistent with the way solveCobraLP returns the dual
             %variables
-            [x,f,y,w,s] = deal(resultgurobi.x,resultgurobi.objval,resultgurobi.pi,osense*resultgurobi.rc,resultgurobi.slack);
+            [x,f,y,w,s] = deal(resultgurobi.x,resultgurobi.objval,resultgurobi.pi,resultgurobi.rc,resultgurobi.slack);
         elseif strcmp(resultgurobi.status,'INFEASIBLE')
             stat = 0; % Infeasible
         elseif strcmp(resultgurobi.status,'UNBOUNDED')

--- a/test/verifiedTests/base/testSolvers/testDuals.m
+++ b/test/verifiedTests/base/testSolvers/testDuals.m
@@ -49,7 +49,7 @@ for k = 1:length(solverPkgs)
         solLP = solveCobraLP(LPproblem);
 
         % test the sign of the ojective value
-        assert(norm(solQP.obj - solLP.obj) < tol)
+        assert(norm(solQP.obj + solLP.obj) < tol) %QP is always a minimisation, and thus will return the minimal value
 
         % test the sign of the duals
         assert(norm(solQP.dual - solLP.dual) < tol)

--- a/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
@@ -22,7 +22,7 @@ cd(fileDir);
 tol = 1e-4;
 
 % test solver packages
-requireOneSolverOf = {'tomlab_cplex','ibm_cplex', 'gurobi','qpng'};
+requireOneSolverOf = {'tomlab_cplex','ibm_cplex', 'gurobi','qpng','ibm_cplex','mosek'};
 solverPkgs = prepareTest('needsQP',true,'requireOneSolverOf', requireOneSolverOf);
 
 %QP Solver test: http://tomopt.com/docs/quickguide/quickguide005.php
@@ -38,8 +38,8 @@ QPproblem.x0 = [0, 1]';  % starting point
 QPproblem.osense = 1;
 QPproblem.csense = ['L'; 'E'];
 
-QPproblem2.F = [-1, 0, 0; 0, -1, 0; 0, 0, -1];  % Matrix F in 1/2 * x' * F * x + c' * x
-QPproblem2.osense = -1; % Maximize the objective (which is minimize the quadratic fluxes)
+QPproblem2.F = [1, 0, 0; 0, 1, 0; 0, 0, 1];  % Matrix F in 1/2 * x' * F * x + c' * x
+QPproblem2.osense = -1; % Maximize the linear part of the objective
 QPproblem2.c = [0, 0, 0]';  % Vector c in 1/2 * x' * F * x + c' * x
 QPproblem2.A = [1, -1, -1 ; 0, 0, 1];  % Constraint matrix
 QPproblem2.b = [0, 5]'; %Accumulate 5 B
@@ -47,6 +47,15 @@ QPproblem2.lb = [0, -inf, 0]';
 QPproblem2.ub = [inf, inf, inf]';
 QPproblem2.csense = ['E'; 'E'];
 
+
+QPproblem3.F = [1, 0, 0; 0, 1, 0; 0, 0, 1];  % Matrix F in 1/2 * x' * F * x + c' * x
+QPproblem3.osense = -1; % Maximize the linear part of the objective
+QPproblem3.c = [1, 1, 1]';  % Vector c in 1/2 * x' * F * x + c' * x
+QPproblem3.A = [1, -1, 0 ; 0, 1, -1];  % Constraint matrix
+QPproblem3.b = [0, 0]'; % Steady State
+QPproblem3.lb = [0, 0, 0]';
+QPproblem3.ub = [inf, inf, inf]';
+QPproblem3.csense = ['E'; 'E'];
 
 for k = 1:length(solverPkgs.QP)
 
@@ -70,9 +79,13 @@ for k = 1:length(solverPkgs.QP)
             assert(isempty(QPsolution.full) & isempty(QPsolution.obj) & QPsolution.origStat == 11)
         end
         QPsolution2 = solveCobraQP(QPproblem2);
-        assert(abs(QPsolution2.obj + 37.5 / 2) < tol); %Objective value
+        assert(abs(QPsolution2.obj - 37.5 / 2) < tol); %Objective value
         assert(all( abs(QPsolution2.full - [2.5;-2.5;5]) < tol)); % Flux distribution
         % output a success message
+        
+        %Test solving maximisation of linear part
+        QPsolution3 = solveCobraQP(QPproblem3);
+        assert(all(abs(QPsolution3.full - 1)< tol)); %We optimize for 0.5x^2 not x^2
         fprintf('Done.\n');
     end
 end

--- a/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
@@ -22,7 +22,7 @@ cd(fileDir);
 tol = 1e-4;
 
 % test solver packages
-requireOneSolverOf = {'tomlab_cplex','ibm_cplex', 'gurobi'};
+requireOneSolverOf = {'tomlab_cplex','ibm_cplex', 'gurobi','qpng'};
 solverPkgs = prepareTest('needsQP',true,'requireOneSolverOf', requireOneSolverOf);
 
 %QP Solver test: http://tomopt.com/docs/quickguide/quickguide005.php
@@ -37,6 +37,16 @@ QPproblem.ub = [inf, inf]';
 QPproblem.x0 = [0, 1]';  % starting point
 QPproblem.osense = 1;
 QPproblem.csense = ['L'; 'E'];
+
+QPproblem2.F = [-1, 0, 0; 0, -1, 0; 0, 0, -1];  % Matrix F in 1/2 * x' * F * x + c' * x
+QPproblem2.osense = -1; % Maximize the objective (which is minimize the quadratic fluxes)
+QPproblem2.c = [0, 0, 0]';  % Vector c in 1/2 * x' * F * x + c' * x
+QPproblem2.A = [1, -1, -1 ; 0, 0, 1];  % Constraint matrix
+QPproblem2.b = [0, 5]'; %Accumulate 5 B
+QPproblem2.lb = [0, -inf, 0]';
+QPproblem2.ub = [inf, inf, inf]';
+QPproblem2.csense = ['E'; 'E'];
+
 
 for k = 1:length(solverPkgs.QP)
 
@@ -59,7 +69,9 @@ for k = 1:length(solverPkgs.QP)
             % no solution because zero time is given and cplex status = 11
             assert(isempty(QPsolution.full) & isempty(QPsolution.obj) & QPsolution.origStat == 11)
         end
-
+        QPsolution2 = solveCobraQP(QPproblem2);
+        assert(abs(QPsolution2.obj + 37.5 / 2) < tol); %Objective value
+        assert(all( abs(QPsolution2.full - [2.5;-2.5;5]) < tol)); % Flux distribution
         % output a success message
         fprintf('Done.\n');
     end


### PR DESCRIPTION
This PR makes the use of osense in solveCobraQP consistent addressing issue #1200 .
As detailed in the documentation, this function now, over all solvers, solves the following problem:
`min 0.5 x' * F * x + osense * c' * x`

The `osense` field will only influence the linear part of the problem. 
MOSEK optimality tolerance was also set according to the documentation, which did not happen before.

I also extended the test to check this functionality.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
