### PR TITLE
Adding an option to check for coupled metabolites

### DIFF
--- a/src/analysis/exploration/biomassPrecursorCheck.m
+++ b/src/analysis/exploration/biomassPrecursorCheck.m
@@ -1,10 +1,15 @@
-function [missingMets, presentMets] = biomassPrecursorCheck(model)
+function [missingMets, presentMets,coupledMets] = biomassPrecursorCheck(model,checkCoupling)
 % Checks if biomass precursors are able to be synthesized.
 %
 % [missingMets, presentMets] = biomassPrecursorCheck(model)
 %
 % INPUT:
-%    model:          COBRA model structure
+%    model:             COBRA model structure
+%
+% OPTIONAL INPUT:
+%    checkCoupling:     Test, whether some compounds can only be produced
+%                       if there is a sink for other biomass precursors
+%                       (Default: false)
 %
 % OUTPUTS:
 %    missingMets:    List of biomass precursors that are not able to be synthesized
@@ -13,6 +18,13 @@ function [missingMets, presentMets] = biomassPrecursorCheck(model)
 % .. Authors: - Pep Charusanti & Richard Que (July 2010)
 % May identify metabolites that are typically recycled within the
 % network such as ATP, NAD, NADPH, ACCOA.
+if nargin < 2
+    checkCoupling = 0;
+end
+
+if ~checkCoupling && nargout == 3
+    error('coupledMets are not being calculated if checkCoupling is not set to true!');
+end
 
 colS_biomass = model.c ~= 0;
 % FIND COLUMN IN S-MATRIX THAT CORRESPONDS TO BIOMASS EQUATION
@@ -24,20 +36,44 @@ biomassMetabs = model.mets(any(model.S(:, colS_biomass) < 0, 2));
 % AND OPTIMIZE.  NOTE: A CRITICAL ASSUMPTION IS THAT THE ADDED DEMAND
 % REACTION IS APPENDED TO THE FAR RIGHT OF THE S-MATRIX.  THE CODE NEEDS TO
 % BE REVISED IF THIS IS NOT THE CASE.
-k = 1;
 m = 1;
+p = 1;
+c = 1;
 % ADD DEMAND REACTIONS
 [model_newDemand, addedRxns] = addDemandReaction(model, biomassMetabs);
+
+if checkCoupling
+    %Close the precursors
+    model_newDemand = changeRxnBounds(model_newDemand,addedRxns,zeros(numel(addedRxns,1)),repmat('b',numel(addedRxns,1)));
+    coupledMets = {};
+end
+
 [missingMets, presentMets] = deal({});
 for i = 1:length(biomassMetabs)
+    if checkCoupling
+        model_newDemand = changeRxnBounds(model_newDemand, addedRxns{i}, 1000, 'u');
+    end
     model_newDemand = changeObjective(model_newDemand, addedRxns{i});
     solution = optimizeCbModel(model_newDemand);                                % OPTIMIZE
     if solution.f == 0                                                          % MAKE LIST OF WHICH BIOMASS PRECURSORS ARE ...
-        missingMets(k) = biomassMetabs(i);                                      %  SYNTHESIZED AND WHICH ARE NOT
-        k = k + 1;
+        if checkCoupling
+            model_newDemand = changeRxnBounds(model_newDemand, addedRxns, 1000, 'u');
+            solution = optimizeCbModel(model_newDemand);
+            if solution.f > 0
+                coupledMets(c) = biomassMetabs(i);                              % NEED ANOTHER SINK
+                c = c + 1;
+            else
+                missingMets(m) = biomassMetabs(i);                              %  SYNTHESIZED AND WHICH ARE NOT
+                m = m + 1;
+            end
+            model_newDemand = changeRxnBounds(model_newDemand, addedRxns, 0, 'u');
+        else
+            missingMets(m) = biomassMetabs(i);                                  %  SYNTHESIZED AND WHICH ARE NOT
+            m = m + 1;
+        end
     else
-        presentMets(m) = biomassMetabs(i);
-        m = m + 1;
+        presentMets(p) = biomassMetabs(i);
+        p = p + 1;
     end
 end
 

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/createToyModelForBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/createToyModelForBiomassPrecursorCheck.m
@@ -1,0 +1,32 @@
+function model = createToyModelForBiomassPrecursorCheck()
+% createToyModelForBiomassPrecursorCheck creates a toy model for
+% the biomassPrecursorCheck (which allows testing for coupling.
+% The model created looks as follows:
+%
+%                           1
+%   <-> A -> B ---> C --> E ----->
+%        \     /       \     / 0.5
+%         -> D          -> F
+%                       
+%           
+% Without checking coupling, The model would declare both F and E as
+% producible during the check, while still being unable to produce biomass.
+% With the check, it wont be able to do so.
+
+model = createModel();
+%Reactions in {Rxn Name, MetaboliteNames, Stoichiometric coefficient} format
+reacIDs = {'Ex_A','R1','R2','R3','R4','Biomass'};
+mets = {'A','B','C','D','E','F'};
+stoich = [ 1 -1  0  0 -1  0;...
+           0  1 -1  0  0  0;...
+           0  0  1 -1  0  0;...
+           0  0 -1  0  1  0;...
+           0  0  0  1  0 -1;...
+           0  0  0  1  0 -0.5];
+lbs = zeros(6,1);       
+
+
+%Add Exchangers
+model = addMultipleMetabolites(model,mets);
+model = addMultipleReactions(model,reacIDs,mets,stoich,'lb',lbs);
+model = changeObjective(model,'Biomass',1);

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
@@ -37,5 +37,22 @@ model = changeObjective(model,'testBiomass');
 assert(isempty(setxor(missingMets,{'NotExist'}))); % NotExist, and only NotExist is not producible.
 assert(isempty(setxor(presentMets,{'amet_c'}))); % amet_c and only amet_c is producible
 
+%Test coupling
+model = createToyModelForBiomassPrecursorCheck();
+%This model cannot carry flux through the objective, but each precursor can
+%be produced if exchangers exist for all precursors.
+[missingMets, presentMets] = biomassPrecursorCheck(model);
+assert(isempty(setxor(presentMets,{'E','F'})));
+
+%Check for coupled Mets
+[missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model,true);
+
+assert(isempty(missingMets))
+assert(isempty(setxor(presentMets,{'F'}))); %F can be produced, as surplus E can be removed by the biomass function.
+assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
+
+%Test error
+assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage','coupledMets are not being calculated if checkCoupling is not set to true!'));
+
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
Adding an option to `biomassPrecursorCheck` to check for coupled metabolites as suggested in #1238 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
