### PR TITLE
Small fix for isCompatible for mac not running OSX 10.12 or 10.13

### DIFF
--- a/src/base/solvers/isCompatible.m
+++ b/src/base/solvers/isCompatible.m
@@ -122,8 +122,11 @@ function compatibleStatus = isCompatible(solverName, printLevel, specificSolverV
                 macOSFound = true;
             end
         end        
-        if ~macOSFound && printLevel > 0
-            fprintf([' > The compatibility can only be evaluated on the following mac OS versions: ', strjoin(testedOS(macpos),', '), '.\n']);
+        if ~macOSFound
+            untestedFlag = true;
+            if printLevel > 0
+                fprintf([' > The compatibility can only be evaluated on the following mac OS versions: ', strjoin(testedOS(macpos),', '), '.\n']);
+            end
         end
     else % Windows
         resultVERS = system_dependent('getos');


### PR DESCRIPTION
*Please include a short description of enhancement here*
I believe that the previous update of isCompatible for macOS did not set `untestedFlag` to be true for untested macOS, causing an error in initCobraToolbox (yes, I am still using OSX 10.10 ...).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
