### PR TITLE
Fixing bug with mCADRE creating non-unique values, which 

### DIFF
--- a/external/mCADRE/mCADRE.m
+++ b/external/mCADRE/mCADRE.m
@@ -71,30 +71,26 @@ function [tissueModel, coreRxn, nonCoreRxn,	zeroExpRxns, pruneTime, cRes] = mCAD
     end
 
 
-    display('Processing inputs and ranking reactions...')
+    disp('Processing inputs and ranking reactions...')
 
     [coreRxn, nonCoreRxn, rankNonCore, zeroExpRxns] = rankReactions(model, ubiquityScore, confidenceScores, protectedRxns);
 
     % Precursor are defined as the metabolites involved in the
     % reactions defined in protected reactions
     if checkFunctionality == 1 && ~isempty(protectedRxns)
-    	precursorMets={};
-    	for i=1:numel(protectedRxns)
-        	colS_obj = findRxnIDs(model,protectedRxns{i});
-            precursorMets = [precursorMets; model.mets(model.S(:,colS_obj)<0)];
-        end
-
+        precursorMets = model.mets(any(model.S(:, findRxnIDs(model, protectedRxns)) < 0, 2));
+        
         genericStatus = checkModelFunction(model, precursorMets);
-
+        
     else
     	precursorMets={};
     	genericStatus=1;
     end
 
     if genericStatus
-    	display('Generic model passed precursor metabolites test');
+    	disp('Generic model passed precursor metabolites test');
 
-        display('Pruning reactions...')
+        disp('Pruning reactions...')
         t0 = clock;
 
         [tissueModel, cRes] = pruningModel(model, rankNonCore, coreRxn, zeroExpRxns, precursorMets, eta, tol);


### PR DESCRIPTION
confuse addReactions
mCADRE would create repeating values of precursorMets (when running with checkFunctionality=1). This would end up confusing the COBRA toolbox when trying to add demand reactions (in checkModelFunction.m) and result in an error.

I've modified the code to have no loops, and no repeating values.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)