### PR TITLE
Fixing issues on addMultipleReactions when the model is empty

### DIFF
--- a/src/reconstruction/refinement/addMultipleReactions.m
+++ b/src/reconstruction/refinement/addMultipleReactions.m
@@ -86,6 +86,8 @@ fieldDefs = getDefinedFieldProperties();
 fieldDefs = fieldDefs(cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,2)) | cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,3)));
 modelRxnFields = getModelFieldsForType(model,'rxns');
 
+model.rxns= [model.rxns;columnVector(rxnIDs)];
+
 for field = 1:2:numel(varargin)
     cfield = varargin{field};
     %Anything thats not a model field or not a specialised field is
@@ -102,7 +104,6 @@ for field = 1:2:numel(varargin)
     end
     model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];
 end
-model.rxns= [model.rxns;columnVector(rxnIDs)];
 newmodel = extendModelFieldsForType(model,'rxns','originalSize',nRxns);
 %Now, we have extended the S matrix. So lets fill it.
 newmodel.S(metPos,(nRxns+1):end) = Stoichiometries;

--- a/src/reconstruction/refinement/addMultipleReactions.m
+++ b/src/reconstruction/refinement/addMultipleReactions.m
@@ -85,7 +85,6 @@ nRxns = numel(model.rxns);
 fieldDefs = getDefinedFieldProperties();
 fieldDefs = fieldDefs(cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,2)) | cellfun(@(x) strcmp(x,'rxns'), fieldDefs(:,3)));
 modelRxnFields = getModelFieldsForType(model,'rxns');
-
 model.rxns= [model.rxns;columnVector(rxnIDs)];
 
 for field = 1:2:numel(varargin)
@@ -98,11 +97,10 @@ for field = 1:2:numel(varargin)
     end
     if ~isfield(model,cfield)
         model = createEmptyFields(model,cfield);
-    end    
-    if ~any(size(varargin{field+1}) == numel(rxnIDs)) %something must fit
-        error('Size of field %s does not fit to the rxnList size', varargin{field});
-    end
-    model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];
+        model.(cfield)((end-numel(varargin{field+1})+1):end) = columnVector(varargin{field+1});  
+    else
+        model.(cfield) = [model.(cfield);columnVector(varargin{field+1})];
+    end       
 end
 newmodel = extendModelFieldsForType(model,'rxns','originalSize',nRxns);
 %Now, we have extended the S matrix. So lets fill it.

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -132,7 +132,14 @@ assert(all(cellfun(@(x) isequal(x,''),modelWGenes.geneField2(~ismember(modelWGen
 %And finally test duplication errors.
 assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'b0008','G1'}}));
 assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'G2','G1','G2'}}));
-                               
+              
+%Test the functions on an empty model
+fprintf('Testing Addition to an empty model');
+model = createModel();
+modelBatch = addMultipleMetabolites(model,metNames,'metNames',metNames,'metCharges', [ -1 1 0],...
+    'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
+modelBatch2 = addMultipleReactions(modelBatch,rxnIDs,{'A','b','c'},[1 -1 0; 0,-2,-1;0,0,1],...
+                                   'lb',[-50,30,1],'ub',[0,60,15],'rxnKEGGID',{'R01','R02','R03'});                              
                                
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
When the model was empty, `addMultipleReactions` would fail if fields referencing rxns where added as optional arguments.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)
