### PR TITLE
Check cofactor pairs in biomassPrecursorCheck

### DIFF
--- a/docs/prepareTutorials.sh
+++ b/docs/prepareTutorials.sh
@@ -96,7 +96,7 @@ createLocalVariables(){
     htmlHyperlink="https://prince.lcsb.uni.lu/cobratoolbox/tutorials/$tutorialFolder/iframe_$tutorialName.html"
     mlxHyperlink="https://github.com/opencobra/COBRA.tutorials/raw/master/$tutorialFolder/$tutorialName.mlx"
     mHyperlink="https://github.com/opencobra/COBRA.tutorials/raw/master/$tutorialFolder/$tutorialName.m"
-    dirHyperLink="https://github.com/opencobra/COBRA.tutorials/tree/master/$tutorialFolder"
+    dirHyperlink="https://github.com/opencobra/COBRA.tutorials/tree/master/$tutorialFolder"
 
     previousSection=""
     if [[ -n $section ]]; then

--- a/src/analysis/exploration/biomassPrecursorCheck.m
+++ b/src/analysis/exploration/biomassPrecursorCheck.m
@@ -1,7 +1,7 @@
-function [missingMets, presentMets,coupledMets] = biomassPrecursorCheck(model,checkCoupling)
+function [missingMets, presentMets,coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model,checkCoupling)
 % Checks if biomass precursors are able to be synthesized.
 %
-% [missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model)
+% [missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model, checkCoupling)
 %
 % INPUT:
 %    model:             COBRA model structure
@@ -16,17 +16,19 @@ function [missingMets, presentMets,coupledMets] = biomassPrecursorCheck(model,ch
 %    presentMets:    List of biomass precursors that are able to be synthesized
 %    coupledMets:    List of metabolites which need an exchange reaction for at least one other
 %                    biomass component because their production is coupled to it.
-%                    
+%    missingCofs:    List of cofactor pairs (defined by the network conserved moieties) 
+%                    that are not able to be synthesized
+%    presentCofs:    List of cofactor pairs that are able to be synthesized
 %
 % .. Authors: - Pep Charusanti & Richard Que (July 2010)
-% May identify metabolites that are typically recycled within the
-% network such as ATP, NAD, NADPH, ACCOA.
+% May identify metabolites that are typically recycled within the network 
+% such as ATP, NAD, NADPH, ACCOA. Turn on checkCoupling to check them.
 if ~exist('checkCoupling','var')
     checkCoupling = 0;
 end
 
-if ~checkCoupling && nargout == 3
-    error('coupledMets are not being calculated if checkCoupling is not set to true!');
+if ~checkCoupling && nargout >= 3
+    error('coupledMets, missingCofs and presentCofs are not being calculated if checkCoupling is not set to true!');
 end
 
 % Find column in s-matrix that corresponds to biomass equation
@@ -79,6 +81,78 @@ for i = 1:length(biomassMetabs)
         p = p + 1;
     end
 end
-
 missingMets = columnVector(missingMets);
 presentMets = columnVector(presentMets);
+
+if checkCoupling && ~isempty(missingMets)
+    % Detect cofactor pairs in the biomass reaction. They contain conserved moieties.
+    EMV = findElementaryMoietyVectors(model);
+    % Biomass metabolites that contain conserved moieties
+    mCofactor = any(model.S(:, colS_biomass) ~= 0, 2) & any(EMV, 2);
+    % Elementary moieties involved in biomass production
+    cofactorPairMatrix = EMV(:, any(EMV(mCofactor, :), 1));
+    % Each cell of cofactorPair stores the set of cofactor metabolites to be produced.
+    % cofactorPairStr represents the set by a string for string comparison
+    % cofactorStoich is the corresponding stoichiometry for cofactorPair
+    [cofactorPair, cofactorPairStr, cofactorStoich] = deal({});
+    % To accommodate possibly multiple objective reactions, first figure out
+    % all different cofactor pairs to be produced among all objective reactions
+    for i = 1:size(cofactorPairMatrix, 2)
+        % Objective reactions involving the current elementary moiety
+        rxnI = find(colS_biomass & any(model.S(cofactorPairMatrix(:, i) ~= 0, :), 1)');
+        for j = 1:numel(rxnI)
+            % Logical index for metabolite contain the current moiety and
+            % involved in the current objective reactions
+            cofactorPairLogic = cofactorPairMatrix(:, i) ~= 0 & model.S(:, rxnI(j)) ~= 0;
+            % If this cofactor pair is not yet found, store it.
+            if ~any(strcmp(strjoin(model.mets(cofactorPairLogic), '|'), cofactorPairStr))
+                % The set of cofactor metabolites to be produced
+                cofactorPair{end + 1, 1} = model.mets(cofactorPairLogic);
+                % Expressed as a string joined by '|' for string comparison
+                cofactorPairStr{end + 1, 1} = strjoin(model.mets(cofactorPairLogic), '|');
+                % Stoichiometry
+                cofactorStoichCur = model.S(cofactorPairLogic, rxnI(j));
+                % The metabolite being consumed in this cofactor pair
+                substrateCur = cofactorPairLogic & model.S(:, rxnI(j)) < 0;
+                % Normalize the stoichiometry of the cofactor pair so that
+                % the substrate has stoich = -1
+                cofactorStoichCur = cofactorStoichCur / abs(model.S(substrateCur, rxnI(j)));
+                cofactorStoich{end + 1, 1} = cofactorStoichCur;
+            end
+        end
+    end
+    % Store the cofactor production formula for printing the results
+    cofactorFormula = cell(numel(cofactorPair), 1);
+    % Cofactor pairs producible or not
+    producible = false(size(cofactorFormula));
+    for i = 1:numel(cofactorPair)
+        % Add the corresponding reaction for cofactor production
+        model_newDemand = addReaction(model, 'cofactor_prod', ...
+            'metaboliteList', cofactorPair{i}, 'stoichCoeffList', cofactorStoich{i}, ...
+            'reversible', false, 'lowerBound', 0, 'printLevel', 0);
+        % Maximize its production
+        model_newDemand = changeObjective(model_newDemand, 'cofactor_prod', 1);
+        solution = optimizeCbModel(model_newDemand);
+        producible(i) = ~isempty(solution.f) && solution.f > 0;
+        % Store the reaction formula
+        cofactorFormula(i) = printRxnFormula(model_newDemand, 'rxnAbbrList', 'cofactor_prod', 'printFlag', false);
+    end
+    % Sort the cofactor pairs with those producible coming first
+    [producible, ind] = sort(producible, 'descend');
+    [cofactorFormula, cofactorPair] = deal(cofactorFormula(ind), cofactorPair(ind));
+    % Print the results
+    for i = 1:numel(cofactorPair)
+        if i == 1 && producible(i)
+            fprintf('Cofactors in the biomass reaction that CAN be synthesized:\n');
+        elseif ~producible(i) && (i == 1 || producible(i - 1))
+            fprintf('Cofactors in the biomass reaction that CANNOT be synthesized:\n');
+        end
+        fprintf('%s\n', cofactorFormula{i});
+        
+    end
+    presentCofs = cofactorPair(producible);
+    missingCofs = cofactorPair(~producible);
+    metCofs = [cofactorPair{:}];
+    % Exclude those metabolites in cofactor pairs from missingMets
+    missingMets = missingMets(~ismember(missingMets, metCofs(:)));
+end

--- a/src/analysis/exploration/biomassPrecursorCheck.m
+++ b/src/analysis/exploration/biomassPrecursorCheck.m
@@ -29,24 +29,24 @@ if ~checkCoupling && nargout == 3
     error('coupledMets are not being calculated if checkCoupling is not set to true!');
 end
 
+% Find column in s-matrix that corresponds to biomass equation
 colS_biomass = model.c ~= 0;
-% FIND COLUMN IN S-MATRIX THAT CORRESPONDS TO BIOMASS EQUATION
 
-% LIST ALL METABOLITES IN THE BIOMASS FUNCTION
+% List all metabolites in the biomass function
 biomassMetabs = model.mets(any(model.S(:, colS_biomass) < 0, 2));
 
-% ADD DEMAND REACTION, SET OBJECTIVE FUNCTION TO MAXIMIZE ITS PRODUCTION,
-% AND OPTIMIZE.  NOTE: A CRITICAL ASSUMPTION IS THAT THE ADDED DEMAND
-% REACTION IS APPENDED TO THE FAR RIGHT OF THE S-MATRIX.  THE CODE NEEDS TO
-% BE REVISED IF THIS IS NOT THE CASE.
+% Add demand reaction, set objective function to maximize its production,
+% and optimize.  Note: a critical assumption is that the added demand
+% reaction is appended to the far right of the s-matrix.  The code needs to
+% be revised if this is not the case.
 m = 1; % position in the missing metabolies vector
 p = 1; % position in the present metabolies vector
 c = 1; % position in the coupled metabolies vector
-% ADD DEMAND REACTIONS
+% Add demand reactions
 [model_newDemand, addedRxns] = addDemandReaction(model, biomassMetabs);
 
 if checkCoupling
-    %Close the precursors
+    % Close the precursors
     model_newDemand = changeRxnBounds(model_newDemand,addedRxns,zeros(numel(addedRxns,1)),repmat('b',numel(addedRxns,1)));
     coupledMets = {};
 end

--- a/src/analysis/exploration/biomassPrecursorCheck.m
+++ b/src/analysis/exploration/biomassPrecursorCheck.m
@@ -21,8 +21,11 @@ function [missingMets, presentMets,coupledMets, missingCofs, presentCofs] = biom
 %    presentCofs:    List of cofactor pairs that are able to be synthesized
 %
 % .. Authors: - Pep Charusanti & Richard Que (July 2010)
-% May identify metabolites that are typically recycled within the network 
-% such as ATP, NAD, NADPH, ACCOA. Turn on checkCoupling to check them.
+%
+% NOTE:
+%    May identify metabolites that are typically recycled within the network 
+%    such as ATP, NAD, NADPH, ACCOA. Turn on checkCoupling to check them.
+
 if ~exist('checkCoupling','var')
     checkCoupling = 0;
 end

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/createToyModelForBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/createToyModelForBiomassPrecursorCheck.m
@@ -3,11 +3,13 @@ function model = createToyModelForBiomassPrecursorCheck()
 % the biomassPrecursorCheck (which allows testing for coupling.
 % The model created looks as follows:
 %
-%                           1
-%   <-> A -> B ---> C --> E ----->
-%        \     /       \     / 0.5
-%         -> D          -> F
-%                       
+%         H   G  ^                  G    H 
+%          \ /   |              1    \  /
+%   <-> A ---- > B ---> C --> E ------------>
+%        \         /       \     / 0.5
+%         -----> D          -> F
+%         
+%         G --> H
 %           
 % Without checking coupling, The model would declare both F and E as
 % producible during the check, while still being unable to produce biomass.
@@ -15,15 +17,18 @@ function model = createToyModelForBiomassPrecursorCheck()
 
 model = createModel();
 %Reactions in {Rxn Name, MetaboliteNames, Stoichiometric coefficient} format
-reacIDs = {'Ex_A','R1','R2','R3','R4','Biomass'};
-mets = {'A','B','C','D','E','F'};
-stoich = [ 1 -1  0  0 -1  0;...
-           0  1 -1  0  0  0;...
-           0  0  1 -1  0  0;...
-           0  0 -1  0  1  0;...
-           0  0  0  1  0 -1;...
-           0  0  0  1  0 -0.5];
-lbs = zeros(6,1);       
+reacIDs = {'Ex_A', 'Ex_B', 'R1','R2','R3','R4', 'R5', 'Biomass'};
+mets = {'A','B','C','D','E','F', 'G', 'H'};
+stoich = [ 1  0 -1  0  0 -1  0  0;...
+           0 -1  1 -1  0  0  0  0;...
+           0  0  0  1 -1  0  0  0;...
+           0  0  0 -1  0  1  0  0;...
+           0  0  0  0  1  0  0 -1;...
+           0  0  0  0  1  0  0 -0.5;...
+           0  0  1  0  0  0 -1 -1; ...
+           0  0 -1  0  0  0  1  1];
+lbs = zeros(8, 1);
+lbs(2) = -1000;
 
 
 %Add Exchangers

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
@@ -13,48 +13,62 @@ currentDir = pwd;
 fileDir = fileparts(which('testBiomassPrecursorCheck'));
 cd(fileDir);
 
-model = readCbModel('iJO1366.mat');
-
-% Test where there is no missing metabolite
-[missingMets, presentMets] = biomassPrecursorCheck(model);
-assert(isempty(missingMets))
-presentMetsResult = {'10fthf_c';'2fe2s_c';'2ohph_c';'4fe4s_c';'ala__L_c';...
-    'amet_c';'arg__L_c';'asn__L_c';'asp__L_c';'atp_c';'bmocogdp_c';'btn_c';...
-    'ca2_c';'cl_c';'coa_c';'cobalt2_c';'ctp_c';'cu2_c';'cys__L_c';'datp_c';...
-    'dctp_c';'dgtp_c';'dttp_c';'fad_c';'fe2_c';'fe3_c';'gln__L_c';'glu__L_c';...
-    'gly_c';'gtp_c';'h2o_c';'his__L_c';'ile__L_c';'k_c';'kdo2lipid4_e';...
-    'leu__L_c';'lys__L_c';'met__L_c';'mg2_c';'mlthf_c';'mn2_c';'mobd_c';...
-    'murein5px4p_p';'nad_c';'nadp_c';'nh4_c';'ni2_c';'pe160_c';'pe160_p';...
-    'pe161_c';'pe161_p';'phe__L_c';'pheme_c';'pro__L_c';'pydx5p_c';'ribflv_c';...
-    'ser__L_c';'sheme_c';'so4_c';'thf_c';'thmpp_c';'thr__L_c';'trp__L_c';...
-    'tyr__L_c';'udcpdp_c';'utp_c';'val__L_c';'zn2_c'};
-assert(isequal(sort(presentMets), presentMetsResult))
-
-% Test where there is a missing metabolite
-model = addReaction(model,'testBiomass','reactionFormula','NotExist + amet_c -> ');
-model = changeObjective(model,'testBiomass');
-[missingMets, presentMets] = biomassPrecursorCheck(model);
-assert(isempty(setxor(missingMets,{'NotExist'}))); % NotExist, and only NotExist is not producible.
-assert(isempty(setxor(presentMets,{'amet_c'}))); % amet_c and only amet_c is producible
-
 % Test coupling
 model = createToyModelForBiomassPrecursorCheck();
 % This model cannot carry flux through the objective, but each precursor can
 % be produced if exchangers exist for all precursors.
 [missingMets, presentMets] = biomassPrecursorCheck(model);
+assert(isempty(setxor(missingMets,{'G'})))
 assert(isempty(setxor(presentMets,{'E','F'})));
 
 % Check for coupled Mets
 [missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model,true);
 
-assert(isempty(missingMets))
-assert(isempty(setxor(presentMets,{'F'}))); %F can be produced, as surplus E can be removed by the biomass function.
+assert(isempty(setxor(missingMets,{'G'})))
+assert(isempty(setxor(presentMets,{'F'}))); % F can be produced, as surplus E can be removed by the biomass function.
 assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
 
-% Test error
-assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage','coupledMets, missingCofs and presentCofs are not being calculated if checkCoupling is not set to true!'));
+% Check for cofactor pairs but not coupled mets
+[missingMets, presentMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, [], true);
+assert(isempty(missingMets))  % G, previously in missingMets now belongs to presentCofs 
+assert(isempty(setxor(presentMets,{'E','F'})));
+assert(isempty(missingCofs))
+presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', false);
+assert(isempty(setxor(presentCofsStr, {'G|H'})))
 
-% Test cofactor pairs
+% Check for both coupled mets and cofactor pairs
+[missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, true, true);
+assert(isempty(missingMets))
+assert(isempty(setxor(presentMets,{'F'}))); % F can be produced, as surplus E can be removed by the biomass function.
+assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
+% cofactor G can be produced from H. No missing cofactor pair.
+assert(isempty(missingCofs))
+presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', false);
+assert(isempty(setxor(presentCofsStr, {'G|H'})))
+
+% Check for the case with missing cofactor pairs
+model = changeRxnBounds(model, 'R1', 0, 'b');  % shut down the reaction generating the cofactor G from H
+[missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, true, true);
+assert(isempty(missingMets))
+% Both E and F become coupled now because the biomass reaction cannot have flux to remove the surplus due to missingCofs G -> H 
+assert(isempty(presentMets))
+assert(isempty(setxor(coupledMets,{'E', 'F'})));
+% cofactor G cannot be produced from H after R1 is shut down.
+missingCofsStr = cellfun(@(x) strjoin(x, '|'), missingCofs, 'UniformOutput', false);
+assert(isempty(setxor(missingCofsStr, {'G|H'})))
+assert(isempty(presentCofs))
+
+% Test error
+assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage', ...
+    sprintf('coupledMets are not being calculated if checkCoupling is not set to true!\n%s', ...
+    'missingCofs and presentCofs are not being calculated if checkConservedQuantities is not set to true!')))
+assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model, [], true},'outputArgCount',5,'testMessage', ...
+    'coupledMets are not being calculated if checkCoupling is not set to true!'))
+assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model, true},'outputArgCount',4,'testMessage', ...
+    'missingCofs and presentCofs are not being calculated if checkConservedQuantities is not set to true!'))
+
+
+% Test the E. coli core model
 model = readCbModel('ecoli_core_model.mat');
 % Add a hypothetical non-producible cofactor pair
 model = addReaction(model, 'COF', 'reactionFormula', 'metTest1[c] -> metTest2[c]');
@@ -66,15 +80,18 @@ if exist([pwd filesep 'testBiomassPrecursorCheck.txt'], 'file')
     delete([pwd filesep 'testBiomassPrecursorCheck.txt'])
 end
 diary('testBiomassPrecursorCheck.txt');
-[missingMets, presentMets,coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model,true);
+[missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, true, true);
 diary off
 
-% Producible cofactors identified as missingMets when checkCoupling not turned on
+% empty coupledMets
+assert(isempty(coupledMets))
+
+% Producible cofactors identified as missingMets when checkConservedQuantities not turned on
 assert(isempty(setxor(missingMets0, {'accoa[c]';'atp[c]';'nad[c]';'nadph[c]';'metTest1[c]'})))
 assert(isempty(setxor(presentMets0, {'3pg[c]';'e4p[c]';'f6p[c]';'g3p[c]';'g6p[c]';...
     'gln-L[c]';'glu-L[c]';'h2o[c]';'oaa[c]';'pep[c]';'pyr[c]';'r5p[c]'})))
 
-% No missingMets when checkCoupling turned on
+% No missingMets when checkConservedQuantities turned on
 assert(isempty(missingMets))
 % Same set of presentMets
 assert(isempty(setxor(presentMets, presentMets0)))

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
@@ -6,16 +6,16 @@
 % Authors:
 %    - Siu Hung Joshua Chan June 2018
 
-% save the current path
+% Save the current path
 currentDir = pwd;
 
-% initialize the test
+% Initialize the test
 fileDir = fileparts(which('testBiomassPrecursorCheck'));
 cd(fileDir);
 
 model = readCbModel('iJO1366.mat');
 
-% test where there is no missing metabolite
+% Test where there is no missing metabolite
 [missingMets, presentMets] = biomassPrecursorCheck(model);
 assert(isempty(missingMets))
 presentMetsResult = {'10fthf_c';'2fe2s_c';'2ohph_c';'4fe4s_c';'ala__L_c';...
@@ -30,29 +30,88 @@ presentMetsResult = {'10fthf_c';'2fe2s_c';'2ohph_c';'4fe4s_c';'ala__L_c';...
     'tyr__L_c';'udcpdp_c';'utp_c';'val__L_c';'zn2_c'};
 assert(isequal(sort(presentMets), presentMetsResult))
 
-% test where there is a missing metabolite
+% Test where there is a missing metabolite
 model = addReaction(model,'testBiomass','reactionFormula','NotExist + amet_c -> ');
 model = changeObjective(model,'testBiomass');
 [missingMets, presentMets] = biomassPrecursorCheck(model);
 assert(isempty(setxor(missingMets,{'NotExist'}))); % NotExist, and only NotExist is not producible.
 assert(isempty(setxor(presentMets,{'amet_c'}))); % amet_c and only amet_c is producible
 
-%Test coupling
+% Test coupling
 model = createToyModelForBiomassPrecursorCheck();
-%This model cannot carry flux through the objective, but each precursor can
-%be produced if exchangers exist for all precursors.
+% This model cannot carry flux through the objective, but each precursor can
+% be produced if exchangers exist for all precursors.
 [missingMets, presentMets] = biomassPrecursorCheck(model);
 assert(isempty(setxor(presentMets,{'E','F'})));
 
-%Check for coupled Mets
+% Check for coupled Mets
 [missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model,true);
 
 assert(isempty(missingMets))
 assert(isempty(setxor(presentMets,{'F'}))); %F can be produced, as surplus E can be removed by the biomass function.
 assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
 
-%Test error
-assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage','coupledMets are not being calculated if checkCoupling is not set to true!'));
+% Test error
+assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage','coupledMets, missingCofs and presentCofs are not being calculated if checkCoupling is not set to true!'));
 
-% change the directory
+% Test cofactor pairs
+model = readCbModel('ecoli_core_model.mat');
+% Add a hypothetical non-producible cofactor pair
+model = addReaction(model, 'COF', 'reactionFormula', 'metTest1[c] -> metTest2[c]');
+model = addReaction(model, 'BIOMASS2', 'reactionFormula', 'metTest1[c] + atp[c] -> metTest2[c] + adp[c]');
+% Test the function's capability to handle >1 objective reactions 
+model = changeObjective(model, {'Biomass_Ecoli_core_N(w/GAM)-Nmet2'; 'BIOMASS2'}, 1);
+[missingMets0, presentMets0] = biomassPrecursorCheck(model);
+if exist([pwd filesep 'testBiomassPrecursorCheck.txt'], 'file')
+    delete([pwd filesep 'testBiomassPrecursorCheck.txt'])
+end
+diary('testBiomassPrecursorCheck.txt');
+[missingMets, presentMets,coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model,true);
+diary off
+
+% Producible cofactors identified as missingMets when checkCoupling not turned on
+assert(isempty(setxor(missingMets0, {'accoa[c]';'atp[c]';'nad[c]';'nadph[c]';'metTest1[c]'})))
+assert(isempty(setxor(presentMets0, {'3pg[c]';'e4p[c]';'f6p[c]';'g3p[c]';'g6p[c]';...
+    'gln-L[c]';'glu-L[c]';'h2o[c]';'oaa[c]';'pep[c]';'pyr[c]';'r5p[c]'})))
+
+% No missingMets when checkCoupling turned on
+assert(isempty(missingMets))
+% Same set of presentMets
+assert(isempty(setxor(presentMets, presentMets0)))
+
+% missingCofs and presentCofs are identified
+missingCofsStr = cellfun(@(x) strjoin(x, '|'), missingCofs, 'UniformOutput', false);
+assert(isempty(setxor(missingCofsStr, {'metTest1[c]|metTest2[c]'})))
+presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', false);
+assert(isempty(setxor(presentCofsStr, {'nadp[c]|nadph[c]'; 'adp[c]|atp[c]'; ...
+    'accoa[c]|coa[c]'; 'nad[c]|nadh[c]'})))
+
+% Check the correct printing of the results
+f = fopen('testBiomassPrecursorCheck.txt', 'r');
+l = fgetl(f);
+text = {};
+while ~isequal(l, -1)
+    text{end + 1} = l;
+    l = fgetl(f);
+end
+fclose(f);
+
+lineCan = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CAN be produced:')));
+assert(isscalar(lineCan))
+lineCannot = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CANNOT be produced:')));
+assert(isscalar(lineCannot))
+cofactorCan = {'nadph[c]  -> nadp[c]', 'atp[c]  -> adp[c]', 'accoa[c]  -> coa[c]', 'nad[c]  -> nadh[c]'};
+cofactorCannot = {'metTest1[c]  -> metTest2[c]'};
+% Correct order of printing
+for j = 1:numel(cofactorCan)
+    lineJ = find(~cellfun(@isempty, strfind(text, cofactorCan{j})));
+    assert(~isempty(lineJ) && lineJ > lineCan && lineJ < lineCannot)
+end
+for j = 1:numel(cofactorCannot)
+    lineJ = find(~cellfun(@isempty, strfind(text, cofactorCannot{j})));
+    assert(~isempty(lineJ) && lineJ > lineCannot)
+end
+delete([pwd filesep 'testBiomassPrecursorCheck.txt'])
+
+% Change the directory
 cd(currentDir)

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
@@ -96,9 +96,9 @@ while ~isequal(l, -1)
 end
 fclose(f);
 
-lineCan = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CAN be produced:')));
+lineCan = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CAN be synthesized:')));
 assert(isscalar(lineCan))
-lineCannot = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CANNOT be produced:')));
+lineCannot = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass reaction that CANNOT be synthesized:')));
 assert(isscalar(lineCannot))
 cofactorCan = {'nadph[c]  -> nadp[c]', 'atp[c]  -> adp[c]', 'accoa[c]  -> coa[c]', 'nad[c]  -> nadh[c]'};
 cofactorCannot = {'metTest1[c]  -> metTest2[c]'};

--- a/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
+++ b/test/verifiedTests/analysis/testBiomassPrecursorCheck/testBiomassPrecursorCheck.m
@@ -6,51 +6,52 @@
 % Authors:
 %    - Siu Hung Joshua Chan June 2018
 
-% Save the current path
+% save the current path
 currentDir = pwd;
 
-% Initialize the test
+% initialize the test
 fileDir = fileparts(which('testBiomassPrecursorCheck'));
 cd(fileDir);
 
-% Test coupling
+% test coupling
 model = createToyModelForBiomassPrecursorCheck();
-% This model cannot carry flux through the objective, but each precursor can
+% this model cannot carry flux through the objective, but each precursor can
 % be produced if exchangers exist for all precursors.
 [missingMets, presentMets] = biomassPrecursorCheck(model);
 assert(isempty(setxor(missingMets,{'G'})))
 assert(isempty(setxor(presentMets,{'E','F'})));
 
-% Check for coupled Mets
+% check for coupled Mets
 [missingMets, presentMets, coupledMets] = biomassPrecursorCheck(model,true);
 
 assert(isempty(setxor(missingMets,{'G'})))
 assert(isempty(setxor(presentMets,{'F'}))); % F can be produced, as surplus E can be removed by the biomass function.
-assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
+assert(isempty(setxor(coupledMets,{'E'}))); % all E has to go to the biomass as long as there is no sink for F.
 
-% Check for cofactor pairs but not coupled mets
-[missingMets, presentMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, [], true);
+% check for cofactor pairs but not coupled mets
+[missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, [], true);
 assert(isempty(missingMets))  % G, previously in missingMets now belongs to presentCofs 
 assert(isempty(setxor(presentMets,{'E','F'})));
+assert(isempty(coupledMets))
 assert(isempty(missingCofs))
 presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', false);
 assert(isempty(setxor(presentCofsStr, {'G|H'})))
 
-% Check for both coupled mets and cofactor pairs
+% check for both coupled mets and cofactor pairs
 [missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, true, true);
 assert(isempty(missingMets))
 assert(isempty(setxor(presentMets,{'F'}))); % F can be produced, as surplus E can be removed by the biomass function.
-assert(isempty(setxor(coupledMets,{'E'}))); % All E has to go to the biomass as long as there is no sink for F.
+assert(isempty(setxor(coupledMets,{'E'}))); % all E has to go to the biomass as long as there is no sink for F.
 % cofactor G can be produced from H. No missing cofactor pair.
 assert(isempty(missingCofs))
 presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', false);
 assert(isempty(setxor(presentCofsStr, {'G|H'})))
 
-% Check for the case with missing cofactor pairs
+% check for the case with missing cofactor pairs
 model = changeRxnBounds(model, 'R1', 0, 'b');  % shut down the reaction generating the cofactor G from H
 [missingMets, presentMets, coupledMets, missingCofs, presentCofs] = biomassPrecursorCheck(model, true, true);
 assert(isempty(missingMets))
-% Both E and F become coupled now because the biomass reaction cannot have flux to remove the surplus due to missingCofs G -> H 
+% both E and F become coupled now because the biomass reaction cannot have flux to remove the surplus due to missingCofs G -> H 
 assert(isempty(presentMets))
 assert(isempty(setxor(coupledMets,{'E', 'F'})));
 % cofactor G cannot be produced from H after R1 is shut down.
@@ -58,22 +59,20 @@ missingCofsStr = cellfun(@(x) strjoin(x, '|'), missingCofs, 'UniformOutput', fal
 assert(isempty(setxor(missingCofsStr, {'G|H'})))
 assert(isempty(presentCofs))
 
-% Test error
+% test error
 assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model},'outputArgCount',3,'testMessage', ...
     sprintf('coupledMets are not being calculated if checkCoupling is not set to true!\n%s', ...
     'missingCofs and presentCofs are not being calculated if checkConservedQuantities is not set to true!')))
-assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model, [], true},'outputArgCount',5,'testMessage', ...
-    'coupledMets are not being calculated if checkCoupling is not set to true!'))
 assert(verifyCobraFunctionError('biomassPrecursorCheck','input',{model, true},'outputArgCount',4,'testMessage', ...
     'missingCofs and presentCofs are not being calculated if checkConservedQuantities is not set to true!'))
 
 
-% Test the E. coli core model
+% test the E. coli core model
 model = readCbModel('ecoli_core_model.mat');
-% Add a hypothetical non-producible cofactor pair
+% add a hypothetical non-producible cofactor pair
 model = addReaction(model, 'COF', 'reactionFormula', 'metTest1[c] -> metTest2[c]');
 model = addReaction(model, 'BIOMASS2', 'reactionFormula', 'metTest1[c] + atp[c] -> metTest2[c] + adp[c]');
-% Test the function's capability to handle >1 objective reactions 
+% test the function's capability to handle >1 objective reactions 
 model = changeObjective(model, {'Biomass_Ecoli_core_N(w/GAM)-Nmet2'; 'BIOMASS2'}, 1);
 % additional functionalities not turned on
 [missingMets0, presentMets0] = biomassPrecursorCheck(model);
@@ -88,14 +87,14 @@ diary off
 % empty coupledMets
 assert(isempty(coupledMets))
 
-% Producible cofactors identified as missingMets when checkConservedQuantities not turned on
+% producible cofactors identified as missingMets when checkConservedQuantities not turned on
 assert(isempty(setxor(missingMets0, {'accoa[c]';'atp[c]';'nad[c]';'nadph[c]';'metTest1[c]'})))
 assert(isempty(setxor(presentMets0, {'3pg[c]';'e4p[c]';'f6p[c]';'g3p[c]';'g6p[c]';...
     'gln-L[c]';'glu-L[c]';'h2o[c]';'oaa[c]';'pep[c]';'pyr[c]';'r5p[c]'})))
 
-% No missingMets when checkConservedQuantities turned on
+% no missingMets when checkConservedQuantities turned on
 assert(isempty(missingMets))
-% Same set of presentMets
+% same set of presentMets
 assert(isempty(setxor(presentMets, presentMets0)))
 
 % missingCofs and presentCofs are identified
@@ -105,7 +104,7 @@ presentCofsStr = cellfun(@(x) strjoin(x, '|'), presentCofs, 'UniformOutput', fal
 assert(isempty(setxor(presentCofsStr, {'nadp[c]|nadph[c]'; 'adp[c]|atp[c]'; ...
     'accoa[c]|coa[c]'; 'nad[c]|nadh[c]'})))
 
-% Check the correct printing of the results
+% check the correct printing of the results
 f = fopen('testBiomassPrecursorCheck.txt', 'r');
 l = fgetl(f);
 text = {};
@@ -121,7 +120,7 @@ lineCannot = find(~cellfun(@isempty, strfind(text, 'Cofactors in the biomass rea
 assert(isscalar(lineCannot))
 cofactorCan = {'nadph[c]  -> nadp[c]', 'atp[c]  -> adp[c]', 'accoa[c]  -> coa[c]', 'nad[c]  -> nadh[c]'};
 cofactorCannot = {'metTest1[c]  -> metTest2[c]'};
-% Correct order of printing
+% correct order of printing
 for j = 1:numel(cofactorCan)
     lineJ = find(~cellfun(@isempty, strfind(text, cofactorCan{j})));
     assert(~isempty(lineJ) && lineJ > lineCan && lineJ < lineCannot)
@@ -132,5 +131,5 @@ for j = 1:numel(cofactorCannot)
 end
 delete([pwd filesep 'testBiomassPrecursorCheck.txt'])
 
-% Change the directory
+% change the directory
 cd(currentDir)


### PR DESCRIPTION
This PR continues the efforts in #1238 and #1249 to improve `biomassPrecursorCheck`.
In some models some cofactors are consumed during biomass production (e.g. AA-charged-tRNA -> unchaged-tRNA, fatty-acyl-ACP -> ACP). The AA-charged tRNA and the uncharged tRNA must be consumed and produced as a pair because the uncharged tRNA is not synthesized in the network (conserved moiety defined by the network structure). The current `biomassPrecursorCheck` would identify these metabolites as unable to be synthesized. This PR adds the functionality to check these cofactor pairs by looking at the conserved moieties defined by the network structure.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
