### PR TITLE
fixing SBOTerm property definition

### DIFF
--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -36,7 +36,7 @@ rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell
 rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is;isVersionOf	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.	'false(1)'	cell
 rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.	'false(1)'	cell
 rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'	cell
-rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	rxns	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'	cell
+rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	hasProperty	rxns	''	^SBO:\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'	cell
 subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(strjoin([y(:)],';')) , x))				{''}		Column Cell Array of Cell Arrays of Strings	subSystem assignment for each reaction	'false(1)'	cell
 description	NaN	NaN	ischar(x) || isstruct(x)				struct()		String or Struct	Name of a file the model is loaded from.	'false(1)'	char
 modelVersion	NaN	NaN	isstruct(x)				struct()		Struct	Information on the model version	'false(1)'	struct

--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -26,7 +26,7 @@ metKEGGID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.compound;keg
 metChEBIID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	chebi;obo.chebi	is	mets	''	^CHEBI:\d+$	Column Cell Array of Strings	ChEBI ID of the metabolite.	'false(1)'	cell
 metPubChemID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubchem.compound	is	mets	''	^\d+$	Column Cell Array of Strings	PubChem ID of each metabolite	'false(1)'	cell
 metMetaNetXID	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.chemical	is	mets	''	^MNXM\d+$	Column Cell Array of Strings	MetaNetX identifier of the metabolite	'false(1)'	cell
-metSBOTerms	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	is	mets	''	^SBO\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the metabolite	'false(1)'	cell
+metSBOTerms	mets	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	hasProperty	mets	''	^SBO:\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the metabolite	'false(1)'	cell
 geneEntrezID	genes	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ncbigene	is;isEncodedBy	genes	''	^\d+$	Column Cell Array of Strings	Entrez IDs of genes	'false(1)'	cell
 grRules	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))				''		Column Cell Array of Strings	A string representation of the GPR rules defined in a readable format.	'false(1)'	cell
 rxnGeneMat	rxns	genes	issparse(x) || isnumeric(x) || islogical(x)				0		Sparse or Full Matrix of Double or Boolean	Matrix with rows corresponding to reactions and columns corresponding to genes.	'false(1)'	sparselogical


### PR DESCRIPTION
This PR fixes the issue reported here:
 #1247

The SBO Term regexp missed a `:` and it had the wrong bioql relation. An SBO identifier is a property of an element (i.e. `hasProperty`) not a `is` relation. 
This information will be duplicated in the output SBML file, as different tools might ignore either the annotation or the SBOterm attribute. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
