### PR TITLE
Small fix in writeCbmodel

### DIFF
--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -44,8 +44,10 @@ function outmodel = writeCbModel(model, varargin)
 
 newKeyWords = {'format', 'fileName', 'compSymbols', 'compNames'};
 
+% set default values
 supportedSBML = 3;
 supportedSBMLv = 1;
+fileName = '';
 
 % We can assume, that the old syntax is not used, if there is no varargin
 % i.e. if numel varargin == 0


### PR DESCRIPTION
Currently when the old style syntax is used and no filename is given, `writeCbmodel` errors with a missing argument exception.
This pr fixes the behaviour and makes the function request a name, if none is provided.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
