### PR TITLE
Implementation of slack variables return for various solver interfaces

### DIFF
--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -582,7 +582,7 @@ switch solver
         [x, f, y, w, stat, origStat] = solveGlpk(c, A, b, lb, ub, csense, osense, param);
         y = -y;
         w = -w;
-        s = b - A*x;
+        s = b - A * x; % output the slack variables
 
     case {'lindo_new', 'lindo_old'}
         %% LINDO
@@ -768,7 +768,7 @@ switch solver
                     end
                     f=c'*x;
                     %slack for blc <= A*x <= buc
-                    s = b - A*x;
+                    s = b - A * x; % output the slack variables
                 elseif strcmp(res.sol.itr.solsta,'MSK_SOL_STA_PRIM_INFEAS_CER') ||...
                         strcmp(res.sol.itr.solsta,'MSK_SOL_STA_NEAR_PRIM_INFEAS_CER') ||...
                         strcmp(res.sol.itr.solsta,'MSK_SOL_STA_DUAL_INFEAS_CER') ||...
@@ -804,7 +804,7 @@ switch solver
                     end
                     f=c'*x;
                     %slack for blc <= A*x <= buc
-                    s = b - A*x;
+                    s = b - A * x; % output the slack variables
                 elseif strcmp(res.sol.bas.solsta,'MSK_SOL_STA_PRIM_INFEAS_CER') ||...
                         strcmp(res.sol.bas.solsta,'MSK_SOL_STA_NEAR_PRIM_INFEAS_CER') ||...
                         strcmp(res.sol.bas.solsta,'MSK_SOL_STA_DUAL_INFEAS_CER') ||...
@@ -1048,8 +1048,7 @@ switch solver
                 stat = 1; % Optimal solution found
                 [x,f,y,w] = deal(resultgurobi.x,resultgurobi.objval,LPproblem.osense*resultgurobi.pi,LPproblem.osense*resultgurobi.rc);
 
-                % save the slack variables
-                s = b - A*x;
+                s = b - A * x; % output the slack variables
 
                 % save the basis
                 basis.vbasis=resultgurobi.vbasis;
@@ -1219,7 +1218,7 @@ switch solver
         % Assign results
         x = Result.x_k;
         f = osense*sum(tomlabProblem.QP.c.*Result.x_k);
-        s = b - A*x;
+        s = b - A * x; % output the slack variables
 
         origStat = Result.Inform;
         w = Result.v_k(1:length(lb));
@@ -1346,7 +1345,7 @@ switch solver
                 x = ILOGcplex.Solution.x;
                 w = ILOGcplex.Solution.reducedcost;
                 y = ILOGcplex.Solution.dual;
-                s = b - A*x;
+                s = b - A * x; % output the slack variables
             elseif origStat == 4
                 %This is likely unbounded, but could be infeasible
                 %Lets check, by solving an additional LP with no objective.
@@ -1371,7 +1370,7 @@ switch solver
                 x = ILOGcplex.Solution.x;
                 w = ILOGcplex.Solution.reducedcost;
                 y = ILOGcplex.Solution.dual;
-                s = b - A*x;
+                s = b - A * x; % output the slack variables
             elseif (origStat >= 10 && origStat <= 12) || origStat == 21 || origStat == 22
                 %Abort due to reached limit. check if there is a solution
                 %and return it.
@@ -1550,7 +1549,8 @@ switch solver
         [x,y,w,inform,PDitns,CGitns,time] = ...
             pdco(osense*c,A,b,lb,ub,d1,d2,options,x0,y0,z0,xsize,zsize);
         f = c'*x;
-        s = b - A*x;
+        s = b - A * x; % output the slack variables
+
         % inform = 0 if a solution is found;
         %        = 1 if too many iterations were required;
         %        = 2 if the linesearch failed too often;

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -1168,6 +1168,7 @@ switch solver
             f = f*osense;
             y = osense*lambda.eqlin;
             w = osense*(lambda.upper-lambda.lower);
+            s = LPproblem.b - LPproblem.A*x;
         elseif (origStat < 0)
             stat = 0; % Infeasible
         else
@@ -1549,6 +1550,7 @@ switch solver
         [x,y,w,inform,PDitns,CGitns,time] = ...
             pdco(osense*c,A,b,lb,ub,d1,d2,options,x0,y0,z0,xsize,zsize);
         f = c'*x;
+        s = b - A*x;
         % inform = 0 if a solution is found;
         %        = 1 if too many iterations were required;
         %        = 2 if the linesearch failed too often;
@@ -1586,29 +1588,45 @@ if ~strcmp(solver,'cplex_direct') && ~strcmp(solver,'mps')
     %% Assign solution
     t = etime(clock, t_start);
     if ~exist('basis','var'), basis=[]; end
-    [solution.full,solution.obj,solution.rcost,solution.dual,solution.slack,solution.solver,solution.algorithm,solution.stat,solution.origStat,solution.time,solution.basis] = ...
-        deal(x,f,w,y,s,solver,algorithm,stat,origStat,t,basis);
+    [solution.full, solution.obj, solution.rcost, solution.dual, solution.slack, ...
+     solution.solver, solution.algorithm, solution.stat, solution.origStat, ...
+     solution.time,solution.basis] = deal(x,f,w,y,s,solver,algorithm,stat,origStat,t,basis);
 elseif strcmp(solver,'mps')
     solution = [];
 end
 
-if ~strcmp(solver, 'mps') && ~strcmp(solver, 'matlab')
-    if solution.stat==1 % TODO check for matlab
-        %TODO slacks for other solvers
-        if any(strcmp(solver,{'gurobi', 'mosek', 'ibm_cplex', 'tomlab_cplex'}))
-            res1 = LPproblem.A*solution.full + solution.slack - LPproblem.b;
-            res1(~isfinite(res1))=0;
-            tmp1=norm(res1,inf);
-            if tmp1 > feasTol*1e4
-                disp(solution.origStat)
-                error(['Optimality condition (1) in solveCobraLP not satisfied, residual = ' num2str(tmp1) ', while feasTol = ' num2str(feasTol)])
+if ~strcmp(solver, 'mps')
+    if solution.stat == 1
+        if any(strcmp(solver,{'pdco', 'matlab', 'glpk', 'gurobi', 'mosek', 'ibm_cplex', 'tomlab_cplex'}))
+            if ~isempty(solution.slack) && ~isempty(solution.full)
+                res1 = LPproblem.A*solution.full + solution.slack - LPproblem.b;
+                res1(~isfinite(res1))=0;
+                tmp1=norm(res1,inf);
+                if tmp1 > feasTol*1e4
+                    disp(solution.origStat)
+                    error(['[' solver '] Optimality condition (1) in solveCobraLP not satisfied, residual = ' num2str(tmp1) ', while feasTol = ' num2str(feasTol)])
+                else
+                    if printLevel > 0
+                        fprintf(['\n > [' solver '] Optimality condition (1) in solveCobraLP satisfied.']);
+                    end
+                end
             end
 
-            res2=osense*LPproblem.c  - LPproblem.A'*solution.dual - solution.rcost;
-            tmp2=norm(res2(strcmp(LPproblem.csense,'E') | strcmp(LPproblem.csense,'=')),inf);
-            if tmp2 > feasTol*1e2
-                disp(solution.origStat)
-                error(['Optimality conditions (2) in solveCobraLP not satisfied, residual = ' num2str(tmp2) ', while optTol = ' num2str(feasTol)])
+            if ~isempty(solution.rcost) && ~isempty(solution.dual)
+                res2=osense*LPproblem.c  - LPproblem.A'*solution.dual - solution.rcost;
+                tmp2=norm(res2(strcmp(LPproblem.csense,'E') | strcmp(LPproblem.csense,'=')),inf);
+                if tmp2 > feasTol*1e2
+                    disp(solution.origStat)
+                    error(['[' solver '] Optimality conditions (2) in solveCobraLP not satisfied, residual = ' num2str(tmp2) ', while optTol = ' num2str(feasTol)])
+                else
+                    if printLevel > 0
+                        fprintf(['\n > [' solver '] Optimality condition (2) in solveCobraLP satisfied.\n']);
+                    end
+                end
+            end
+        else
+            if printLevel > 0
+                warning(['\nThe return of slack variables is not implemented for ' solver '.\n']);
             end
         end
     end
@@ -1618,8 +1636,6 @@ function [varargout] = setupOPTIproblem(c,A,b,osense,csense,solver)
 % setup the constraint coeffiecient matrix and rhs vector for OPTI solvers
 % this can be done here for lower level calls or disregarded when solver is
 % called using an OPTI object as argument
-
-
 
 % set constraint type
 e = zeros(size(A,1),1);

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -1595,14 +1595,19 @@ elseif strcmp(solver,'mps')
     solution = [];
 end
 
+% check the optimality conditions for variaous solvers
 if ~strcmp(solver, 'mps')
     if solution.stat == 1
         if any(strcmp(solver,{'pdco', 'matlab', 'glpk', 'gurobi', 'mosek', 'ibm_cplex', 'tomlab_cplex'}))
             if ~isempty(solution.slack) && ~isempty(solution.full)
+
+                % determine the residual 1
                 res1 = LPproblem.A*solution.full + solution.slack - LPproblem.b;
                 res1(~isfinite(res1))=0;
-                tmp1=norm(res1,inf);
-                if tmp1 > feasTol*1e4
+                tmp1 = norm(res1, inf);
+
+                % evaluate the optimality condition 1
+                if tmp1 > feasTol * 1e4
                     disp(solution.origStat)
                     error(['[' solver '] Optimality condition (1) in solveCobraLP not satisfied, residual = ' num2str(tmp1) ', while feasTol = ' num2str(feasTol)])
                 else
@@ -1613,9 +1618,13 @@ if ~strcmp(solver, 'mps')
             end
 
             if ~isempty(solution.rcost) && ~isempty(solution.dual)
-                res2=osense*LPproblem.c  - LPproblem.A'*solution.dual - solution.rcost;
-                tmp2=norm(res2(strcmp(LPproblem.csense,'E') | strcmp(LPproblem.csense,'=')),inf);
-                if tmp2 > feasTol*1e2
+
+                % determine the residual 2
+                res2 = osense * LPproblem.c  - LPproblem.A' * solution.dual - solution.rcost;
+                tmp2 = norm(res2(strcmp(LPproblem.csense,'E') | strcmp(LPproblem.csense,'=')), inf);
+
+                % evaluate the optimality condition 2
+                if tmp2 > feasTol * 1e2
                     disp(solution.origStat)
                     error(['[' solver '] Optimality conditions (2) in solveCobraLP not satisfied, residual = ' num2str(tmp2) ', while optTol = ' num2str(feasTol)])
                 else

--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -221,7 +221,7 @@ end
 
 % Check solver compatibility with minNorm option
 if max(minNorm) ~= 0 && ~any(strcmp(solver, {'cplex_direct', 'cplex'}))
-  error('minNorm only works for LP solver ''cplex_direct'' from this interface, use optimizeCbModel for other solvers.')
+    error('minNorm only works for LP solver ''cplex_direct'' from this interface, use optimizeCbModel for other solvers.')
 end
 
 % Save Input if selected
@@ -1128,11 +1128,11 @@ switch solver
         else
             clinprog = @(f,A,b,Aeq,beq,lb,ub,options) linprog(f,A,b,Aeq,beq,lb,ub,options);
         end
-        
+
         if optTol < 1e-8
             optTol = optTol * 100; %make sure, that we are within the range of allowed values.
         end
-        
+
         linprogOptions = optimoptions('linprog','Display',matlabPrintLevel,optToleranceParam,optTol*0.01,constTolParam,feasTol);
         %Replace all options if they are provided by the solverParameters
         %struct
@@ -1340,12 +1340,13 @@ switch solver
                 x = ILOGcplex.Solution.x;
                 w = ILOGcplex.Solution.reducedcost;
                 y = ILOGcplex.Solution.dual;
+                s = b - A*x;
             elseif origStat == 4
                 %This is likely unbounded, but could be infeasible
                 %Lets check, by solving an additional LP with no objective.
                 %If that LP has a solution, its unbounded. If it doesn't
                 %its infeasible.
-                Solution = ILOGcplex.Solution;                
+                Solution = ILOGcplex.Solution;
                 ILOGcplex.Model.obj(:) = 0;
                 ILOGcplex.solve();
                 origStatNew   = ILOGcplex.Solution.status;
@@ -1364,6 +1365,7 @@ switch solver
                 x = ILOGcplex.Solution.x;
                 w = ILOGcplex.Solution.reducedcost;
                 y = ILOGcplex.Solution.dual;
+                s = b - A*x;
             elseif (origStat >= 10 && origStat <= 12) || origStat == 21 || origStat == 22
                 %Abort due to reached limit. check if there is a solution
                 %and return it.
@@ -1588,18 +1590,18 @@ end
 if ~strcmp(solver, 'mps') && ~strcmp(solver, 'matlab')
     if solution.stat==1 % TODO check for matlab
         %TODO slacks for other solvers
-        if any(strcmp(solver,{'gurobi','mosek'}))
+        if any(strcmp(solver,{'gurobi', 'mosek', 'ibm_cplex'}))
             res1 = LPproblem.A*solution.full + solution.slack - LPproblem.b;
             res1(~isfinite(res1))=0;
             tmp1=norm(res1,inf);
-            if tmp1 > feasTol*1000
+            if tmp1 > feasTol*1e4
                 disp(solution.origStat)
                 error(['Optimality condition (1) in solveCobraLP not satisfied, residual = ' num2str(tmp1) ', while feasTol = ' num2str(feasTol)])
             end
 
             res2=osense*LPproblem.c  - LPproblem.A'*solution.dual - solution.rcost;
             tmp2=norm(res2(strcmp(LPproblem.csense,'E') | strcmp(LPproblem.csense,'=')),inf);
-            if tmp2 > feasTol*100
+            if tmp2 > feasTol*1e2
                 disp(solution.origStat)
                 error(['Optimality conditions (2) in solveCobraLP not satisfied, residual = ' num2str(tmp2) ', while optTol = ' num2str(feasTol)])
             end

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -23,8 +23,7 @@ currentDir = pwd;
 fileDir = fileparts(which('testSolveCobraLP'));
 cd(fileDir);
 
-% Dummy Model
-% http://www2.isye.gatech.edu/~spyros/LP/node2.html
+% define a dummy model: http://www2.isye.gatech.edu/~spyros/LP/node2.html
 LPproblem.c = [200; 400];
 LPproblem.A = [1 / 40, 1 / 60; 1 / 50, 1 / 50];
 LPproblem.b = [1; 1];
@@ -63,8 +62,7 @@ for k = 1:length(solverPkgs)
 
         elseif p == 2
             % solve th ecoli_core_model (csense vector is missing)
-            %This is explicitly a load, to test missing csense
-            %vector compensation
+            % Note: this is explicitly a load, to test missing csense vector compensation
             load([getDistributedModelFolder('ecoli_core_model.mat') filesep 'ecoli_core_model.mat'], 'model');
 
             % solveCobraLP
@@ -154,7 +152,7 @@ for k = 1:length(solverPkgs)
     if solverOK
         fprintf('   Running optimalityConditions tests in solveCobraLP using %s ... ', solverPkgs{k});
 
-        assert(~verifyCobraFunctionError('solveCobraLP', 'inputs', {model}));
+        assert(~verifyCobraFunctionError('solveCobraLP', 'inputs', {LPproblem}));
         fprintf(' Done.\n');
     end
 end

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -145,7 +145,7 @@ model.osense = -1;
 assert(abs(min(all_obj)) < tol + 1.0 & abs(max(all_obj)) < tol + 1.0)
 
 % only test the solvers for which the optimality conditions have been implemented
-solverPkgs = {'tomlab_cplex', 'gurobi', 'mosek', 'ibm_cplex'};
+solverPkgs = {'pdco', 'glpk', 'matlab', 'tomlab_cplex', 'gurobi', 'mosek', 'ibm_cplex'};
 
 % change the COBRA solver (LP)
 for k = 1:length(solverPkgs)

--- a/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraLP.m
@@ -144,9 +144,6 @@ model.osense = -1;
 [~, all_obj] = runLPvariousSolvers(model, solverPkgs, params);
 assert(abs(min(all_obj)) < tol + 1.0 & abs(max(all_obj)) < tol + 1.0)
 
-% load the testData based on sampling of the iJO1366 model (issue 1188)
-load('testDataSolveCobraLP.mat')
-
 % only test the solvers for which the optimality conditions have been implemented
 solverPkgs = {'tomlab_cplex', 'gurobi', 'mosek', 'ibm_cplex'};
 
@@ -157,7 +154,7 @@ for k = 1:length(solverPkgs)
     if solverOK
         fprintf('   Running optimalityConditions tests in solveCobraLP using %s ... ', solverPkgs{k});
 
-        assert(~verifyCobraFunctionError('solveCobraLP', 'inputs', {LP}));
+        assert(~verifyCobraFunctionError('solveCobraLP', 'inputs', {model}));
         fprintf(' Done.\n');
     end
 end


### PR DESCRIPTION
Slack variables are now returned for:

- `pdco`
- `glpk`
- `matlab`
- `tomlab_cplex`
- `gurobi`
- `mosek`
- `ibm_cplex`

This PR also fixes issue #1188 - the slack variables for `gurobi` are now re-calculated.

There is also a test to check if the optimality conditions are verified.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)
