### PR TITLE
Check SBML Charges/Formulas

### DIFF
--- a/src/base/io/utilities/writeSBML.m
+++ b/src/base/io/utilities/writeSBML.m
@@ -169,8 +169,14 @@ for i=1:size(model.mets, 1)
     
     if isfield(model, 'metCharges')
         if ~isnan(model.metCharges(i))
-            tmp_metCharge=model.metCharges(i);
-            tmp_isSetfbc_charge=1;
+            if mod(model.metCharges(i),1) ~= 0
+                warning('Metabolite %s has a charge of %f. FBC 2.1 only allows integer values for charges.\nDiscarding the value.',model.mets{i},model.metCharges(i));
+                tmp_metCharge=0;
+                tmp_isSetfbc_charge=0;
+            else
+                tmp_metCharge=model.metCharges(i);
+                tmp_isSetfbc_charge=1;
+            end
         else
             tmp_metCharge=0;
             tmp_isSetfbc_charge=0;

--- a/src/base/io/utilities/writeSBML.m
+++ b/src/base/io/utilities/writeSBML.m
@@ -162,7 +162,17 @@ for i=1:size(model.mets, 1)
     end
     
     if isfield(model, 'metFormulas')
-        tmp_metFormulas = model.metFormulas{i};
+        % check the chemical formula
+        tmp_metFormulas = model.metFormulas{i};        
+        if ~isempty(model.metFormulas{i})
+            coefs = regexp(model.metFormulas{i},'(?<nums>[\.0-9]+)','names');
+            intVals = cellfun(@(x) mod(str2double(x),1) == 0,{coefs.nums});
+            if any(~intVals)
+                warning('Metabolite %s has formula %s. FBC 2.1 only allows integer values for coefficients.\nDiscarding the formula.',model.mets{i},model.metFormulas{i});
+                tmp_metFormulas = emptyChar;
+            end
+        end
+        
     else
         tmp_metFormulas=emptyChar; %cell(0,1)% {''};%0;%emptyChar;
     end


### PR DESCRIPTION
The FBC packages places some restrictions on the use of  the charge and formulas fields for species. 
This PR adds some checks to avoid writing invalid SBML files (non integer coefficients). 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
