### PR TITLE
Storing invalid charges in Notes

### DIFF
--- a/src/base/io/utilities/writeSBML.m
+++ b/src/base/io/utilities/writeSBML.m
@@ -160,6 +160,10 @@ for i=1:size(model.mets, 1)
     else
         tmp_metName=emptyChar;
     end
+    % create annotations and notes
+    tmp_species.metaid=tmp_species.id;  % set the metaid for each species
+    [tmp_annot,met_notes] = makeSBMLAnnotationString(model,tmp_species.metaid,'met',i);
+
     
     if isfield(model, 'metFormulas')
         % check the chemical formula
@@ -169,7 +173,8 @@ for i=1:size(model.mets, 1)
             intVals = cellfun(@(x) mod(str2double(x),1) == 0,{coefs.nums});
             if any(~intVals)
                 warning('Metabolite %s has formula %s. FBC 2.1 only allows integer values for coefficients.\nDiscarding the formula.',model.mets{i},model.metFormulas{i});
-                tmp_metFormulas = emptyChar;
+                met_notes(end+1,1:2) = {'FORMULA',tmp_metFormulas};
+                tmp_metFormulas = emptyChar;                
             end
         end
         
@@ -181,6 +186,7 @@ for i=1:size(model.mets, 1)
         if ~isnan(model.metCharges(i))
             if mod(model.metCharges(i),1) ~= 0
                 warning('Metabolite %s has a charge of %f. FBC 2.1 only allows integer values for charges.\nDiscarding the value.',model.mets{i},model.metCharges(i));
+                met_notes(end+1,1:2) = {'CHARGE',num2str(model.metCharges(i))};
                 tmp_metCharge=0;
                 tmp_isSetfbc_charge=0;
             else
@@ -219,13 +225,11 @@ for i=1:size(model.mets, 1)
     tmp_species.fbc_chemicalFormula=tmp_metFormulas;
     tmp_species.isSetfbc_charge=tmp_isSetfbc_charge;
     %% Add annotations for metaoblites to the reconstruction
-    tmp_species.metaid=tmp_species.id;  % set the metaid for each species
-    [tmp_annot,met_notes] = makeSBMLAnnotationString(model,tmp_species.metaid,'met',i);
     
     tmp_note = emptyChar;
     if ~isempty(met_notes)
         for noteid = 1:size(met_notes,1)
-            tmp_note = [ tmp_note ' <p>' regexprep(met_notes{noteid,1},'^rxn','') ':' met_notes{noteid,2} '</p>'];
+            tmp_note = [ tmp_note ' <p>' regexprep(met_notes{noteid,1},'^met','') ':' met_notes{noteid,2} '</p>'];
         end
     end
     if isfield(model,'metNotes')

--- a/src/base/io/writeCbModel.m
+++ b/src/base/io/writeCbModel.m
@@ -59,8 +59,13 @@ if numel(varargin) > 0
     if ischar(varargin{1})        
         if any(ismember(varargin{1}, newKeyWords))
             legacySignature = false;            
-        else
-            legacySignature = true;            
+        else 
+            if ~isempty(regexp(varargin{1},'\.','ONCE')) % this is a file name.
+                varargin = {'fileName', varargin{1}, varargin{2:end}};
+                legacySignature = false;            
+            else
+               legacySignature = true;            
+            end
         end
     else
         %If its not a char, its not the old signature, as that signature


### PR DESCRIPTION
Until the new FBC package finally provides key/value pairs, we will put invalid charges/formulas into the notes section. We read this part anyways and therefore don't loose model information during IO, and do not need to adapt code in the future as it will stay for compatability anyways.

This PR also adds a simplification for writeCbModel which allows its use as:
writeCbModel(model,'FileName') 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
