### PR TITLE
Fix calculation of failed tests in testAll

### DIFF
--- a/docs/source/installation/compatMatrix.md
+++ b/docs/source/installation/compatMatrix.md
@@ -8,6 +8,7 @@
 | IBM CPLEX 12.7.1  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | IBM CPLEX 12.7    | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | IBM CPLEX 12.6.3  | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| GUROBI 8.0.0      | :warning:          | :warning:          | :white_check_mark: | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.2      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | GUROBI 7.5.1      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | GUROBI 7.0.2      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -26,6 +27,7 @@
 | IBM CPLEX 12.7.1  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | IBM CPLEX 12.7    | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | IBM CPLEX 12.6.3  | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| GUROBI 8.0.0      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.2      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | GUROBI 7.5.1      | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | GUROBI 7.0.2      | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -36,6 +38,25 @@
 | DQQ MINOS         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | PDCO              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
+## macOS 10.13
+
+| SolverName        | R2017b             | R2017a             | R2016b             | R2016a             | R2015b             | R2015a             | R2014b             | R2014a             |
+|-------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| IBM CPLEX 12.8    | :warning:          | :warning:          | :white_check_mark: | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| IBM CPLEX 12.7.1  | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| IBM CPLEX 12.7    | :warning:          | :warning:          | :x:                | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| IBM CPLEX 12.6.3  | :warning:          | :warning:          | :x:                | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 8.0.0      | :warning:          | :warning:          | :white_check_mark: | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 7.5.2      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 7.5.1      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 7.0.2      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 6.5.0      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| TOMLAB CPLEX 8.3  | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| MOSEK 8           | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GLPK              | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| DQQ MINOS         | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| PDCO              | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+
 ## Windows 7
 
 | SolverName        | R2017b             | R2017a             | R2016b             | R2016a             | R2015b             | R2015a             | R2014b             | R2014a             |
@@ -44,6 +65,7 @@
 | IBM CPLEX 12.7.1  | :white_check_mark: | :warning:          | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | IBM CPLEX 12.7    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | IBM CPLEX 12.6.3  | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| GUROBI 8.0.0      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.2      | :white_check_mark: | :warning:          | :white_check_mark: | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.1      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | GUROBI 7.0.2      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -62,6 +84,7 @@
 | IBM CPLEX 12.7.1  | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | IBM CPLEX 12.7    | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | IBM CPLEX 12.6.3  | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
+| GUROBI 8.0.0      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.2      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.5.1      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |
 | GUROBI 7.0.2      | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          | :warning:          |

--- a/src/base/solvers/isCompatible.m
+++ b/src/base/solvers/isCompatible.m
@@ -112,16 +112,18 @@ function compatibleStatus = isCompatible(solverName, printLevel, specificSolverV
             end
         end
     elseif ismac % macOS
-        tableNb = 2;
+        macpos = find(strncmp(testedOS,'macOS',5));
+        macOSFound = false;
         [~, resultVERS] = unix('sw_vers');
-        tmp = strsplit(testedOS{tableNb});
-        if ~isempty(strfind(resultVERS, tmp{2}))
-            cMatrix = compatMatrix{tableNb};
-        else
-            untestedFlag = true;
-            if printLevel > 0
-                fprintf([' > The compatibility can only be evaluated on macOS ', tmp{2}, '.\n']);
+        for tableNb = macpos %             
+            tmp = strsplit(testedOS{tableNb});
+            if ~isempty(strfind(resultVERS, tmp{2}))
+                cMatrix = compatMatrix{tableNb};
+                macOSFound = true;
             end
+        end        
+        if ~macOSFound && printLevel > 0
+            fprintf([' > The compatibility can only be evaluated on the following mac OS versions: ', strjoin(testedOS(macpos),', '), '.\n']);
         end
     else % Windows
         resultVERS = system_dependent('getos');

--- a/test/testAll.m
+++ b/test/testAll.m
@@ -171,7 +171,7 @@ try
         [result, resultTable] = runTestSuite();
 
         sumSkipped = sum(resultTable.Skipped);
-        sumFailed = sum(resultTable.Failed) - sumSkipped;
+        sumFailed = sum(resultTable.Failed);
 
         fprintf(['\n > ', num2str(sumFailed), ' tests failed. ', num2str(sumSkipped), ' tests were skipped due to missing requirements.\n\n']);
 

--- a/test/verifiedTests/base/testSolvers/testIsCompatible.m
+++ b/test/verifiedTests/base/testSolvers/testIsCompatible.m
@@ -19,11 +19,11 @@ cd(fileDir);
 matlabVersion = ['R' version('-release')];
 
 if isunix && strcmp(matlabVersion, 'R2016b')
-    % GUROBI 6.5.0 is compatible on UNIX when running R2016b
-    compatibleStatus = isCompatible('gurobi', 1, '6.5.0');
+    % GUROBI 8.0.0 is compatible on UNIX when running R2016b    
+    compatibleStatus = isCompatible('gurobi', 1, '8.0.0');
     assert(compatibleStatus == 1);
 
-    % IBM CPLEX 12.7.0 is not compatible on UNIX when running R2016b
+    % IBM CPLEX 12.6.3 is not compatible on UNIX when running R2016b
     compatibleStatus = isCompatible('ibm_cplex', 0, '12.6.3');
     assert(compatibleStatus == 0);
 


### PR DESCRIPTION
This pr fies the calculation of the number of failed tests in testAll.
It also adapts the compatMatrix to include macOS 10.13 and adds some (few) tested solvers to the table for it.
Further gurobi 8.0.0 is added to the compatability Matrix (only tested with 2016b/mac+linux yet.) 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
