### PR TITLE
Updated minerva redirect and response fix

### DIFF
--- a/src/visualization/maps/ReconMap/generateSubsystemLayouts.m
+++ b/src/visualization/maps/ReconMap/generateSubsystemLayouts.m
@@ -21,7 +21,7 @@ function [] = generateSubsystemLayouts( minerva, cobra_model, color )
             response = generateSubsytemsLayout(cobra_model, subsystems(i), color);
         end
 
-        if ~isempty(regexp(response, '"status":"OK"'))
+        if ~isempty(regexp(response, strcat('"creator":"', minerva.login, '"')))
             result = [subsystems(i), ' successfully sent to ReconMap.'];
             disp(result)
         else

--- a/src/visualization/maps/ReconMap/postMINERVArequest.m
+++ b/src/visualization/maps/ReconMap/postMINERVArequest.m
@@ -28,13 +28,13 @@ function [ response ] = postMINERVArequest(login, password, map, googleLicenseCo
 %    xmlresponse = urlread(minerva_servlet, 'POST', content);
 
     headerlength = ' ';
-   loginURL = strcat({'curl'}, {headerlength} , {'-X POST -c - --data "login='}, login, {'&password='}, password, {'" https://vmh.uni.lu/MapViewer/api/doLogin/'});
+   loginURL = strcat({'curl'}, {headerlength} , {'-X POST -c - --data "login='}, login, {'&password='}, password, {'" https://vmh.uni.lu/minerva/api/doLogin/'});
    [x , command_out] = system(char(loginURL));
    if isempty(regexp(command_out, 'Invalid credentials'))
        [startIndex,endIndex] = regexp(command_out,'MINERVA_AUTH_TOKEN\s+(.*)$');
        split = strsplit(command_out(startIndex:endIndex), '\t');
        minerva_auth_token = split{2};
-       minerva_server = strcat('https://vmh.uni.lu/MapViewer/api/projects/', map, '/overlays/');
+       minerva_server = strcat('https://vmh.uni.lu/minerva/api/projects/', map, '/overlays/');
        filename = strcat(identifier, '.txt');
        curl_str = strcat({'curl'}, {headerlength}, '-X POST --data "content=', content, '&description=', identifier ,'&filename=', filename, '&name=', identifier, {'&googleLicenseConsent='}, googleLicenseContent, {'" --cookie "MINERVA_AUTH_TOKEN='}, minerva_auth_token, {'" '}, minerva_server);
        [x , response] = system(char(curl_str));

--- a/test/verifiedTests/visualization/testReconMap/testReconMap.m
+++ b/test/verifiedTests/visualization/testReconMap/testReconMap.m
@@ -22,7 +22,7 @@ model = getDistributedModel('ecoli_core_model.mat');
 % Get the minerva structure
 load('minerva.mat');
 
-prepareTest('needsWebAddress','https://vmh.uni.lu/MapViewer/')
+prepareTest('needsWebAddress','https://vmh.uni.lu/minerva/')
 
 % check if the URL exists
 % Set the user to testing user
@@ -41,13 +41,13 @@ FBAsolution = optimizeCbModel(model, 'max');
 response = buildFluxDistLayout(minerva, model, FBAsolution, 'Test - Flux distribution 1');
 
 % 2 Correct responses, either successful or layout exists already
-assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
+assert(~isempty(regexp(response, strcat('"creator":"', minerva.login, '"'))) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
 
 % Send the subsystem layout to MINERVA
 response = generateSubsytemsLayout(minerva, model, 'Pyruvate metabolism', '#6617B5');
 
 % Same as before - two possible correct responses
-assert(~isempty(regexp(response, 'Overlay generated successfully!')) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
+assert(~isempty(regexp(response, strcat('"creator":"', minerva.login, '"'))) | ~isempty(regexp(response, 'ERROR. Layout with given identifier ("Pyruvate metabolism") already exists.')));
 
 
 minerva.login = oldLogin;


### PR DESCRIPTION
With the new MINERVA update, there were 2 issues in need of solving

- Redirect `MapViewer` not working at the moment so replace with `minerva` in all calls
- Response format now different when overlay has been sent, so the test was failing - parsing user of the submitter to recognize that the overlay is successfully sent

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
