### PR TITLE
Fixing bug with caps mismatch with printLevel

### DIFF
--- a/src/base/solvers/liftModel.m
+++ b/src/base/solvers/liftModel.m
@@ -18,7 +18,7 @@ function LPproblem = liftModel(model, BIG, printLevel,fileName,directory)
 %    BIG:           A parameter the controls the largest entries that appear in the
 %                   reformulated problem (default = 1000).
 %    printLevel:    printLevel = 1 enables printing of problem statistics (default);
-%                   printlevel = 0 silent
+%                   printLevel = 0 silent
 %    fileName:      name of th file to load
 %    directory:     file directory (if `model` is empty, you can load it using `fileName` and `directory`)
 %

--- a/src/base/solvers/reformulate.m
+++ b/src/base/solvers/reformulate.m
@@ -13,7 +13,7 @@ function [LPproblem] = reformulate(LPproblem, BIG, printLevel)
 % structure FBA. `reformulate` assumes `S` and `C` do not contain very small entries
 % and transforms constraints containing very large entries (entries larger than
 % BIG). BIG should be set between 1000 and 10000 on double precision machines.
-% `printlevel` = 1 or 0 enables/diables printing respectively.
+% `printLevel` = 1 or 0 enables/diables printing respectively.
 %
 % Reformulation techniques are described in detail in:
 % `Y. Sun, R. M.T. Fleming, M. A. Saunders, I. Thiele, An Algorithm for Flux

--- a/src/dataIntegration/transcriptomics/FASTCORE/fastcore.m
+++ b/src/dataIntegration/transcriptomics/FASTCORE/fastcore.m
@@ -1,4 +1,4 @@
-function [tissueModel,coreRxnBool] = fastcore(model, core, epsilon, printlevel)
+function [tissueModel,coreRxnBool] = fastcore(model, core, epsilon, printLevel)
 % Use the FASTCORE algorithm ('Vlassis et al, 2014') to extract a context
 % specific model. FASTCORE algorithm defines one set of core
 % reactions that is guaranteed to be active in the extracted model and find
@@ -40,7 +40,7 @@ function [tissueModel,coreRxnBool] = fastcore(model, core, epsilon, printlevel)
 %       - Anne Richelle, code adaptation to fit with createTissueSpecificModel
 
 if nargin < 4 || ~exist('printLevel','var')
-    printlevel = 0;
+    printLevel = 0;
 end
 if nargin < 3 || isempty(epsilon)
     epsilon=1e-4;
@@ -69,7 +69,7 @@ singleton = false;
 % Find irreversible core reactions
 J = intersect(coreSetRxn, irrevRxns);
 
-if printlevel > 0
+if printLevel > 0
     fprintf('|J|=%d  ', length(J));
 end
 
@@ -86,13 +86,13 @@ if ~isempty(setdiff(J, Supp))
 end
 
 A = Supp;
-if printlevel > 0
+if printLevel > 0
     fprintf('|A|=%d\n', length(A));
 end
 
 % J is the set of irreversible reactions
 J = setdiff(coreSetRxn, A);
-if printlevel > 0
+if printLevel > 0
     fprintf('|J|=%d  ', length(J));
 end
 
@@ -106,13 +106,13 @@ while ~isempty(J)
     [Supp, basis] = findSparseMode(J, P, singleton, model, epsilon, basis);
     
     A = union(A, Supp);
-    if printlevel > 0
+    if printLevel > 0
         fprintf('|A|=%d\n', length(A));
     end
     
     if ~isempty( intersect(J, A))
         J = setdiff(J, A);
-        if printlevel > 0
+        if printLevel > 0
             fprintf('|J|=%d  ', length(J));
         end
         flipped = false;
@@ -136,17 +136,17 @@ while ~isempty(J)
             model.lb(JiRev) = -tmp;
             flipped = true;
             
-            if printlevel > 0
+            if printLevel > 0
                 fprintf('(flip)  ');
             end
         end
     end
 end
-if printlevel > 0
+if printLevel > 0
     fprintf('|A|=%d\n', length(A)); % A : indices of reactions in the new model
 end
 
-if printlevel > 1
+if printLevel > 1
     toc
 end
 

--- a/src/dataIntegration/transcriptomics/createTissueSpecificModel.m
+++ b/src/dataIntegration/transcriptomics/createTissueSpecificModel.m
@@ -173,7 +173,7 @@ else
                 error('The required option field "core" is not defined for fastCore method')                
             end
             if ~isfield(options,'epsilon'),options.epsilon=1e-4;end
-            if ~isfield(options,'printlevel'),options.printlevel=0;end
+            if ~isfield(options,'printLevel'),options.printLevel=0;end
     end
 end
 
@@ -196,7 +196,7 @@ switch options.solver
     case 'mCADRE'
         tissueModel = mCADRE(model, options.ubiquityScore, options.confidenceScores, options.protectedRxns, options.checkFunctionality, options.eta, options.tol);
     case 'fastCore'
-        tissueModel = fastcore(model, options.core, options.epsilon, options.printlevel);
+        tissueModel = fastcore(model, options.core, options.epsilon, options.printLevel);
 end
 
 


### PR DESCRIPTION
The print level was defined as printLevel in most of the code, but fastcore (for example) would check for the existence of printLevel, and then set printlevel, which resulted in this variable having no effect.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)
