### PR TITLE
Fixing bug in generateRules caused by #1234

### DIFF
--- a/src/reconstruction/refinement/addGenes.m
+++ b/src/reconstruction/refinement/addGenes.m
@@ -27,7 +27,7 @@ function newmodel = addGenes(model,geneIDs,varargin)
 %    
 
 
-if (isfield(model,'genes') && any(ismember(model.genes,geneIDs))) || numel(unique(geneIDs)) < numel(geneIDs)
+if (isfield(model,'genes') && ~isempty(model.genes) && any(ismember(model.genes,geneIDs))) || numel(unique(geneIDs)) < numel(geneIDs)
     error('Duplicate Reaction ID detected.');
 end
 

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -1,4 +1,4 @@
-function [model] = generateRules(model)
+function [model] = generateRules(model, printLevel)
 % If a model does not have a model.rules field but has a model.grRules
 % field, can be regenerated using this script
 %
@@ -7,7 +7,9 @@ function [model] = generateRules(model)
 %    [model] = generateRules(model)
 %
 % INPUT:
-%    model:     COBRA model with model.grRules
+%    model:        COBRA model with model.grRules
+%    printLevel:   optional variable to print out all new genes 
+%                  (default = TRUE), can be zero if not needed
 %
 % OUTPUT:
 %    model:     same model but with model.rules added
@@ -17,13 +19,22 @@ function [model] = generateRules(model)
 %            - Diana El Assal 30/8/2017
 %            - Laurent Heirendt December 2017, speedup
 
+    if (nargin < 2)
+        printLevel = 1;
+    end
     [preParsedGrRules,genes] = preparseGPR(model.grRules);  % preparse all model.grRules
     allGenes =  unique([genes{~cellfun(@isempty,genes)}]); %Get the unique gene list
-    newGenes = setdiff(allGenes,model.genes);
+    if (~isfield(model, 'genes'))
+        newGenes = allGenes;
+    else
+        newGenes = setdiff(allGenes,model.genes);
+    end
     if ~isempty(newGenes)
-        warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
-        model.genes = addGenes(model,newGenes);
-    end        
+        if printLevel
+            warning('Found the following genes not present in the original model:\n%s\nAdding them to the model.',strjoin(newGenes,'\n'));
+        end
+        model = addGenes(model,newGenes);
+    end
     
     % determine the number of rules
     nRules = length(model.grRules);

--- a/src/reconstruction/refinement/generateRules.m
+++ b/src/reconstruction/refinement/generateRules.m
@@ -19,7 +19,7 @@ function [model] = generateRules(model, printLevel)
 %            - Diana El Assal 30/8/2017
 %            - Laurent Heirendt December 2017, speedup
 
-    if (nargin < 2)
+    if ~exist('printLevel', 'var')
         printLevel = 1;
     end
     [preParsedGrRules,genes] = preparseGPR(model.grRules);  % preparse all model.grRules

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -23,6 +23,12 @@ for i=1:length(modelsToTry)
     
     model2 = generateRules(model);
     model.rules = strrep(model.rules, '  ', ' ');
+    model3 = model;
+    model3.genes = []; % Empty genes field
+    model3 = generateRules(model3, 0);
+    model4 = model;
+    model4 = rmfield(model4, 'genes');
+    model4 = generateRules(model4, 0);
     
     fp = FormulaParser();
     % fix for Recon2
@@ -40,18 +46,27 @@ for i=1:length(modelsToTry)
         if isempty(model.rules{rule})
             %assert that both formulas are empty (and thus equal).
             assert(isequal(model.rules{rule},model2.rules{rule}))
+            assert(isequal(model.rules{rule},model3.rules{rule}))
+            assert(isequal(model.rules{rule},model4.rules{rule}))
             continue;
         elseif strcmp(model.rules{rule},model2.rules{rule})
             %If the strings are identical than we don't need to check
             %equivalence.
             assert(isequal(model.rules{rule},model2.rules{rule}))
+            assert(isequal(model.rules{rule},model3.rules{rule}))
+            assert(isequal(model.rules{rule},model4.rules{rule}))
             continue
         end
         
         head1 = fp.parseFormula(model.rules{rule});
         head2 = fp.parseFormula(model2.rules{rule});
+        head3 = fp.parseFormula(model3.rules{rule});
+        head4 = fp.parseFormula(model4.rules{rules});
+        
         %Assert that the formulas are equal.
         assert(head1.isequal(head2));
+        assert(head1.isequal(head3));
+        assert(head1.isequal(head4));
     end
     fprintf('Succesfully completed model %s\n', modelsToTry{i});
 end

--- a/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testGenerateRules.m
@@ -42,31 +42,44 @@ for i=1:length(modelsToTry)
     %also, introduce spaces around the individual genes:    
     model.rules = regexprep(model.rules,'([^\s])(x\([0-9]+\))','$1 $2');
     model.rules = regexprep(model.rules,'(x\([0-9]+\))([^\s])','$1 $2');
+    
+    % Create a model with sorted genes
+    sortedModel = model;
+    sortedRules = sortedModel.rules;
+    [sortedModel.genes, newInd] = sort(model.genes);
+    [~, newInd] = sort(newInd);
+    for j=1:length(newInd)
+        sortedRules = strrep(sortedRules, ['x(', num2str(j), ')'], ['x(New', num2str(newInd(j)), ')']);
+    end
+    sortedRules = strrep(sortedRules, 'New', '');
+    sortedModel.rules = sortedRules;
+    
     for rule = 1:numel(model.rules)        
         if isempty(model.rules{rule})
             %assert that both formulas are empty (and thus equal).
             assert(isequal(model.rules{rule},model2.rules{rule}))
-            assert(isequal(model.rules{rule},model3.rules{rule}))
-            assert(isequal(model.rules{rule},model4.rules{rule}))
+            assert(isequal(sortedModel.rules{rule},model3.rules{rule}))
+            assert(isequal(sortedModel.rules{rule},model4.rules{rule}))
             continue;
         elseif strcmp(model.rules{rule},model2.rules{rule})
             %If the strings are identical than we don't need to check
             %equivalence.
             assert(isequal(model.rules{rule},model2.rules{rule}))
-            assert(isequal(model.rules{rule},model3.rules{rule}))
-            assert(isequal(model.rules{rule},model4.rules{rule}))
+            assert(isequal(sortedModel.rules{rule},model3.rules{rule}))
+            assert(isequal(sortedModel.rules{rule},model4.rules{rule}))
             continue
         end
         
         head1 = fp.parseFormula(model.rules{rule});
         head2 = fp.parseFormula(model2.rules{rule});
+        headSort = fp.parseFormula(sortedModel.rules{rule});
         head3 = fp.parseFormula(model3.rules{rule});
-        head4 = fp.parseFormula(model4.rules{rules});
+        head4 = fp.parseFormula(model4.rules{rule});
         
         %Assert that the formulas are equal.
         assert(head1.isequal(head2));
-        assert(head1.isequal(head3));
-        assert(head1.isequal(head4));
+        assert(headSort.isequal(head3));
+        assert(headSort.isequal(head4));
     end
     fprintf('Succesfully completed model %s\n', modelsToTry{i});
 end


### PR DESCRIPTION
PR #1234 created a bug, where if genes needed to be added it is model.genes = addGenes(model, newGenes). However, addGenes returns a COBRA model full structure, so I fixed that bug.

There was also one linked bug
generateRules could deal with model.genes being empty, but not with it being missing.
addGenes would crash if model.genes was empty, but could deal with it being missing.

I've fixed that.

Right now, the tests will fail due to changes I've made to testGenerateRules, since I added checking both cases. Unfortunately, when model.genes is empty or missing, it will be repopulated in sorted order, which means that the rules will not match up.
I'm having it fail to ask the maintainers how to deal with this - I don't know how to add genes in a non-sorted manner.
One option is to compare model3 and model4 (and NOT compare them to the original model). Another option is not to check this subcases, and just leave testGenerateRules as it was before.

What do you think?

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)