### PR TITLE
Adjusting Cobra parameter update to those parameters defined

### DIFF
--- a/src/base/solvers/changeCobraSolverParams.m
+++ b/src/base/solvers/changeCobraSolverParams.m
@@ -24,7 +24,30 @@ function changeOK = changeCobraSolverParams(solverType, paramName, paramValue)
 %    * 3 - More detailed information
 %    * > 10 - Pause statements, and maximal printing (debug mode)
 %
-%  * primalOnly:    {(0), 1}; 1 = only return the primal vector (lindo solvers)
+%  * primalOnly:        {(0), 1}; 1 = only return the primal vector (lindo solvers)
+%
+%  * saveInput:         Saves LPproblem to filename specified in field.
+%                       i.e. parameters.saveInput = 'LPproblem.mat';
+%
+%  * minNorm:           {(0), scalar , `n x 1` vector}, where `[m, n] = size(S)`;
+%                       If not zero then, minimise the Euclidean length
+%                       of the solution to the LP problem. minNorm ~1e-6 should be
+%                       high enough for regularisation yet maintain the same value for
+%                       the linear part of the objective. However, this should be
+%                       checked on a case by case basis, by optimization with and
+%                       without regularisation.
+%
+%  * optTol             Optimality tolerance
+%
+%  * feasTol            Feasibility tolerance
+%
+%  * timeLimit:         Global solver time limit
+%
+%  * intTol:            Integrality tolerance
+%
+%  * relMipGapTol:      Relative MIP gap tolerance
+%
+%  * logFile:           Log file (for CPLEX)
 %
 % NOTE:
 %
@@ -41,6 +64,7 @@ function changeOK = changeCobraSolverParams(solverType, paramName, paramValue)
 %       - Markus Herrgard, 5/3/07
 %       - Jan Schellenberger, 09/28/09
 %       - Ronan Fleming, 12/07/09 commenting of input/output
+%       - Thomas Pfau 2018 - Update to allow all solver Types 
 
 
 global CBT_LP_PARAMS;

--- a/src/base/solvers/changeCobraSolverParams.m
+++ b/src/base/solvers/changeCobraSolverParams.m
@@ -13,19 +13,6 @@ function changeOK = changeCobraSolverParams(solverType, paramName, paramValue)
 % OUTPUT:
 %    changeOK:          Logical inicator that supplied parameter is allowed (= 1)
 %
-% Allowed MILP parameter names:
-%
-%    * timeLimit:       Global time limit
-%    * intTol:          Integer tolerance
-%    * relMipGapTol:    Relative MIP gap tolerance
-%    * logFile:         Internal log file for solver
-%    * printLevel:      Print level for solver
-%
-% Allowed LP parameter names:
-%
-%    * optTol:          Optimal objective accuracy tolerance
-%    * teasTol:         Constraint feasibilty tolerance
-%    * minNorm:         {(0), scalar , `n` x 1 vector}, where `[m,n]=size(S)`;
 %
 % Explanation on parameters:
 %
@@ -41,6 +28,8 @@ function changeOK = changeCobraSolverParams(solverType, paramName, paramValue)
 %
 % NOTE:
 %
+%    The available solver Parameters can be obtained by calling
+%    getSolverParamsOptionsForType().
 %    If input argument `minNorm` is not zero, then minimise the Euclidean length
 %    of the solution to the LP problem. `minNorm ~1e-6` should be
 %    high enough for regularisation yet maintain the same value for
@@ -53,6 +42,13 @@ function changeOK = changeCobraSolverParams(solverType, paramName, paramValue)
 %       - Jan Schellenberger, 09/28/09
 %       - Ronan Fleming, 12/07/09 commenting of input/output
 
+
+global CBT_LP_PARAMS;
+global CBT_MILP_PARAMS;
+global CBT_QP_PARAMS;
+global CBT_MIQP_PARAMS;
+global CBT_NLP_PARAMS;
+% get the parameter structs
 changeOK = false;
 
 if strcmp(paramName,'objTol')
@@ -60,36 +56,11 @@ if strcmp(paramName,'objTol')
     paramName='optTol';
 end
 
-allowedLPparams = {'optTol', 'primalOnly', 'minNorm', 'printLevel','feasTol'};
-allowedQPparams = {'minNorm', 'printLevel'};
-allowedMILPparams = {'intTol','relMipGapTol','timeLimit','logFile','printLevel'};
-
-% Only LP, QP and MILP are currently included
-switch solverType
-    case 'LP'
-        if (ismember(paramName,allowedLPparams))
-            global CBT_LP_PARAMS;
-            CBT_LP_PARAMS.(paramName) = paramValue;
-            changeOK = true;
-        else
-            error(['Parameter name ' paramName ' not allowed for LP solvers']);
-        end
-    case 'QP'
-         if (ismember(paramName,allowedQPparams))
-            global CBT_QP_PARAMS;
-            CBT_QP_PARAMS.(paramName) = paramValue;
-            changeOK = true;
-        else
-            error(['Parameter name ' paramName ' not allowed for QP solvers']);
-        end
-    case 'MILP'
-        if (ismember(paramName,allowedMILPparams))
-            global CBT_MILP_PARAMS;
-            CBT_MILP_PARAMS.(paramName) = paramValue;
-            changeOK = true;
-        else
-            error(['Parameter name ' paramName ' not allowed for MILP solvers']);
-        end
-    otherwise
-        error(['solver type ' solverType ' not valid']);
+allowedParameters = getCobraSolverParamsOptionsForType(solverType);
+if (ismember(paramName,allowedParameters))   
+    eval(['CBT_' solverType '_PARAMS.(paramName) = paramValue;']);
+    changeOK = true;
+else
+    error(['Parameter name ' paramName ' not allowed for LP solvers']);
+end
 end

--- a/src/base/solvers/getCobraSolverParamsOptionsForType.m
+++ b/src/base/solvers/getCobraSolverParamsOptionsForType.m
@@ -67,7 +67,8 @@ switch solverType
                       'printLevel',...      % print level
                       'saveInput', ...      % save the input to a file (specified)
                       'solver'};            % the solver to use
-
+    otherwise
+        error('Solver type %s is not supported by the Toolbox');
 end
 
 


### PR DESCRIPTION
THis PR updates the `changeCobraSolverParams` function to allow all known parameters for the individual solver Types and removes the restriction of this function to a minimal subset of parameters.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
