### PR TITLE
Exclude qpng

### DIFF
--- a/test/verifiedTests/analysis/testMOMA/testMOMA.m
+++ b/test/verifiedTests/analysis/testMOMA/testMOMA.m
@@ -30,7 +30,7 @@ cd(fileDir);
 model = getDistributedModel('ecoli_core_model.mat');
 
 % test solver packages
-solverPkgs = prepareTest('needsLP', true, 'needsQP', true, 'excludeSolvers', 'pdco');
+solverPkgs = prepareTest('needsLP', true, 'needsQP', true, 'excludeSolvers', {'qpng','pdco'});
 
 % define solver tolerances
 QPtol = 0.02;


### PR DESCRIPTION
Exclude the qpng solver from the MOMA test.
qpng does not work with normal models due to them commonly not being full rank. 
We might need to find a way to make those models fit to the qpng scheme.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
