### PR TITLE
Simplifying findRxnFromCompartment and printRxnFormula

### DIFF
--- a/src/analysis/exploration/findRxnFromCompartment.m
+++ b/src/analysis/exploration/findRxnFromCompartment.m
@@ -14,17 +14,13 @@ function [compartmentReactions] = findRxnFromCompartment(model, compartment)
 %
 % .. Authors:
 %       - written by Diana El Assal 01/06/16
+%       - rewritten by Uri David Akavia 6-Jul-2018
 
-[reactions]=[model.rxns, printRxnFormula(model, model.rxns)]; % Form a matrix with the metabolites and its identifiers
-%Find the reactions in the compartment of interest (e.g. '[m], '[n]')
-compartmentRxns=strfind(reactions(:,2), compartment);
-index=find(~cellfun(@isempty, compartmentRxns));
-compartmentRxns=unique(reactions(index,1));
-
-%Find all reaction identifiers
-for i=1:size(compartmentRxns,1);
-    num=find(ismember(reactions(:,1),compartmentRxns{i,1}));
-    if ~isempty(num);
-        compartmentReactions(i,:)=reactions(num,:);
-    end
+if (length(compartment) == 1)
+    compartment = ['[' compartment ']'];
 end
+% Find mets in this compartment
+compartmentMets = ~cellfun(@isempty, strfind(model.mets, compartment));
+% Find reactions that involve the above mets
+compartmentRxns = model.rxns(any(model.S(compartmentMets, :)));
+compartmentReactions = [compartmentRxns, printRxnFormula(model, 'rxnAbbrList', compartmentRxns, 'printFlag', false)];

--- a/src/analysis/exploration/printRxnFormula.m
+++ b/src/analysis/exploration/printRxnFormula.m
@@ -75,15 +75,15 @@ end
 
 parser = inputParser();
 parser.addRequired('model',@isstruct) % we only check, whether its a struct, no details for speed
-parser.addParameter('rxnAbbrList',model.rxns,@(x) iscell(x) || ischar(x))
-parser.addParameter('printFlag',true,@(x) isnumeric(x) || islogical(x))
-parser.addParameter('lineChangeFlag',true,@(x) isnumeric(x) || islogical(x));
-parser.addParameter('metNameFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParameter('fid',1, @isnumeric);
-parser.addParameter('directionFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParameter('gprFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParameter('proteinFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParameter('printBounds',false,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('rxnAbbrList',model.rxns,@(x) iscell(x) || ischar(x))
+parser.addParamValue('printFlag',true,@(x) isnumeric(x) || islogical(x))
+parser.addParamValue('lineChangeFlag',true,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('metNameFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('fid',1, @isnumeric);
+parser.addParamValue('directionFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('gprFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('proteinFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParamValue('printBounds',false,@(x) isnumeric(x) || islogical(x));
 
 parser.parse(model,varargin{:})
 

--- a/src/analysis/exploration/printRxnFormula.m
+++ b/src/analysis/exploration/printRxnFormula.m
@@ -75,15 +75,15 @@ end
 
 parser = inputParser();
 parser.addRequired('model',@isstruct) % we only check, whether its a struct, no details for speed
-parser.addParamValue('rxnAbbrList',model.rxns,@(x) iscell(x) || ischar(x))
-parser.addParamValue('printFlag',true,@(x) isnumeric(x) || islogical(x))
-parser.addParamValue('lineChangeFlag',true,@(x) isnumeric(x) || islogical(x));
-parser.addParamValue('metNameFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParamValue('fid',1, @isnumeric);
-parser.addParamValue('directionFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParamValue('gprFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParamValue('proteinFlag',false,@(x) isnumeric(x) || islogical(x));
-parser.addParamValue('printBounds',false,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('rxnAbbrList',model.rxns,@(x) iscell(x) || ischar(x))
+parser.addParameter('printFlag',true,@(x) isnumeric(x) || islogical(x))
+parser.addParameter('lineChangeFlag',true,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('metNameFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('fid',1, @isnumeric);
+parser.addParameter('directionFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('gprFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('proteinFlag',false,@(x) isnumeric(x) || islogical(x));
+parser.addParameter('printBounds',false,@(x) isnumeric(x) || islogical(x));
 
 parser.parse(model,varargin{:})
 
@@ -163,9 +163,9 @@ for i = 1:length(rxnAbbrList)
         end
 
         if (model.lb(rxnID) < 0)
-            formulaStr = sprintf('%s  <=> ', formulaStr);
+            formulaStr = sprintf('%s <=> ', formulaStr);
         else
-            formulaStr = sprintf('%s  -> ', formulaStr);
+            formulaStr = sprintf('%s -> ', formulaStr);
         end
         
         for j = 1:length(prodMets)
@@ -180,8 +180,8 @@ for i = 1:length(rxnAbbrList)
         end
         formulas{i} = formulaStr;
         if (printFlag)
-            formulaStr = regexprep(formulaStr, '  <=> ', '\t<=>\t');
-            formulaStr = regexprep(formulaStr, '  -> ', '\t->\t');
+            formulaStr = regexprep(formulaStr, ' <=> ', '\t<=>\t');
+            formulaStr = regexprep(formulaStr, ' -> ', '\t->\t');
             fprintf(fid, '%s\t%s', rxnAbbr, formulaStr);
             if gprFlag
                 if (isfield(model, 'grRules'))

--- a/src/analysis/exploration/printRxnFormula.m
+++ b/src/analysis/exploration/printRxnFormula.m
@@ -110,8 +110,6 @@ if metNameFlag && ~isfield(model,'metNames')
     model.metNames = model.mets;
 end
 
-formulas = {};
-
 if (~iscell(rxnAbbrList))
     if (strcmp(rxnAbbrList, 'all'))
         rxnAbbrList = model.rxns;
@@ -122,16 +120,13 @@ if (~iscell(rxnAbbrList))
     end
 end
 
+formulas = cell(size(rxnAbbrList));
 
 for i = 1:length(rxnAbbrList)
 
     rxnAbbr = rxnAbbrList{i};
 
     rxnID = findRxnIDs(model, rxnAbbr);
-
-    if (printFlag)
-        fprintf(fid, '%s\t', rxnAbbr);
-    end
 
     if (rxnID > 0)
 
@@ -158,53 +153,56 @@ for i = 1:length(rxnAbbrList)
         formulaStr = '';
         for j = 1:length(reactMets)
             if (j > 1)
-                if (printFlag)
-                    fprintf(fid, '+ ');
-                end
-                formulaStr = [formulaStr '+ '];
+                formulaStr = sprintf('%s+ ', formulaStr);
             end
             if (abs(Sreact(j)) ~= 1)
-                if (printFlag)
-                    fprintf(fid, '%g %s ', abs(Sreact(j)), reactMets{j});
-                end
-                formulaStr = [formulaStr num2str(abs(Sreact(j))) ' ' reactMets{j} ' '];
+                formulaStr = sprintf('%s%g %s ', formulaStr, abs(Sreact(j)), reactMets{j});
             else
-                if (printFlag)
-                    fprintf(fid, '%s ', reactMets{j});
-                end
-                formulaStr = [formulaStr reactMets{j} ' '];
+                formulaStr = sprintf('%s%s ', formulaStr, reactMets{j});
             end
         end
 
         if (model.lb(rxnID) < 0)
-            if (printFlag)
-                fprintf(fid, '\t<=>\t');
-            end
-            formulaStr = [formulaStr ' <=> '];
+            formulaStr = sprintf('%s  <=> ', formulaStr);
         else
-            if (printFlag)
-                fprintf(fid, '\t->\t');
-            end
-            formulaStr = [formulaStr ' -> '];
+            formulaStr = sprintf('%s  -> ', formulaStr);
         end
-
+        
         for j = 1:length(prodMets)
             if (j > 1)
-                if (printFlag)
-                    fprintf(fid, '+ ');
-                end
-                formulaStr = [formulaStr '+ '];
+                formulaStr = sprintf('%s+ ', formulaStr);
             end
             if (Sprod(j) ~= 1)
-                if (printFlag)
-                    fprintf(fid, '%g %s ', Sprod(j), prodMets{j});
-                end
-                formulaStr = [formulaStr num2str(Sprod(j)) ' ' prodMets{j} ' '];
+                formulaStr = sprintf('%s%g %s ', formulaStr, abs(Sprod(j)), prodMets{j});
             else
-                if (printFlag)
-                    fprintf(fid, '%s ', prodMets{j});
+                formulaStr = sprintf('%s%s ', formulaStr, prodMets{j});
+            end
+        end
+        formulas{i} = formulaStr;
+        if (printFlag)
+            formulaStr = regexprep(formulaStr, '  <=> ', '\t<=>\t');
+            formulaStr = regexprep(formulaStr, '  -> ', '\t->\t');
+            fprintf(fid, '%s\t%s', rxnAbbr, formulaStr);
+            if gprFlag
+                if (isfield(model, 'grRules'))
+                    fprintf(fid, '\t%s', model.grRules{rxnID});
+                elseif (isfield(model,'rules'))
+                    rule = regexprep(model.rules{rxnID},'|','or');
+                    rule = regexprep(rule,'&','and');
+                    rule = regexprep(rule,'x\((?<id>[0-9]+)\)','${model.genes{num2str($1)}}');
+                    fprintf(fid, '\t%s', rule);
                 end
-                formulaStr = [formulaStr prodMets{j} ' '];
+            end
+            if proteinFlag
+                if (isfield(model, 'rules'))
+                    rule = regexprep(model.rules{rxnID},'|','or');
+                    rule = regexprep(rule,'&','and');
+                    rule = regexprep(rule,'x\((?<id>[0-9]+)\)','${model.proteins{num2str($1)}}');
+                    fprintf(fid, '\t%s', rule);
+                end
+            end
+            if printBounds
+                fprintf('\tlb:%f\tub:%f',model.lb(rxnID),model.ub(rxnID));
             end
         end
     else
@@ -212,51 +210,12 @@ for i = 1:length(rxnAbbrList)
             fprintf(fid, 'not in model');
         end
         formulaStr = 'NA';
+        formulas{i} = formulaStr;
     end
-    if printFlag && gprFlag
-        if (rxnID > 0) 
-            if (isfield(model, 'grRules'))
-                if (isempty(model.grRules{rxnID}))
-                    fprintf(fid, '\t');
-                else
-                    fprintf(fid, '\t%s', model.grRules{rxnID});
-                end
-            elseif (isfield(model,'rules'))
-                if (isempty(model.rules{rxnID}))
-                    fprintf(fid, '\t');
-                else            
-                    rule = regexprep(model.rules{rxnID},'|','or');
-                    rule = regexprep(rule,'&','and');
-                    rule = regexprep(rule,'x\((?<id>[0-9]+)\)','${model.genes{num2str($1)}}');                
-                    fprintf(fid, '\t%s', rule);
-                end
-            end
-                
-        end
-    end
-    if printFlag && proteinFlag
-        if (rxnID > 0) && (isfield(model, 'rules'))            
-            if (isempty(model.rules{rxnID}))
-                fprintf(fid, '\t');
-            else            
-                rule = regexprep(model.rules{rxnID},'|','or');
-                rule = regexprep(rule,'&','and');
-                rule = regexprep(rule,'x\((?<id>[0-9]+)\)','${model.proteins{num2str($1)}}');                
-                fprintf(fid, '\t%s', rule);
-            end
-        end
-    end
-    if printBounds && printFlag
-        if rxnID > 0
-            fprintf('\tlb:%f\tub:%f',model.lb(rxnID),model.ub(rxnID));
-        end
-    end
-    if (lineChangeFlag) && printFlag
+    if (lineChangeFlag && printFlag)
         fprintf(fid, '\n');
     end
-    formulas{i} = formulaStr;
 end
-formulas = formulas';
 
 % %pass out a character string if only one reaction in the abbreviation list
 % if length(rxnAbbrList)==1


### PR DESCRIPTION
I simplified findRxnFromCompartment and I think it sped up a bit.
I tried simplifying printRxnFormula - the tests will fail, since I can't match up the space composition with the reference data. It seems quirks due to strcat not including spaces at the end of a string, and similar issues.
Would it be possible to change the reference data? If not, can someone help me match the results to the reference data.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
