### PR TITLE
Adding a option to check for a website to prepareTest

### DIFF
--- a/src/base/install/prepareTest.m
+++ b/src/base/install/prepareTest.m
@@ -23,6 +23,7 @@ function [solversToUse] = prepareTest(varargin)
 %                   - `needsWindows`: Whether the test only works on a Windows system (default: false)
 %                   - `needsMac`: Whether the test only works on a Mac system (default: false)
 %                   - `needsLinux`: Whether the test only works on a Linux system (default: false)
+%                   - `needsWebAddress`: Tests, whether the supplied url exists (default: '') 
 %
 % OUTPUTS:
 %
@@ -96,6 +97,7 @@ parser.addParamValue('needsUnix', false, @(x) islogical(x) || x == 1 || x == 0);
 parser.addParamValue('needsLinux', false, @(x) islogical(x) || x == 1 || x == 0);
 parser.addParamValue('needsWindows', false, @(x) islogical(x) || x == 1 || x == 0);
 parser.addParamValue('needsMac', false, @(x) islogical(x) || x == 1 || x == 0);
+parser.addParamValue('needsWebAddress', '', @ischar);
 
 parser.parse(varargin{:});
 
@@ -115,6 +117,7 @@ requiredSolvers = parser.Results.requiredSolvers;
 possibleSolvers = parser.Results.requireOneSolverOf;
 excludedSolvers = parser.Results.excludeSolvers;
 preferredSolvers = parser.Results.useSolversIfAvailable;
+needsWebAddress = parser.Results.needsWebAddress;
 
 runtype = getenv('CI_RUNTYPE');
 
@@ -141,6 +144,14 @@ if linuxOnly
         if ~strcmp(computer('arch'), 'glnx64')
             errorMessage{end + 1} = 'This test only works on Linux Systems';
         end
+    end
+end
+
+if ~isempty(needsWebAddress)
+    try
+        webread(needsWebAddress);
+    catch 
+        errorMessage{end + 1} = sprintf('This tests needs to connect to %s and was unable to do so.',needsWebAddress);
     end
 end
 

--- a/test/verifiedTests/base/testIO/testLoadBiGGModel.m
+++ b/test/verifiedTests/base/testIO/testLoadBiGGModel.m
@@ -13,7 +13,7 @@ global CBTDIR
 global CBT_MISSING_REQUIREMENTS_ERROR_ID
 
 %Check the requirements (a LP solver is necessary)
-solverPkgs = prepareTest('needsLP',true,'requireOneSolverOf',{'gurobi','ibm_cplex','glpk','mosek','quadMinos'});
+solverPkgs = prepareTest('needsLP',true,'requireOneSolverOf',{'gurobi','ibm_cplex','glpk','mosek','quadMinos'},'needsWebAddress','http://bigg.ucsd.edu/api/v2/models');
 
 % save the current path
 currentDir = pwd;

--- a/test/verifiedTests/visualization/testReconMap/testReconMap.m
+++ b/test/verifiedTests/visualization/testReconMap/testReconMap.m
@@ -9,8 +9,6 @@
 %     - Original file: Alberto Noronha 21/03/2017
 %
 
-global CBTDIR
-
 % save the current path
 currentDir = pwd;
 
@@ -24,40 +22,36 @@ model = getDistributedModel('ecoli_core_model.mat');
 % Get the minerva structure
 load('minerva.mat');
 
-[status_curl, result_curl] = system(['curl -s -k --head https://vmh.uni.lu/MapViewer/']);
+prepareTest('needsWebAddress','https://vmh.uni.lu/MapViewer/')
 
 % check if the URL exists
-if status_curl == 0 && ~isempty(strfind(result_curl, '200 OK'))
-    % Set the user to testing user
-    oldLogin = minerva.login;
-    oldPassword = minerva.password;
-    
-    minerva.login = 'cobratoolbox-test';
-    minerva.password = 'test';
-    minerva.googleLicenseConsent = 'true';
+% Set the user to testing user
+oldLogin = minerva.login;
+oldPassword = minerva.password;
 
-    % FBA solution for flux distribution
-    changeCobraSolver('glpk', 'LP');
-    FBAsolution = optimizeCbModel(model, 'max');
+minerva.login = 'cobratoolbox-test';
+minerva.password = 'test';
+minerva.googleLicenseConsent = 'true';
 
-    % Send the flux distribution to MINERVA
-    response = buildFluxDistLayout(minerva, model, FBAsolution, 'Test - Flux distribution 1');
+% FBA solution for flux distribution
+changeCobraSolver('glpk', 'LP');
+FBAsolution = optimizeCbModel(model, 'max');
 
-    % 2 Correct responses, either successful or layout exists already 
-    assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
+% Send the flux distribution to MINERVA
+response = buildFluxDistLayout(minerva, model, FBAsolution, 'Test - Flux distribution 1');
 
-    % Send the subsystem layout to MINERVA
-    response = generateSubsytemsLayout(minerva, model, 'Pyruvate metabolism', '#6617B5');
+% 2 Correct responses, either successful or layout exists already
+assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
 
-    % Same as before - two possible correct responses
-    assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
-    
-    
-    minerva.login = oldLogin;
-    minerva.password = oldPassword;
-else
-    error('The remote repository cannot be reached. Please check your internet connection.');
-end
+% Send the subsystem layout to MINERVA
+response = generateSubsytemsLayout(minerva, model, 'Pyruvate metabolism', '#6617B5');
+
+% Same as before - two possible correct responses
+assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
+
+
+minerva.login = oldLogin;
+minerva.password = oldPassword;
 
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
Adding an option to check for access to a website to `prepareTest`.
This allows e.g. testReconMap to determine, if the vmh server is available and skip instead of fail, if it is not available. If something is wrong with the code, it will still fail, but it wont fail if the website is down.
The same for loadBiGGModel.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
