### PR TITLE
Utility functions

### DIFF
--- a/src/analysis/exploration/getModelSizes.m
+++ b/src/analysis/exploration/getModelSizes.m
@@ -15,7 +15,7 @@ function [nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
 %    nGenes:    The number of genes in the model
 %    nComps:    The number of compartments in the model
 
-[nRxns,nMets] = size(model.S);
+[nMets,nRxns] = size(model.S);
 
 nCtrs = 0;
 nVars = 0;

--- a/src/analysis/exploration/getModelSizes.m
+++ b/src/analysis/exploration/getModelSizes.m
@@ -1,15 +1,15 @@
-function [nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
+function [nMets, nRxns, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
 % Get the sizes of the basic fields of the model structure
 %
 % USAGE:
-% [nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
+%    [nMets, nRxns, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
 %
 % INPUT:
 %    model:     A COBRA model structure
 %
-% OUTPUT:
-%    nRxns:     The number of reactions in the model
+% OUTPUTS:
 %    nMets:     The number of metabolites in the model
+%    nRxns:     The number of reactions in the model
 %    nCtrs:     The number of constraints in the model
 %    nVars:     The number of variables in the model
 %    nGenes:    The number of genes in the model

--- a/src/analysis/exploration/getModelSizes.m
+++ b/src/analysis/exploration/getModelSizes.m
@@ -1,0 +1,37 @@
+function [nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
+% Get the sizes of the basic fields of the model structure
+%
+% USAGE:
+% [nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model)
+%
+% INPUT:
+%    model:     A COBRA model structure
+%
+% OUTPUT:
+%    nRxns:     The number of reactions in the model
+%    nMets:     The number of metabolites in the model
+%    nCtrs:     The number of constraints in the model
+%    nVars:     The number of variables in the model
+%    nGenes:    The number of genes in the model
+%    nComps:    The number of compartments in the model
+
+[nRxns,nMets] = size(model.S);
+
+nCtrs = 0;
+nVars = 0;
+nComps = 0;
+nGenes = 0;
+if isfield(model,'C')
+    nCtrs = size(model.C,1);
+end
+if isfield(model,'E')
+    nVars = size(model.E,2);
+end
+
+if isfield(model,'comps')
+    nComps = size(model.comps,1);
+end
+
+if isfield(model,'genes')
+    nGenes = size(model.genes,1);
+end

--- a/test/verifiedTests/analysis/testExploration/testGetModelSizes.m
+++ b/test/verifiedTests/analysis/testExploration/testGetModelSizes.m
@@ -17,16 +17,16 @@ currentDir = cd(fileDir);
 model = getDistributedModel('ecoli_core_model.xml'); % need xml here, to be sure about comps.
 
 % get basic info 
-[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+[nMets, nRxns, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
 assert(nRxns == 95 && nMets == 72 && nCtrs == 0 && nVars == 0 && nGenes == 137 && nComps == 2);
 
 % check that vars are determined correctly
-model = addCOBRAVariables(model,'Blubb');
-[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+model = addCOBRAVariables(model,'TestVariable');
+[nMets, nRxns, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
 assert(nRxns == 95 && nMets == 72 && nCtrs == 0 && nVars == 1 && nGenes == 137 && nComps == 2);
 
 model = addCOBRAConstraints(model,model.rxns(1),3);
-[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+[nMets, nRxns, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
 assert(nRxns == 95 && nMets == 72 && nCtrs == 1 && nVars == 1 && nGenes == 137 && nComps == 2);
 
 %Return to original directory

--- a/test/verifiedTests/analysis/testExploration/testGetModelSizes.m
+++ b/test/verifiedTests/analysis/testExploration/testGetModelSizes.m
@@ -1,0 +1,33 @@
+% The COBRAToolbox: testGetModelSizes.m
+%
+% Purpose:
+%     - tests the getModelSizes function. 
+%
+% Authors:
+%     - Thomas Pfau - 2018
+%
+
+
+% initialize the test
+fileDir = fileparts(which('testSearchModel'));
+% save the current path
+currentDir = cd(fileDir);
+
+% load model
+model = getDistributedModel('ecoli_core_model.xml'); % need xml here, to be sure about comps.
+
+% get basic info 
+[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+assert(nRxns == 95 && nMets == 72 && nCtrs == 0 && nVars == 0 && nGenes == 137 && nComps == 2);
+
+% check that vars are determined correctly
+model = addCOBRAVariables(model,'Blubb');
+[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+assert(nRxns == 95 && nMets == 72 && nCtrs == 0 && nVars == 1 && nGenes == 137 && nComps == 2);
+
+model = addCOBRAConstraints(model,model.rxns(1),3);
+[nRxns, nMets, nCtrs, nVars, nGenes, nComps] = getModelSizes(model);
+assert(nRxns == 95 && nMets == 72 && nCtrs == 1 && nVars == 1 && nGenes == 137 && nComps == 2);
+
+%Return to original directory
+cd(currentDir);


### PR DESCRIPTION
Adding a function that determines the basic model field sizes. 
Allows to avoid lengthy code to determine `nRxns,nMets,nCtrs,nVars` which is often necessary when modifying COBRA Problem structures derived from a model. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
