### PR TITLE
Changing babel to obabel

### DIFF
--- a/src/analysis/thermo/componentContribution/getInchies.m
+++ b/src/analysis/thermo/componentContribution/getInchies.m
@@ -14,14 +14,14 @@ if ~exist(KEGG_ADDITIONS_TSV_FNAME, 'file')
 end
 
 if ismac
-    babel_cmd = '/usr/local/bin/babel';
+    babel_cmd = '/usr/local/bin/obabel';
 else
-    babel_cmd = 'babel';
+    babel_cmd = 'obabel';
 end
 
 [success, ~] = system(babel_cmd);
 if success ~= 0
-    error('Please make sure the command line program "babel" is installed and in the path');
+    error('Please make sure the command line program "obabel" is installed and in the path');
 end
 
 % Load relevant InChIs (for all compounds in the training data)
@@ -35,9 +35,9 @@ end
 if ~isempty(setdiff(target_cids, inchies.cids))
     % load the InChIs for all KEGG compounds in the 'kegg_additions.tsv' file.
     % this contains a few corrections needed in KEGG and added compounds (all starting with C80000)
-    
+
     fprintf('Obtaining MOL files for the training data from KEGG and converting to InChI using OpenBabel\n');
-    
+
     fid = fopen(KEGG_ADDITIONS_TSV_FNAME, 'r');
     fgetl(fid); % fields are: name, cid, inchi
     filecols = textscan(fid, '%s%d%s', 'delimiter','\t');
@@ -53,7 +53,7 @@ if ~isempty(setdiff(target_cids, inchies.cids))
 
     for i = 1:length(target_cids)
         cid = target_cids(i);
-        
+
         if ismember(cid, added_cids)
             inchi = added_inchis{find(added_cids == cid)};
             if ispc
@@ -67,14 +67,14 @@ if ~isempty(setdiff(target_cids, inchies.cids))
             if isempty(mol)
                 continue
             end
-            
+
             if ispc
                 cmd = ['echo ' mol ' | ' babel_cmd ' -imol -oinchi ---errorlevel 0'];
             else
                 cmd = ['echo "' mol '" | ' babel_cmd ' -imol -oinchi ---errorlevel 0'];
             end
         end
-        
+
         [success, std_inchi] = system([cmd ' -xT/noiso/nochg/nostereo']);
         if success == 0 && ~isempty(std_inchi) && strcmp('InChI=',std_inchi(1:6))
             std_inchi = strtok(std_inchi);

--- a/src/analysis/thermo/groupContribution/modelMetabolitesToSDF.m
+++ b/src/analysis/thermo/groupContribution/modelMetabolitesToSDF.m
@@ -88,12 +88,12 @@ else
     end
 end
 
-%check that babel is installed and working on the current unix machine
-[status, result] = system('babel -V');
+%check that obabel is installed and working on the current unix machine
+[status, result] = system('obabel -V');
 if status~=0 || ~isunix
     error('Babel must be installed and it is assumed this is a *nix machine');
 end
-%todo - add support for babel on windows
+%todo - add support for obabel on windows
 
 %preallocate cell array of already printed metabolites
 printedMetAbbr=cell(nMet,1);
@@ -107,7 +107,7 @@ printedMetAbbr=cell(nMet,1);
 fid2=fopen('water.inchi','w');
 fprintf(fid2,'%s\n','InChI=1/H2O/h1H2');
 fclose(fid2);
-[status, result] = system('babel --title  water -iinchi water.inchi -omol mater.mol');
+[status, result] = system('obabel --title  water -iinchi water.inchi -omol mater.mol');
 
 %exact mass for H
 HexactMass=1.0078250321;
@@ -117,7 +117,7 @@ sdfFilename=[model.description '.sdf'];
 fid=fopen(sdfFilename,'w');
 fclose(fid);
 
-%create a file with problematic InChI for babel
+%create a file with problematic InChI for obabel
 fidBabel=fopen('InChI_Babel_NoMol.txt','w');
 fclose(fidBabel);
 
@@ -184,7 +184,7 @@ for m=1:nMet
             fprintf(fid2,'%s\n',model.met(m).InChI);
             fclose(fid2);
             %better to use mol output since no $$$$ at the end
-            sysCall1=['babel --title ' metAbbr ' -iinchi tmp.inchi -omol ' metAbbr '.mol'];
+            sysCall1=['obabel --title ' metAbbr ' -iinchi tmp.inchi -omol ' metAbbr '.mol'];
             [status, result] = system(sysCall1);
 
             %check size of mol file, leave it out if zero bytes

--- a/src/analysis/thermo/inchi/sdf2inchi.m
+++ b/src/analysis/thermo/inchi/sdf2inchi.m
@@ -34,7 +34,7 @@ if ~isempty(options)
 end
 
 % Convert to InChI with OpenBabel
-[success,result] = system(['babel ' sdfFileName ' -oinchi' options]);
+[success,result] = system(['obabel ' sdfFileName ' -oinchi' options]);
 
 % Parse output from OpenBabel
 if success == 0
@@ -46,7 +46,7 @@ if success == 0
     inchi = strtrim(inchi);
     metList = strtrim(metList);
 else
-    [success,result] = system(['babel ' sdfFileName ' -oinchi' options])
+    [success,result] = system(['obabel ' sdfFileName ' -oinchi' options])
     fprintf('%s\n','If you get a ''not found'' message from the call to Babel, make sure that Matlab''s LD_LIBRARY_PATH is edited to include correct system libraries. See initVonBertylanffy')
     error('Conversion to InChI not successful. Make sure OpenBabel is installed correctly.\n')
 end

--- a/src/analysis/thermo/protons/assignpKasToSpecies.m
+++ b/src/analysis/thermo/protons/assignpKasToSpecies.m
@@ -185,7 +185,7 @@ for k = 1:nMets
             end
 
             % Get inchis for all species in abundantSpecies.sdf
-            [~, inchis] = system('babel abundantSpecies.sdf -oinchi -xFwT/nostereo');
+            [~, inchis] = system('obabel abundantSpecies.sdf -oinchi -xFwT/nostereo');
             inchis = regexp(inchis, '\n', 'split');
             inchiIdx = regexp(inchis,'InChI=');
             inchis = inchis(~cellfun('isempty',inchiIdx))';
@@ -228,7 +228,7 @@ for k = 1:nMets
             dataArray = [dataArray, num2cell(abundanceAtpH7)];
 
             % Get inchis for all species in abundantSpecies.sdf
-            %                 [~, uniqueInchis] = system('babel abundantSpecies.sdf -oinchi -xFwuT/nostereo');
+            %                 [~, uniqueInchis] = system('obabel abundantSpecies.sdf -oinchi -xFwuT/nostereo');
             %                 uniqueInchis = regexp(uniqueInchis, '\n', 'split');
             %                 uniqueInchis = uniqueInchis(strmatch('InChI=',uniqueInchis))';
             inchis = dataArray(:,1);

--- a/src/analysis/thermo/protons/inchi2mol.m
+++ b/src/analysis/thermo/protons/inchi2mol.m
@@ -70,7 +70,7 @@ for n = 1:nInchis
     if ~isempty(inchis{n})
         if isempty(strfind(existingMolFiles,['.mol' filenames{n} '.mol'])) || overwrite == 1 % If mol file of same name does not already exist or if it should be overwritten
             system(['echo ' inchis{n} ' > inchi.inchi']); % Temporary place holder for inchi. Overwritten in each loop.
-            system(['babel inchi.inchi ' filenames{n} '.mol']); % Convert InChI to mol file
+            system(['obabel inchi.inchi ' filenames{n} '.mol']); % Convert InChI to mol file
 
             f = dir([outputdir '\' filenames{n} '.mol']);
             if f.bytes > eps % If mol file is empty the conversion failed

--- a/src/analysis/thermo/vonBertalanffy/initVonBertalanffy.m
+++ b/src/analysis/thermo/vonBertalanffy/initVonBertalanffy.m
@@ -30,22 +30,22 @@ if status ~= 0
     end
 end
 
-%check if call to babel works
-[status,result] = system('ldd /usr/bin/babel');
+%check if call to obabel works
+[status,result] = system('ldd /usr/bin/obabel');
 if ~isempty(strfind(result,'MATLAB'))
     disp(result)
-    fprintf('%s\n','babel must depend on the system libstdc++.so.6 not the one from MATLAB')
+    fprintf('%s\n','obabel must depend on the system libstdc++.so.6 not the one from MATLAB')
     fprintf('%s\n','Trying to edit the ''LD_LIBRARY_PATH'' to make sure that it has the correct system path before the Matlab path!')
     setenv('LD_LIBRARY_PATH',['/usr/lib/x86_64-linux-gnu:' getenv('LD_LIBRARY_PATH')]);
     fprintf('%s\n','The solution will be arch dependent');
 end
 
-[status,result] = system('babel');
+[status,result] = system('obabel');
 if status ~= 0
     setenv('LD_LIBRARY_PATH',['/usr/lib/x86_64-linux-gnu:' getenv('LD_LIBRARY_PATH')]);
 end
 
-[status,result] = system('babel');
+[status,result] = system('obabel');
 if status ~= 0
     error('Check that OpenBabel is installed and on the system path.')
 end

--- a/src/reconstruction/modelGeneration/massBalance/basicPhysicochemicalData/getMolecularMass.m
+++ b/src/reconstruction/modelGeneration/massBalance/basicPhysicochemicalData/getMolecularMass.m
@@ -76,7 +76,7 @@ function [Masses, knownMasses, unknownElements, Ematrix, elements] = getMolecula
 %    If you want to double check that the mass given by this script is correct
 %    then compare it to either
 %
-%      1. OpenBabel: `echo "InChIstring" | babel -iinchi -  -oreport`  or
+%      1. OpenBabel: `echo "InChIstring" | obabel -iinchi -  -oreport`  or
 %      2. http://www.sisweb.com/referenc/tools/exactmass.htm
 %    Please report any errors as these are critical for use of this script
 %    with mass spec machines.


### PR DESCRIPTION
Changing `babel` to `obabel` as `babel` will be deprecated in the next version.

```
WARNING: babel is deprecated and will be removed in a future release
         of Open Babel. You should use obabel instead. For information
         on the differences please see:
             http://openbabel.org/docs/current/Command-line_tools/babel.html
```
- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)