### PR TITLE
Updating Installation info wrt libssl

### DIFF
--- a/docs/source/installation/requirements.rst
+++ b/docs/source/installation/requirements.rst
@@ -62,14 +62,14 @@ Linux (Ubuntu or Debian)
 
     $ sudo apt-get install git-all curl
 
-In addition, some Matlab versions (known for 2016b and before) ship with several broken system libraries. This is particularily true for ``libssl.so.1.0.0``, which leads to Matlab crashes if accessing any ``https://`` ressource. To fix this issue, replace the shipped matlab file with the system file: 
+In addition, some MATLAB versions (known for 2016b and before) ship with several broken system libraries. This is particularily true for ``libssl.so.1.0.0``, which leads to Matlab crashes if accessing any ``https://`` ressource. To fix this issue, replace the shipped MATLAB file with the system file: 
 
 .. code-block:: console
 
     $ sudo mv <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0.old
     $ sudo cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0
 
-where ``<MATLAB_ROOT>`` is the directory of your Matlab installation.
+where ``<MATLAB_ROOT>`` is the directory of your MATLAB installation.
 
 macOS
 ^^^^^

--- a/docs/source/installation/requirements.rst
+++ b/docs/source/installation/requirements.rst
@@ -62,6 +62,15 @@ Linux (Ubuntu or Debian)
 
     $ sudo apt-get install git-all curl
 
+In addition, some Matlab versions (known for 2016b and before) ship with several broken system libraries. This is particularily true for ``libssl.so.1.0.0``, which leads to Matlab crashes if accessing any ``https://`` ressource. To fix this issue, replace the shipped matlab file with the system file: 
+
+.. code-block:: console
+
+    $ sudo mv <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0.old
+    $ sudo cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0
+
+where ``<MATLAB_ROOT>`` is the directory of your Matlab installation.
+
 macOS
 ^^^^^
 

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -3,6 +3,8 @@ Frequently Asked Questions (FAQ)
 
 .. begin-faq-marker
 
+.. contents::
+
 .. |ImageLink| image:: https://img.shields.io/badge/COBRA-forum-blue.svg
 .. _ImageLink: https://groups.google.com/forum/#!forum/cobra-toolbox
 
@@ -76,6 +78,21 @@ In order to fix this issue, follow these steps:
 -  Finish the installation of CPLEX ``12.7.1``
 -  Restart your computer
 -  Start MATLAB and the above commands again
+
+
+On Linux, MATLAB Suddenly crashes without any error
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This can happen due to some MATLAB versions shipping broken libraries, in particular ``libssl.so.1.0.0``. 
+To fix this, you will have to replace the matlab library by the system library as follows:
+
+.. code-block:: console
+
+    $ sudo mv <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0.old
+    $ sudo cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 <MATLAB_ROOT>/bin/glnxa64/libssl.so.1.0.0
+
+where ``<MATLAB_ROOT>`` is the directory of your MATLAB installation.
+
 
 Parallel programming
 --------------------

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -3,7 +3,7 @@ Frequently Asked Questions (FAQ)
 
 .. begin-faq-marker
 
-.. contents::
+.. contents::Table of contents
 
 .. |ImageLink| image:: https://img.shields.io/badge/COBRA-forum-blue.svg
 .. _ImageLink: https://groups.google.com/forum/#!forum/cobra-toolbox

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -3,7 +3,7 @@ Frequently Asked Questions (FAQ)
 
 .. begin-faq-marker
 
-.. contents::Table of contents
+.. contents:: Table of contents
 
 .. |ImageLink| image:: https://img.shields.io/badge/COBRA-forum-blue.svg
 .. _ImageLink: https://groups.google.com/forum/#!forum/cobra-toolbox


### PR DESCRIPTION
Some Matlab versions ship broken system libraries (in particular `libssl.so.1.0.0`) which need to be replaced by working ones in order to use webread without crashing matlab.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
