### PR TITLE
feat: rxnMetaNetXID as new definition

### DIFF
--- a/docs/source/notes/COBRAModelFields.md
+++ b/docs/source/notes/COBRAModelFields.md
@@ -49,6 +49,7 @@ The following fields are defined in the COBRA toolbox. IF the field is present i
 |`model.rxnECNumbers`| `n x 1` | Column Cell Array of Strings | E.C. number for each reaction. | 
 |`model.rxnReferences`| `n x 1` | Column Cell Array of Strings | Description of references for each corresponding reaction. | 
 |`model.rxnKEGGID`| `n x 1` | Column Cell Array of Strings | Formula for each reaction in the KEGG format. | 
+|`model.rxnMetaNetXID`| `n x 1` | Column Cell Array of Strings | MetaNetX identifier of the reaction | 
 |`model.rxnSBOTerms`| `n x 1` | Column Cell Array of Strings | The SBO Identifier associated with the reaction | 
 |`model.subSystems`| `n x 1` | Column Cell Array of Cell Arrays of Strings | subSystem assignment for each reaction | 
 |`model.description`| `` | String or Struct | Name of a file the model is loaded from. | 

--- a/src/base/io/definitions/COBRA_structure_fields.csv
+++ b/src/base/io/definitions/COBRA_structure_fields.csv
@@ -36,6 +36,7 @@ rxnNotes	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))					''		Column Cel
 rxnECNumbers	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	ec-code	is;isVersionOf	bioQualifier	rxns	''	^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$	Column Cell Array of Strings	E.C. number for each reaction.	'false(1)'	cell
 rxnReferences	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	pubmed	isDescribedBy	bioQualifier	rxns	''	^\d+$	Column Cell Array of Strings	Description of references for each corresponding reaction.	'false(1)'	cell
 rxnKEGGID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	kegg.reaction;kegg	is	bioQualifier	rxns	''	^R\d+$	Column Cell Array of Strings	Formula for each reaction in the KEGG format.	'false(1)'	cell
+rxnMetaNetXID	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	metanetx.reaction	is	bioQualifier	rxns	''	^MNXR\d+$	Column Cell Array of Strings	MetaNetX identifier of the reaction	'false(1)'	cell
 rxnSBOTerms	rxns	1	iscell(x) && all(cellfun(@(y) ischar(y) , x))	sbo	hasProperty	bioQualifier	rxns	''	^SBO:\d{7}$	Column Cell Array of Strings	The SBO Identifier associated with the reaction	'false(1)'	cell
 subSystems	rxns	1	iscell(x) && all(cellfun(@(y) ischar(strjoin([y(:)],';')) , x))					{''}		Column Cell Array of Cell Arrays of Strings	subSystem assignment for each reaction	'false(1)'	cell
 description	NaN	NaN	ischar(x) || isstruct(x)					struct()		String or Struct	Name of a file the model is loaded from.	'false(1)'	char


### PR DESCRIPTION
**Problem this PR addresses:**

MetaNetX **_metabolite_** IDs are currently a recognized model field (`metMetaNetXID`), but MetaNetX **_reaction_** IDs are not. The function `addMIRIAMAnnotations` exists for adding any type of MIRIAM annotation to the model that is not in the definitions; however, if used for the MetaNetX reaction IDs,  they will be stored in the COBRA structure as `rxnismetanetx__46__reactionID` (which is inconsistent with the metabolite counterpart naming style).

In this PR, MetaNetX reaction IDs were added as definition in `COBRA_structure_fields.csv` and `COBRAModelFields.md`. With this, the IDs will be now stored in the COBRA structure as `rxnMetaNetXID`, consistent with `metMetaNetXID`.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)