### PR TITLE
Update initCobraToolbox.m

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -192,7 +192,7 @@ function initCobraToolbox(updateToolbox)
         end
 
         % Update/initialize submodules
-        [status_gitSubmodule, result_gitSubmodule] = system('git submodule update --init --remote --no-fetch --depth 1');
+        [status_gitSubmodule, result_gitSubmodule] = system('git submodule update --init --remote --no-fetch');
 
         if status_gitSubmodule ~= 0
             fprintf(strrep(result_gitSubmodule, '\', '\\'));


### PR DESCRIPTION
Removing '--depth 1' from git-submodule-update command - thus more portable to older versions of git.

*Please include a short description of enhancement here*
As remedy for this issue: https://github.com/opencobra/cobratoolbox/issues/1244

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)
