### PR TITLE
Adding a flag to allow a toolbox update to be optional

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -1,4 +1,4 @@
-function initCobraToolbox()
+function initCobraToolbox(updateToolbox)
 %      _____   _____   _____   _____     _____     |
 %     /  ___| /  _  \ |  _  \ |  _  \   / ___ \    |   COnstraint-Based Reconstruction and Analysis
 %     | |     | | | | | |_| | | |_| |  | |___| |   |   The COBRA Toolbox - 2017
@@ -41,7 +41,10 @@ function initCobraToolbox()
     global ENV_VARS;
     global gitBashVersion;
     global CBT_MISSING_REQUIREMENTS_ERROR_ID;
-
+        
+    if ~exist('updateToolbox','var')
+        updateToolbox = true;
+    end
     % define a base version of gitBash that is tested
     gitBashVersion = '2.13.3';
 
@@ -533,8 +536,12 @@ function initCobraToolbox()
     changeCobraSolver('gurobi', 'ALL', 0);
 
     % check if a new update exists
-    if ENV_VARS.printLevel && status_curl == 0 && ~isempty(strfind(result_curl, ' 200'))
+    if ENV_VARS.printLevel && status_curl == 0 && ~isempty(strfind(result_curl, ' 200')) && updateToolbox
         updateCobraToolbox(true); % only check
+    else
+        if ~updateToolbox && ENV_VARS.printLevel
+            fprintf('> Checking for available updates ... skipped\n')
+        end
     end
 
     % restore global configuration by unsetting http.sslVerify

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/adaptVMHDietToAGORA.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/adaptVMHDietToAGORA.m
@@ -97,7 +97,7 @@ if nargin > 2
     global CBT_LP_SOLVER
     solver = CBT_LP_SOLVER;
     if isempty(solver)
-        initCobraToolbox;
+        initCobraToolbox(0); %Don't update the toolbox automatically
     end
     % inconsistency in reaction IDs..can currently only be fixed manually.
     TestAdaptedDietConstraints = adaptedDietConstraints;

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/microbiotaModelSimulator.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/microbiotaModelSimulator.m
@@ -100,7 +100,7 @@ for k = startIter:(patNumb + 1)
     global CBT_LP_SOLVER
     solver = CBT_LP_SOLVER;
     if isempty(solver)
-        initCobraToolbox;
+        initCobraToolbox(0); %Don't update the toolbox automatically
     end
     solution_allOpen = solveCobraLP(model);
     % solution_allOpen=solveCobraLPCPLEX(model,2,0,0,[],0);

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/computeParetoOptimality.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/computeParetoOptimality.m
@@ -63,7 +63,7 @@ FVAflag = parser.Results.FVAflag;
 global CBT_LP_SOLVER
 solver = CBT_LP_SOLVER;
 if isempty(solver)
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically
 end
 
 % Find the range of possible optimal values for both objective functions

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/computeRescuedGenes.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/computeRescuedGenes.m
@@ -76,7 +76,7 @@ end
 global CBT_LP_SOLVER
 solver = CBT_LP_SOLVER;
 if isempty(solver)
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically
 end
 
 % Start the gene deletion analysis.

--- a/src/base/install/installDevTools.m
+++ b/src/base/install/installDevTools.m
@@ -22,7 +22,7 @@ function installDevTools(repoName)
     % git and curl are tested here
     if isempty(ENV_VARS)
         ENV_VARS.printLevel = false;
-        initCobraToolbox;
+        initCobraToolbox(0); %Don't update the toolbox automatically
         ENV_VARS.printLevel = true;
     end
 

--- a/src/base/io/utilities/generateFieldDescriptionFile.m
+++ b/src/base/io/utilities/generateFieldDescriptionFile.m
@@ -16,7 +16,7 @@ function FileString = generateFieldDescriptionFile(FileName)
 global CBTDIR
 if ~exist('FileName','var')
     if isempty(CBTDIR)
-        initCobraToolbox
+        initCobraToolbox(0); %Don't update the toolbox automatically
     end
     FileName = [CBTDIR filesep 'docs' filesep 'source' filesep 'notes' filesep 'COBRAModelFields.md'];
 end

--- a/src/base/io/utilities/getDistributedModel.m
+++ b/src/base/io/utilities/getDistributedModel.m
@@ -22,7 +22,7 @@ global ENV_VARS
 
 if isempty(CBTDIR)
     ENV_VARS.printLevel = false;
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically
     ENV_VARS.printLevel = true;
 end
 

--- a/src/base/io/utilities/getDistributedModelFolder.m
+++ b/src/base/io/utilities/getDistributedModelFolder.m
@@ -18,7 +18,7 @@ global CBTDIR
 global ENV_VARS
 if isempty(CBTDIR)    
     ENV_VARS.printLevel = false;
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically
     ENV_VARS.printLevel = true;    
 end
 

--- a/src/base/solvers/changeCobraSolver.m
+++ b/src/base/solvers/changeCobraSolver.m
@@ -214,7 +214,7 @@ solverInstalled = false;
 
 if isempty(SOLVERS) || isempty(OPT_PROB_TYPES)
     ENV_VARS.printLevel = false;
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically
     ENV_VARS.printLevel = true;
 end
 

--- a/src/base/solvers/getAvailableSolversByType.m
+++ b/src/base/solvers/getAvailableSolversByType.m
@@ -15,7 +15,7 @@ global SOLVERS
 
 if isempty(SOLVERS) || isempty(OPT_PROB_TYPES)
     ENV_VARS.printLevel = false;
-    initCobraToolbox;
+    initCobraToolbox(0); %Don't update the toolbox automatically;
     ENV_VARS.printLevel = true;
 end
 

--- a/src/base/solvers/getCobraSolverVersion.m
+++ b/src/base/solvers/getCobraSolverVersion.m
@@ -25,7 +25,7 @@ function solverVersion = getCobraSolverVersion(solverName, printLevel, rootPathS
     % run initCobraToolbox when not yet initialised
     if isempty(SOLVERS)
         ENV_VARS.printLevel = false;
-        initCobraToolbox;
+        initCobraToolbox(0); %Don't update the toolbox automatically
         ENV_VARS.printLevel = true;
     end
 

--- a/src/reconstruction/refinement/addReaction.m
+++ b/src/reconstruction/refinement/addReaction.m
@@ -57,6 +57,19 @@ function [model, rxnIDexists] = addReaction(model, rxnID, varargin)
 %    model = addReaction(model,'newRxn1','reactionFormula','A -> B + 2 C', ...
 %                        'subSystem', 'Glycolysis', 'geneRule', 'Gene1 or Gene2');
 %
+% 
+% NOTE:
+%    Using `addReaction` to add several reactions iteratively is a very
+%    inefficient procedure, as it extends all reaction related fields one
+%    at a time, leading to a large memory reallocation overhead. There are
+%    also many checks performed which allow for a more flexible use of the
+%    function, but which simultaneously lead to a slower computation time.
+%    This function is mainly intended to be used when adding individual reactions during
+%    analysis. When adding multiple reactions, in particular when coding
+%    for a more compex methodology, please use the `addMultipleReactions`
+%    function which only performs very basic checks, but is much more
+%    efficient.
+%
 % .. Authors:
 %       - Markus Herrgard 1/12/07
 %       - Richard Que 11/13/2008 Modified the check to see if duplicate reaction already is in model by using S matrix coefficients to be able to handle larger matricies


### PR DESCRIPTION
Introducing a flag to `initCobraToolbox` that allows skipping the toolbox update. 
Changed the behaviour of all functions within the toolbox that call `initCobraToolbox` to not update the toolbox.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
