### PR TITLE
Some speedup for generateRules

### DIFF
--- a/src/base/parseGPR.m
+++ b/src/base/parseGPR.m
@@ -40,6 +40,9 @@ if nargin < 3 %This is faster than checking exist)
     preparsed = false;
 end
 
+%Preparsing and providing IDs allows a lot of things to be ignored, so we
+%essentially have 2 distinct functions. One for preparsed and one for non
+%preparsed.
 if ~preparsed
     newGeneList = {};
     if isempty(grRuleString) || ~isempty(regexp(grRuleString,'^[\s\(\{\[\}\]\)]*$'))
@@ -49,13 +52,6 @@ if ~preparsed
         totalGeneList = currentGenes;
         return
     end
-else
-    %If its preparsed, there is no new gene list!
-    newGeneList = {};
-end
-
-% preparse all model.grRules
-if ~preparsed
     grRuleString = preparseGPR(grRuleString);
     %Now, genes are items which do not have brackets, operators or whitespace characters
     genes = regexp(grRuleString,'([^\(\)\|\&\s]+)','match');
@@ -76,6 +72,7 @@ if ~preparsed
     convertGenes = @(x) sprintf('x(%d)',  find(strcmp(x, totalGeneList)));
 
 else
+    newGeneList = {};
     totalGeneList = currentGenes;
     convertGenes = @(x) sprintf('x(%d)',  positions(strcmp(x, totalGeneList)));
 end

--- a/src/base/preparseGPR.m
+++ b/src/base/preparseGPR.m
@@ -22,6 +22,5 @@ function [preParsedGrRules,genes] = preparseGPR(grRules)
     preParsedGrRules = regexprep(preParsedGrRules, '([\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\(]|\s)\s*', '$1|$3'); %replace all ors
     preParsedGrRules = regexprep(preParsedGrRules, '[\s]?&[\s]?', ' & '); %introduce spaces around ands
     preParsedGrRules = regexprep(preParsedGrRules, '[\s]?\|[\s]?', ' | '); %introduce spaces around ors.    
-    genes = cellfun(@unique,regexp(preParsedGrRules,'([^\(\)\|\&\s]+)','match'),'Uniform',0); %Get all genes for each reaction.
-        
+    genes = cellfun(@unique,regexp(preParsedGrRules,'([^\(\)\|\&\s]+)','match'),'Uniform',0); %Get all genes for each reaction.       
 end

--- a/src/base/preparseGPR.m
+++ b/src/base/preparseGPR.m
@@ -1,4 +1,4 @@
-function preParsedGrRules = preparseGPR(grRules)
+function [preParsedGrRules,genes] = preparseGPR(grRules)
 % preparse model.grRules before parsing the remaining part
 % and transforming model.grRules into model.rules
 %
@@ -21,6 +21,7 @@ function preParsedGrRules = preparseGPR(grRules)
     preParsedGrRules = regexprep(preParsedGrRules, '([\)]\s?|\s)\s*(?i)(and)\s*?(\s?[\(]|\s)\s*', '$1&$3'); %Replace all ands
     preParsedGrRules = regexprep(preParsedGrRules, '([\)]\s?|\s)\s*(?i)(or)\s*?(\s?[\(]|\s)\s*', '$1|$3'); %replace all ors
     preParsedGrRules = regexprep(preParsedGrRules, '[\s]?&[\s]?', ' & '); %introduce spaces around ands
-    preParsedGrRules = regexprep(preParsedGrRules, '[\s]?\|[\s]?', ' | '); %introduce spaces around ors.
-
+    preParsedGrRules = regexprep(preParsedGrRules, '[\s]?\|[\s]?', ' | '); %introduce spaces around ors.    
+    genes = cellfun(@unique,regexp(preParsedGrRules,'([^\(\)\|\&\s]+)','match'),'Uniform',0); %Get all genes for each reaction.
+        
 end

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -29,13 +29,15 @@ function [model] = generateRules(model)
     nRules = length(model.grRules);
 
     % allocate the model.rules field
-    model.rules = cell(nRules, 1);
-    toc
+    model.rules = cell(nRules, 1);    
     % loop through all the grRules
     for i = 1:nRules
         if ~isempty(preParsedGrRules{i})
-            [genePres,genePos] = ismember(genes{i},model.genes);
-            rule = parseGPR(preParsedGrRules{i}, genes{i}, true, genePos(genePres));    
+            genePos = zeros(numel(genes{i}));
+            for j = 1:numel(genes{i})
+                genePos(j) = find(strcmp(model.genes,genes{i}{j}));
+            end            
+            rule = parseGPR(preParsedGrRules{i}, genes{i}, true, genePos);    
             model.rules{i, 1} = rule;
         else
             model.rules{i, 1} = '';

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -18,7 +18,7 @@ function [model] = generateRules(model)
 %            - Laurent Heirendt December 2017, speedup
 
     [preParsedGrRules,genes] = preparseGPR(model.grRules);  % preparse all model.grRules
-    allGenes =  unique([genes{:}]); %Get the unique gene list
+    allGenes =  unique([genes{~cellfun(@isempty,genes)}]); %Get the unique gene list
     newGenes = setdiff(allGenes,model.genes);
     if ~isempty(newGenes)
         warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
@@ -30,7 +30,7 @@ function [model] = generateRules(model)
 
     % allocate the model.rules field
     model.rules = cell(nRules, 1);
-
+    toc
     % loop through all the grRules
     for i = 1:nRules
         if ~isempty(preParsedGrRules{i})

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -17,8 +17,14 @@ function [model] = generateRules(model)
 %            - Diana El Assal 30/8/2017
 %            - Laurent Heirendt December 2017, speedup
 
-    preParsedGrRules = preparseGPR(model.grRules);  % preparse all model.grRules
-
+    [preParsedGrRules,genes] = preparseGPR(model.grRules);  % preparse all model.grRules
+    allGenes =  unique([genes{:}]); %Get the unique gene list
+    newGenes = setdiff(allGenes,model.genes);
+    if ~isempty(newGenes)
+        warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
+        model.genes = addGenes(model,newGenes);
+    end        
+    
     % determine the number of rules
     nRules = length(model.grRules);
 
@@ -28,11 +34,8 @@ function [model] = generateRules(model)
     % loop through all the grRules
     for i = 1:nRules
         if ~isempty(preParsedGrRules{i})
-            [rule,~,newGenes] = parseGPR(preParsedGrRules{i}, model.genes,true);
-            if ~isempty(newGenes)
-                warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
-                model.genes = [model.genes ; newGenes];
-            end
+            [genePres,genePos] = ismember(genes{i},model.genes);
+            rule = parseGPR(preParsedGrRules{i}, genes{i}, true, genePos(genePres));    
             model.rules{i, 1} = rule;
         else
             model.rules{i, 1} = '';

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -23,6 +23,7 @@ for i=1:length(modelsToTry)
     
     model2 = generateRules(model);
     model.rules = strrep(model.rules, '  ', ' ');
+    
     fp = FormulaParser();
     % fix for Recon2
     if strcmp(modelsToTry{i}, 'Recon2.v04.mat')
@@ -32,12 +33,21 @@ for i=1:length(modelsToTry)
         model.rules(2940) = {'(x(4)) | (x(60)) | (x(2)) | (x(61)) | (x(3))'}; % '(314.1) or (4128.1) or (26.1) or (4129.1) or (314.2)'
         model.rules(3133) = {'(x(2)) | (x(4)) | (x(1)) | (x(3))'}; % '(26.1) or (314.1) or (314.2)'
     end
-    for rule = 1:numel(model.rules)
+    %also, introduce spaces around the individual genes:    
+    model.rules = regexprep(model.rules,'([^\s])(x\([0-9]+\))','$1 $2');
+    model.rules = regexprep(model.rules,'(x\([0-9]+\))([^\s])','$1 $2');
+    for rule = 1:numel(model.rules)        
         if isempty(model.rules{rule})
             %assert that both formulas are empty (and thus equal).
             assert(isequal(model.rules{rule},model2.rules{rule}))
             continue;
+        elseif strcmp(model.rules{rule},model2.rules{rule})
+            %If the strings are identical than we don't need to check
+            %equivalence.
+            assert(isequal(model.rules{rule},model2.rules{rule}))
+            continue
         end
+        
         head1 = fp.parseFormula(model.rules{rule});
         head2 = fp.parseFormula(model2.rules{rule});
         %Assert that the formulas are equal.


### PR DESCRIPTION
This PR speeds up generateRules a little bit by extending the precomputation to include the actual genes. This allows a faster strmatch (fewer checks necessary for rules which contain the same gene multiple times).
The big advantage is the speedUp of the testing function. By small (non altering) modifications on the rules string of the original models, it is possible to allow the stringwise comparison of the rules field instead of requiring a full evaluation. 
If the stings do match, no evaluation is necessary,

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
