### PR TITLE
Reaction addition improvements

### DIFF
--- a/src/reconstruction/refinement/addDemandReaction.m
+++ b/src/reconstruction/refinement/addDemandReaction.m
@@ -11,7 +11,7 @@ function [model,rxnNames] = addDemandReaction(model,metaboliteNameList, printLev
 %    metaboliteNameList:    List of metabolite names (cell array)
 %
 % OPTIONAL INPUT:
-%    printLevel:            If > 0 will print out the reaction formula.
+%    printLevel:            If > 0 will print out the reaction formulas (Default: 1).
 %
 % OUTPUTS:
 %    model:                 COBRA model structure with added demand reactions
@@ -20,7 +20,7 @@ function [model,rxnNames] = addDemandReaction(model,metaboliteNameList, printLev
 % .. Authors:
 %       - Markus Herrgard 5/8/07
 %       - Ines Thiele 03/09 - Corrected reaction coefficient for demand reaction
-%       - SpeedUp
+%       - Thomas Pfau, June 2018 - Change to use addMultipleReactions and adding printLevel 
 
 if (~iscell(metaboliteNameList))
     metaboliteNameList = {metaboliteNameList};

--- a/src/reconstruction/refinement/addDemandReaction.m
+++ b/src/reconstruction/refinement/addDemandReaction.m
@@ -1,4 +1,4 @@
-function [model,rxnNames] = addDemandReaction(model,metaboliteNameList)
+function [model,rxnNames] = addDemandReaction(model,metaboliteNameList, printLevel)
 % Adds demand reactions for a set of metabolites
 % The reaction names for the demand reactions will be `DM_[metaboliteName]``
 %
@@ -10,6 +10,9 @@ function [model,rxnNames] = addDemandReaction(model,metaboliteNameList)
 %    model:                 COBRA model structure
 %    metaboliteNameList:    List of metabolite names (cell array)
 %
+% OPTIONAL INPUT:
+%    printLevel:            If > 0 will print out the reaction formula.
+%
 % OUTPUTS:
 %    model:                 COBRA model structure with added demand reactions
 %    rxnNames:              List of added reactions
@@ -17,16 +20,29 @@ function [model,rxnNames] = addDemandReaction(model,metaboliteNameList)
 % .. Authors:
 %       - Markus Herrgard 5/8/07
 %       - Ines Thiele 03/09 - Corrected reaction coefficient for demand reaction
+%       - SpeedUp
 
 if (~iscell(metaboliteNameList))
-    tmp = metaboliteNameList;
-    clear metaboliteNameList;
-    metaboliteNameList{1} = tmp;
+    metaboliteNameList = {metaboliteNameList};
 end
 
-for i = 1:length(metaboliteNameList)
-    rxnName = ['DM_' metaboliteNameList{i}];
-    rxnNames{i}=rxnName;
-    metaboliteList = {metaboliteNameList{i}};
-    model = addReaction(model,rxnName,metaboliteList,-1,false,0,1000,0,'Demand');
+if nargin < 3 %No PrintLevel
+    printLevel = 1;
+end
+
+missingMets = setdiff(metaboliteNameList,model.mets);
+if ~isempty(missingMets)
+    warning('The following Metabolites have been added to the model, as they were not in the model before:\n%s', strjoin(missingMets,'\n'));
+    model = addMultipleMetabolites(model,missingMets);
+end
+
+rxnNames = strcat('DM_',metaboliteNameList);    
+nMets = length(metaboliteNameList);
+stoich = -1 * speye(nMets);
+subSystems = repmat({'Demand'},nMets,1);
+ubs = repmat(1000,nMets,1);
+lbs = zeros(nMets,1);
+model = addMultipleReactions(model,rxnNames,metaboliteNameList,stoich,...
+                             'lb',lbs,'ub',ubs,'subSystems',subSystems,...
+                             'printLevel',printLevel);        
 end

--- a/src/reconstruction/refinement/addExchangeRxn.m
+++ b/src/reconstruction/refinement/addExchangeRxn.m
@@ -18,12 +18,27 @@ function [newModel, AddedExchRxn] = addExchangeRxn(model, metList, lb, ub)
 %
 % .. Author: - Ines Thiele 02/2009
 
+if ~iscell(metList) 
+    if ischar(metList)
+        metList = {metList};
+    else
+        error('metList must either be a cell array of metabolite names or the name of a metabolite as a char');
+    end
+end
 if nargin < 3
     lb = ones(length(metList),1)*min(model.lb);
 end
 if nargin < 4
     ub = ones(length(metList),1)*max(model.ub);
 end
+
+missingMets = setdiff(metList,model.mets);
+if ~isempty(missingMets)
+    warning('The following Metabolites have been added to the model, as they were not in the model before:\n%s', strjoin(missingMets,'\n'));
+    model = addMultipleMetabolites(model,missingMets);
+end
+
+
 Revs = zeros(length(metList),1);
 Revs(lb<0) = 1;
 
@@ -48,6 +63,7 @@ if ~isempty(duplicate)
         warning(['Model already has the same reaction you tried to add: ', newModel.rxns{duplicate(j)}]);
     end
 end
+
 
 %Set the Exchanger Names that are added
 AddedExchRxn = strcat('EX_',metList);

--- a/src/reconstruction/refinement/addExchangeRxn.m
+++ b/src/reconstruction/refinement/addExchangeRxn.m
@@ -17,6 +17,7 @@ function [newModel, AddedExchRxn] = addExchangeRxn(model, metList, lb, ub)
 %    newModel:    COBRA model with added exchange reactions
 %
 % .. Author: - Ines Thiele 02/2009
+%            - Thomas Pfau, June 2018 - Change to use addMultipleReactions  
 
 if ~iscell(metList) 
     if ischar(metList)

--- a/src/reconstruction/refinement/addMultipleReactions.m
+++ b/src/reconstruction/refinement/addMultipleReactions.m
@@ -100,7 +100,10 @@ for field = 1:2:numel(varargin)
         printLevel = varargin{field+1};
         continue;
     end
-    if any(ismember({'S','rxnGeneMat','rules','genes'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelRxnFields,cfield)))        
+    if any(ismember({'rules','genes'},cfield))
+        continue; %Don't throw a warning here.
+    end
+    if any(ismember({'S','rxnGeneMat'},cfield)) || (~any(ismember(fieldDefs(:,1),cfield)) && ~any(ismember(modelRxnFields,cfield)))        
         warning('Field %s is excluded.',cfield);
         continue;
     end
@@ -148,12 +151,12 @@ if any(ismember(varargin(1:2:end),'rules'))
         %Find all genes (and their positions) which are already in the model.
         [genePres,genePos] = ismember(genes,newmodel.genes);
         additionalGenes = sum(~genePres);
-        newmodel = addGenes(model,genes(~genePres));
+        newmodel = addGenes(newmodel,genes(~genePres));
         genePos(~genePres) = nGenes+(1:additionalGenes);
         %now, replace the ids.
         genePos = cellfun(@(x) strcat('x(', num2str(x),')'), num2cell(genePos),'Uniformoutput',false);
         rules = regexprep(rules,'x\(([0-9]+)\)','${genePos{str2num($1)}}');
-        newmodel.rules(nRxns+1:length(model.rxns)) = rules;
+        newmodel.rules(nRxns+1:length(newmodel.rxns)) = rules;
     else
         rulesPos = 2 * find(ismember(varargin(1:2:end),'rules'));
         if ~isfield(newmodel,'rules') %If rules does not exist, create it.

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -80,9 +80,11 @@ assert(head1.isequal(head2));
 %Also check logical format addition:              
 modelBatch3 = addMultipleReactions(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
                                    'rules',{'x(3) | x(2)', 'x(4) & x(1)',''}, 'genes', {'G4';'b0727';'G1';'b0008'});
+
 %The same addition as above but a different
 %format, so test the same things.
 assert(numel(modelBatch3.genes) == numel(model.genes)+2); %Only two genes were added, the others already existed.
+assert(verifyModel(modelBatch3,'simpleCheck',true))
 %Since the model has a rules field, we will test the equality of the rules.
 fp = FormulaParser();
 %Assert all correct genes are there.
@@ -95,6 +97,26 @@ Formula = ['x(' num2str(G1pos) ,') | x(' num2str(b0727pos) ')'];
 head1 = fp.parseFormula(Formula);
 head2 = fp.parseFormula(modelBatch3.rules{ExAPos});
 assert(head1.isequal(head2));
+
+%Now also check the printLevel argument at different positions.
+diary('reacAdd1.txt');
+modelBatch4 = addMultipleReactions(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],'printLevel',1,...
+                                   'rules',{'x(3) | x(2)', 'x(4) & x(1)',''}, 'genes', {'G4';'b0727';'G1';'b0008'});
+diary off
+diary('comparison.txt')
+printRxnFormula(modelBatch4,{'ExA','ATob','BToC'});
+diary off
+assert(all(fileread('reacAdd1.txt')==fileread('comparison.txt')));
+diary('reacAdd2.txt');
+modelBatch4 = addMultipleReactions(modelBatch,{'ExA','ATob','BToC'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1],...
+                                   'rules',{'x(3) | x(2)', 'x(4) & x(1)',''},'printLevel',1, 'genes', {'G4';'b0727';'G1';'b0008'});
+diary off
+assert(all(fileread('reacAdd2.txt')==fileread('comparison.txt')));
+%clean diaries
+delete('reacAdd1.txt');
+delete('reacAdd2.txt');
+delete('comparison.txt');
+
 
 %Now, test duplicate ID fails (duplicate in the reaction list
 assert(verifyCobraFunctionError('addMultipleReactions', 'inputs',{model,{'ExA','ATob','ExA'},{'A','b','c'},[1 -1 0; 0,1,-1;0,0,1]}));
@@ -134,12 +156,12 @@ assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'b0008','G1'}}));
 assert(verifyCobraFunctionError('addGenes', 'inputs',{model,{'G2','G1','G2'}}));
               
 %Test the functions on an empty model
-fprintf('Testing Addition to an empty model');
+fprintf('>> Testing Addition to an empty model\n');
 model = createModel();
 modelBatch = addMultipleMetabolites(model,metNames,'metNames',metNames,'metCharges', [ -1 1 0],...
     'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
 modelBatch2 = addMultipleReactions(modelBatch,rxnIDs,{'A','b','c'},[1 -1 0; 0,-2,-1;0,0,1],...
                                    'lb',[-50,30,1],'ub',[0,60,15],'rxnKEGGID',{'R01','R02','R03'});                              
-                               
+
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
- This PR addresses a bug in `addMultipleReactions` where trying to set GPR rules resulted in an invalid model. 
- It also introduces a `printLevel` parameter to the `addMultipleReactions` functions that allows this function to also print all reactions added, if requested. Also added testing code for it.
- Further updated the `addDemandRxn` function to use `addMultipleReactions` speeding up the function.
- Finally, `addExchangeRxn` is corrected to allow the addition of exchangers for non existing metabolites (adding the metabolite), which was impossible after the change to addMultipleReactions.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
