### PR TITLE
Further updates for Extensive TestFurther adjustments for the extensive test suite.

### DIFF
--- a/test/verifiedTests/analysis/testFBA/testMinimizeModelFlux.m
+++ b/test/verifiedTests/analysis/testFBA/testMinimizeModelFlux.m
@@ -29,21 +29,21 @@ for k = 1:length(solverPkgs.LP)
     % qpng does not support this model size, so we don't use quadratic
     % minimzation.
     sol = minimizeModelFlux(currentmodel,'min','one');
-    assert(sol.x(end) == 0);
+    assert(abs(sol.x(end)) < tol);
     sol = minimizeModelFlux(currentmodel);
-    assert(sol.x(end) == 12000); %Since its reversible, exchangers cycle and all rev reactions cycle.
+    assert(abs(sol.x(end) - 12000) <= tol); %Since its reversible, exchangers cycle and all rev reactions cycle.
     sol = minimizeModelFlux(currentmodel,'max','one'); %same as before.
-    assert(sol.x(end) == 12000); %Since its reversible, exchangers cycle and all rev reactions cycle.
+    assert(abs(sol.x(end) - 12000 ) <= tol); %Since its reversible, exchangers cycle and all rev reactions cycle.
     currentmodel.osenseStr = 'min';
     modelChanged = changeRxnBounds(currentmodel,'R3',5,'l');
     sol = minimizeModelFlux(modelChanged);
-    assert(sol.x(end) == 20); %Can only come from the cycle
+    assert(abs(sol.x(end) - 20)  <= tol); %Can only come from the cycle
     sol = minimizeModelFlux(modelChanged,'max');
-    assert(sol.x(end) == 11000); %MAx flux through C-> E and Exchangers, + 3 reactions from the cycle.
+    assert(abs(sol.x(end) - 11000)  <= tol); %MAx flux through C-> E and Exchangers, + 3 reactions from the cycle.
     modelChanged = changeRxnBounds(currentmodel,'EX_E',5,'l'); %Force production of E
     sol = minimizeModelFlux(modelChanged);
     modelChanged = rmfield(modelChanged,'osenseStr');
-    assert(sol.x(end) == 25); %Flux -> A -> B -> C -> E -> 
+    assert(abs(sol.x(end) - 25)  <= tol); %Flux -> A -> B -> C -> E -> 
 end
 
 % change the directory

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -22,7 +22,10 @@ tol = 1e-4;
 
 % define the solver packages to be used to run this test, can't use
 % dqq/Minos for the parallel part.
-solverPkgs = prepareTest('needsLP',true,'needsMILP',true,'needsQP',true,'useSolversIfAvailable',{'ibm_cplex'},'excludeSolvers',{'dqqMinos','quadMinos'});
+solverPkgs = prepareTest('needsLP',true,'needsMILP',true,'needsQP',true,...
+                         'useSolversIfAvailable',{'ibm_cplex'},...
+                         'excludeSolvers',{'dqqMinos','quadMinos'},...
+                         'minimalMatlabSolverVersion',8.0);
 
 
 
@@ -143,7 +146,7 @@ end
 %there
 pttoolboxPath = which('parpool');
 % here, we can use dqq and quadMinos again, because this is not parallel.
-solverPkgs = prepareTest('needsLP',true,'needsMILP',true,'needsQP',true,'useSolversIfAvailable',{'ibm_cplex'});
+solverPkgs = prepareTest('needsLP',true,'needsMILP',true,'needsQP',true,'useSolversIfAvailable',{'ibm_cplex'},'minimalMatlabSolverVersion',8.0);
 if ~isempty(pttoolboxPath)
     %We also have to shut down the parallel pool, as otherwise problems
     %occur with the pool.

--- a/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
+++ b/test/verifiedTests/base/testSolvers/testSolveCobraQP.m
@@ -23,7 +23,9 @@ tol = 1e-4;
 
 % test solver packages
 useIfAvailable = {'tomlab_cplex','ibm_cplex', 'gurobi','qpng','ibm_cplex','mosek'};
-solverPkgs = prepareTest('needsQP',true,'useSolversIfAvailable', useIfAvailable);
+% pdco is a normalizing solver not a general purpose QP solver, so it will
+% fail the test
+solverPkgs = prepareTest('needsQP',true,'useSolversIfAvailable', useIfAvailable,'excludeSolvers',{'pdco'});
 
 %QP Solver test: http://tomopt.com/docs/quickguide/quickguide005.php
 


### PR DESCRIPTION
Further adjustments for the extensive test suite.
prepareTest now allows to remove the matlab solver if the optimization toolbox is known not to cope with the problem up to a specific version.
Added tolerances for some tests. 
**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
