### PR TITLE
Cplex as MIQP solver

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -328,7 +328,7 @@ function initCobraToolbox(updateToolbox)
     SOLVERS.dqqMinos.type = {'LP'};
     SOLVERS.glpk.type = {'LP', 'MILP'};
     SOLVERS.gurobi.type = {'LP', 'MILP', 'QP', 'MIQP'};
-    SOLVERS.ibm_cplex.type = {'LP', 'MILP', 'QP'};
+    SOLVERS.ibm_cplex.type = {'LP', 'MILP', 'QP', 'MIQP'};
     SOLVERS.matlab.type = {'LP', 'NLP'};
     SOLVERS.mosek.type = {'LP', 'QP'};
     SOLVERS.pdco.type = {'LP', 'QP'};

--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -324,7 +324,7 @@ function initCobraToolbox(updateToolbox)
                      'mosek',struct(),...
                      'matlab',struct());
     % active support - supported solvers
-    SOLVERS.cplex_direct.type = {'LP', 'MILP', 'QP', 'MIQP'};
+    SOLVERS.cplex_direct.type = {'LP', 'MILP', 'QP'};
     SOLVERS.dqqMinos.type = {'LP'};
     SOLVERS.glpk.type = {'LP', 'MILP'};
     SOLVERS.gurobi.type = {'LP', 'MILP', 'QP', 'MIQP'};

--- a/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
+++ b/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
@@ -27,12 +27,12 @@ catch ME
 end
 if (~isempty(Problem.csense))
     % build the rhs/lhs of the problem.
-    b_L(Problem.csense == 'E') = b(Problem.csense == 'E');
-    b_U(Problem.csense == 'E') = b(Problem.csense == 'E');
-    b_L(Problem.csense == 'G') = b(Problem.csense == 'G');
+    b_L(Problem.csense == 'E') = Problem.b(Problem.csense == 'E');
+    b_U(Problem.csense == 'E') = Problem.b(Problem.csense == 'E');
+    b_L(Problem.csense == 'G') = Problem.b(Problem.csense == 'G');
     b_U(Problem.csense == 'G') = inf;
     b_L(Problem.csense == 'L') = -inf;
-    b_U(Problem.csense == 'L') = b(Problem.csense == 'L');
+    b_U(Problem.csense == 'L') = Problem.b(Problem.csense == 'L');
 elseif isfield(Problem.csense, 'b_L') && isfield(Problem, 'b_U')
     % or extract them 
     b_L = Problem.b_L;
@@ -51,12 +51,12 @@ cplexProblem.Model.lb = Problem.lb;
 cplexProblem.Model.obj = Problem.osense * Problem.c;
 
 if isfield(Problem,'vartype')
-    cplexProblem.Model.ctype = Problem.varType;
+    cplexProblem.Model.ctype = columnVector(Problem.vartype)';
 end
 if isfield(Problem,'x0')
-    cplexlp.Start.x = Problem.x0;
+    cplexProblem.Start.x = Problem.x0;
 end
 
 if isfield(Problem,'F')
-    cplexlp.Model.Q = F;
+    cplexProblem.Model.Q = Problem.F;
 end

--- a/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
+++ b/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
@@ -44,8 +44,8 @@ else
 end
 
 cplexProblem.Model.A = Problem.A;
-cplexProblem.Model.rhs = b_U;
-cplexProblem.Model.lhs = b_L;
+cplexProblem.Model.rhs = columnVector(b_U);
+cplexProblem.Model.lhs = columnVector(b_L);
 cplexProblem.Model.ub = Problem.ub;
 cplexProblem.Model.lb = Problem.lb;
 cplexProblem.Model.obj = Problem.osense * Problem.c;

--- a/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
+++ b/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
@@ -53,6 +53,7 @@ cplexProblem.Model.obj = Problem.osense * Problem.c;
 if isfield(Problem,'vartype')
     cplexProblem.Model.ctype = columnVector(Problem.vartype)';
 end
+
 if isfield(Problem,'x0')
     cplexProblem.Start.x = Problem.x0;
 end

--- a/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
+++ b/src/base/solvers/buildCplexProblemFromCOBRAStruct.m
@@ -1,0 +1,62 @@
+function  cplexProblem = buildCplexProblemFromCOBRAStruct(Problem)
+% Build a cplex object from the given LP problem in COBRA Format
+% USAGE:
+%    cplexProblem = buildCplexProblemFromCOBRAStruct(LPproblem)
+%
+% INPUT:
+%    LPproblem:         A COBRA style Problem with the following fields:
+%                        * .A - The equality and in equality matrix
+%                        * .b - The right hand side values of the constraints
+%                        * .ub - the upper bounds of the variables
+%                        * .lb - the lower bounds of the variables
+%                        * .osense - The objective sense (-1 for max, 1 for min)
+%                        * .c - the objective coefficient vector for the linear part
+%                       OPTIONAL:
+%                        * .F - The objective coefficient matrix for the quadratic part.
+%                        * .varType - The variable types for mixed integer problems ('I', integer, 'C', continous,'B' binary)
+%                        * .b_L - left hand sides of the constraints (will only be used if csense is empty)
+%                        * .csense - The constraint senses, Default assumption is all 'E'
+%                        * .x0 - Basis to use 
+%
+
+
+try
+    cplexProblem = Cplex('COBRAProblem');
+catch ME
+    error('CPLEX not installed or licence server not up')
+end
+if (~isempty(Problem.csense))
+    % build the rhs/lhs of the problem.
+    b_L(Problem.csense == 'E') = b(Problem.csense == 'E');
+    b_U(Problem.csense == 'E') = b(Problem.csense == 'E');
+    b_L(Problem.csense == 'G') = b(Problem.csense == 'G');
+    b_U(Problem.csense == 'G') = inf;
+    b_L(Problem.csense == 'L') = -inf;
+    b_U(Problem.csense == 'L') = b(Problem.csense == 'L');
+elseif isfield(Problem.csense, 'b_L') && isfield(Problem, 'b_U')
+    % or extract them 
+    b_L = Problem.b_L;
+    b_U = Problem.b_U;
+else
+    % or simply use the equality assumption.
+    b_L = Problem.b;
+    b_U = Problem.b;
+end
+
+cplexProblem.Model.A = Problem.A;
+cplexProblem.Model.rhs = b_U;
+cplexProblem.Model.lhs = b_L;
+cplexProblem.Model.ub = Problem.ub;
+cplexProblem.Model.lb = Problem.lb;
+cplexProblem.Model.obj = Problem.osense * Problem.c;
+
+if isfield(Problem,'vartype')
+    cplexProblem.Model.ctype = Problem.varType;
+end
+if isfield(Problem,'x0')
+    cplexlp.Start.x = Problem.x0;
+end
+
+if isfield(Problem,'F')
+    cplexlp.Model.Q = F;
+end

--- a/src/base/solvers/getCobraSolverParams.m
+++ b/src/base/solvers/getCobraSolverParams.m
@@ -49,23 +49,23 @@ end
 persistent valDef
 if isempty(valDef)
     % Default Values
-    
+    % For descriptions of the different settings please have a look at 
+    % getCobraSolverParamsOptionsForType
     valDef.minNorm = 0;
-    valDef.objTol = 1e-6; %used in optimizeTwoCbModels
+    valDef.objTol = 1e-6; 
     valDef.optTol = 1e-9;
     valDef.feasTol = 1e-9;
     valDef.printLevel = 0;
     valDef.primalOnly = 0;
-    valDef.timeLimit = 1e36; % this should indicate No time limit per default
+    valDef.timeLimit = 1e36; 
     valDef.iterationLimit = 1000;
     valDef.logFile = ['Cobra' solverType 'Solver.log'];
     valDef.saveInput = [];
     valDef.PbName = [solverType 'problem'];
     valDef.debug = 0;
     valDef.lifting = 0;
-       
-    % GUROBI parameters
-    valDef.method = -1; % solver method: -1 = automatic, 0 = primal simplex, 1 = dual simplex, 2 = barrier, 3 = concurrent, 4 = deterministic concurrent
+           
+    valDef.method = -1; 
     
     % CPLEX parameters
     valDef.DATACHECK = 1;

--- a/src/base/solvers/getCobraSolverParams.m
+++ b/src/base/solvers/getCobraSolverParams.m
@@ -45,41 +45,37 @@ end
 if nargin <3
     parameters = '';
 end
+% Persistence will make names specific to one type of solver.
+% Default Values
+% For descriptions of the different settings please have a look at 
+% getCobraSolverParamsOptionsForType
+valDef.minNorm = 0;
+valDef.objTol = 1e-6; 
+valDef.optTol = 1e-9;
+valDef.feasTol = 1e-9;
+valDef.printLevel = 0;
+valDef.primalOnly = 0;
+valDef.timeLimit = 1e36; 
+valDef.iterationLimit = 1000;
+valDef.logFile = ['Cobra' solverType 'Solver.log'];
+valDef.saveInput = [];
+valDef.PbName = [solverType 'problem'];
+valDef.debug = 0;
+valDef.lifting = 0;
+   
+valDef.method = -1; 
 
-persistent valDef
-if isempty(valDef)
-    % Default Values
-    % For descriptions of the different settings please have a look at 
-    % getCobraSolverParamsOptionsForType
-    valDef.minNorm = 0;
-    valDef.objTol = 1e-6; 
-    valDef.optTol = 1e-9;
-    valDef.feasTol = 1e-9;
-    valDef.printLevel = 0;
-    valDef.primalOnly = 0;
-    valDef.timeLimit = 1e36; 
-    valDef.iterationLimit = 1000;
-    valDef.logFile = ['Cobra' solverType 'Solver.log'];
-    valDef.saveInput = [];
-    valDef.PbName = [solverType 'problem'];
-    valDef.debug = 0;
-    valDef.lifting = 0;
-           
-    valDef.method = -1; 
-    
-    % CPLEX parameters
-    valDef.DATACHECK = 1;
-    valDef.DEPIND = 1;
-    valDef.checkNaN = 0;
-    valDef.warning = 0;
-    
-    % tolerances
-    valDef.intTol = 1e-12;
-    valDef.relMipGapTol = 1e-12;
-    valDef.absMipGapTol = 1e-12;
-    valDef.NUMERICALEMPHASIS = 1;    
-    
-end
+% CPLEX parameters
+valDef.DATACHECK = 1;
+valDef.DEPIND = 1;
+valDef.checkNaN = 0;
+valDef.warning = 0;
+
+% tolerances
+valDef.intTol = 1e-12;
+valDef.relMipGapTol = 1e-12;
+valDef.absMipGapTol = 1e-12;
+valDef.NUMERICALEMPHASIS = 1;    
 
 if ~iscell(paramNames)
     paramNames = {paramNames};

--- a/src/base/solvers/getCobraSolverParamsOptionsForType.m
+++ b/src/base/solvers/getCobraSolverParamsOptionsForType.m
@@ -26,7 +26,7 @@ switch solverType
                       'lifting'};           % whether to lift a problem
 
     case 'QP'
-        paramNames = {'method', ...         % solver method: -1 = automatic, 0 = primal simplex, 1 = dual simplex, 2 = barrier, 3 = concurrent, 4 = deterministic concurrent (if supported by the solver)
+        paramNames = {'method', ...         % solver method: -1 = automatic, 0 = primal simplex, 1 = dual simplex, 2 = barrier, 3 = concurrent, 4 = deterministic concurrent, 5 = Network Solver(if supported by the solver)
                       'printLevel', ...     % print level
                       'saveInput', ...      % save the input to a file (specified)
                       'feasTol',...         % feasibility tolerance
@@ -50,6 +50,7 @@ switch solverType
 
     case 'MIQP'
         paramNames = {'timeLimit', ...      % maximum time before stopping computation (if supported by the solver)
+                      'method', ...         % solver method: -1 = automatic, 0 = primal simplex, 1 = dual simplex, 2 = barrier, 3 = concurrent, 4 = deterministic concurrent, 5 = Network Solver(if supported by the solver)
                       'feasTol',...         % feasibility tolerance
                       'optTol',...          % optimality tolerance
                       'intTol', ...         % integer tolerance (accepted derivation from integer numbers)

--- a/src/base/solvers/getCobraSolverParamsOptionsForType.m
+++ b/src/base/solvers/getCobraSolverParamsOptionsForType.m
@@ -22,6 +22,7 @@ switch solverType
                       'optTol', ...         % optimality tolerance
                       'solver', ...         % solver to use (overriding set solver)
                       'debug', ...          % run debgugging code
+                      'logFile', ...        % file (location) to write logs to
                       'lifting'};           % whether to lift a problem
 
     case 'QP'
@@ -30,6 +31,7 @@ switch solverType
                       'saveInput', ...      % save the input to a file (specified)
                       'feasTol',...         % feasibility tolerance
                       'optTol',...          % optimality tolerance
+                      'logFile', ...        % file (location) to write logs to
                       'solver'};            % the solver to use
 
 
@@ -55,6 +57,7 @@ switch solverType
                       'absMipGapTol', ...   % absolute MIP Gap tolerance
                       'printLevel', ...     % print level
                       'saveInput',...       % save the input to a file (specified)
+                      'logFile', ...        % file (location) to write logs to
                       'solver'};            % the solver to use
 
     case 'NLP'

--- a/src/base/solvers/setCplexParam.m
+++ b/src/base/solvers/setCplexParam.m
@@ -1,6 +1,9 @@
 function LP = setCplexParam(LP, solverParams,verbFlag)
 % Sets the parameters of the IBM ILOG CPLEX object according to the structure `solverParams`
-%
+% The `solverParams` structure has to contain the same structure as the
+% Cplex.Param structue in a Cplex object. But values can be set by directly
+% setting the respective parameter instead of the `Cur` value which would
+% be necessary if directly modifying the Cplex.Param structure.
 % USAGE:
 %
 %    LP = setCplexParam(LP, solverParams, verbFlag);

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -35,6 +35,8 @@ cplexProblem.DisplayFunc = @(x) redirect(logFile,x);
 % set tolerances
 cplexProblem.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
 cplexProblem.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;
+cplexProblem.Param.network.tolerances.feasibility.Cur = cobraParams.feasTol;
+cplexProblem.Param.barrier.convergetol.Cur = cobraParams.feasTol;
 if strcmp(problemType,'MILP') || strcmp(problemType,'MIQP')
     % Set Integer specific parameters.
     cplexProblem.Param.mip.tolerances.mipgap.Cur =  cobraParams.relMipGapTol;
@@ -46,7 +48,7 @@ end
 if strcmp(problemType,'QP') || strcmp(problemType,'MIQP')
     switch cobraParams.method
         case -1 % automatic
-            cplexProblem.Param.qpmethod.Cur = 1; % we can choose whatever we want, so lets do primal simplex as it is the most stable option
+            cplexProblem.Param.qpmethod.Cur = -1;
         case 0
             cplexProblem.Param.qpmethod.Cur = 1;
         case 1

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -41,7 +41,7 @@ if strcmp(problemType,'MILP') || strcmp(problemType,'MIQP')
     cplexProblem.Param.timelimit.Cur = cobraParams.timeLimit;
 end
 
-if strcmp(problemType','QP') || strcmp(problemType,'MIQP')
+if strcmp(problemType,'QP') || strcmp(problemType,'MIQP')
     switch cobraParams.method
         case -1 % automatic
             cplexProblem.Param.qpmethod.Cur = 0;

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -41,6 +41,25 @@ if strcmp(problemType,'MILP') || strcmp(problemType,'MIQP')
     cplexProblem.Param.timelimit.Cur = cobraParams.timeLimit;
 end
 
+if strcmp(problemType','QP' || strcmp(problemType,'MIQP')
+    switch cobraParams.method
+        case -1 % automatic
+            cplexProblem.Param.qpmethod.Cur = 0;
+        case 0
+            cplexProblem.Param.qpmethod.Cur = 1;
+        case 1
+            cplexProblem.Param.qpmethod.Cur = 2;
+        case 2
+            cplexProblem.Param.qpmethod.Cur = 4;
+        case 3
+            cplexProblem.Param.qpmethod.Cur = 6;
+        case 5
+            cplexProblem.Param.qpmethod.Cur = 3;
+        otherwise
+            cplexProblem.Param.qpmethod.Cur = 0;
+    end
+end
+
 % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
 cplexProblem = setCplexParam(cplexProblem, solverParams);
 end

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -1,15 +1,17 @@
 function [cplexProblem,logFile,logToFile] = setCplexParametersForProblem(cplexProblem, cobraParams, solverParams, problemType)
 % Set the parameters for a specific problem from the COBRA Parameter
 % structure and a solver specific parameter structre (latter has
-% precedence)
+% precedence). The cobra parameters structure contains fields as specified in 
+% `getCobraSolverParamsOptionsForType`, while solverParams needs to
+% contain a structure compatible with `setCplexParam`.
 % USAGE:
 %    cplexProblem = setCplexParametersForProblem(cplexProblem, cobraParams, solverParams, ProblemType)
 %
 % INPUTS:
 %    cplexProblem:      the Cplex() object to set the parameters
-%    cobraParams:       the COBRA parameter structure
-%    solverParams:      the solver specific parameter structure (must be a
-%                       valid input to `setCplexParam`;
+%    cobraParams:       the COBRA parameter structure, with parameters as defined in
+%                       `getCobraSolverParamsOptionsForType`
+%    solverParams:      the solver specific parameter structure has to be compatible with `setCplexParam`
 %    problemType:       The type of Problem ('LP','MILP','QP','MIQP').
 %
 

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -44,7 +44,7 @@ end
 if strcmp(problemType,'QP') || strcmp(problemType,'MIQP')
     switch cobraParams.method
         case -1 % automatic
-            cplexProblem.Param.qpmethod.Cur = 0;
+            cplexProblem.Param.qpmethod.Cur = 1; % we can choose whatever we want, so lets do primal simplex as it is the most stable option
         case 0
             cplexProblem.Param.qpmethod.Cur = 1;
         case 1

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -29,7 +29,7 @@ else
 end
 
 
-cplexProblem.DisplayFunc = @(x) redirect(outputfile);
+cplexProblem.DisplayFunc = @(x) redirect(logFile,x);
 % set tolerances
 cplexProblem.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
 cplexProblem.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;
@@ -45,7 +45,7 @@ end
 cplexProblem = setCplexParam(cplexProblem, solverParams);
 end
 
-function redirect(l)
+function redirect(outFile,l)
 % Write the line of log output
-fprintf(outputfile, '%s\n', l);
+fprintf(outFile, '%s\n', l);
 end

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -41,7 +41,7 @@ if strcmp(problemType,'MILP') || strcmp(problemType,'MIQP')
     cplexProblem.Param.timelimit.Cur = cobraParams.timeLimit;
 end
 
-if strcmp(problemType','QP' || strcmp(problemType,'MIQP')
+if strcmp(problemType','QP') || strcmp(problemType,'MIQP')
     switch cobraParams.method
         case -1 % automatic
             cplexProblem.Param.qpmethod.Cur = 0;

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -1,0 +1,51 @@
+function [cplexProblem,logFile,logToFile] = setCplexParametersForProblem(cplexProblem, cobraParams, solverParams, problemType)
+% Set the parameters for a specific problem from the COBRA Parameter
+% structure and a solver specific parameter structre (latter has
+% precedence)
+% USAGE:
+%    cplexProblem = setCplexParametersForProblem(cplexProblem, cobraParams, solverParams, ProblemType)
+%
+% INPUTS:
+%    cplexProblem:      the Cplex() object to set the parameters
+%    cobraParams:       the COBRA parameter structure
+%    solverParams:      the solver specific parameter structure (must be a
+%                       valid input to `setCplexParam`;
+%    problemType:       The type of Problem ('LP','MILP','QP','MIQP').
+%
+
+% set the printLevel to the cobra Parameters
+cplexProblem.Param.output.writelevel.Cur = cobraParams.printLevel;
+cplexProblem.Param.barrier.display.Cur = cobraParams.printLevel;
+cplexProblem.Param.simplex.display.Cur = cobraParams.printLevel;
+cplexProblem.Param.sifting.display.Cur = cobraParams.printLevel;
+
+if isscalar(cobraParams.logFile) && cobraParams.logFile == 1
+    % allow print to command window by setting solverParams.logFile == 1
+    logFile = 1;
+    logToFile = false;
+else
+    logFile = fopen(cobraParams.logFile,'a');
+    logToFile = true;
+end
+
+
+cplexProblem.DisplayFunc = @(x) redirect(outputfile);
+% set tolerances
+cplexProblem.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
+cplexProblem.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;
+if strcmp(problemType,'MILP') || strcmp(problemType,'MIQP')
+    % Set Integer specific parameters.
+    cplexProblem.Param.mip.tolerances.mipgap.Cur =  cobraParams.relMipGapTol;
+    cplexProblem.Param.mip.tolerances.integrality.Cur =  cobraParams.intTol;
+    cplexProblem.Param.mip.tolerances.absmipgap.Cur =  cobraParams.absMipGapTol;
+    cplexProblem.Param.timelimit.Cur = cobraParams.timeLimit;
+end
+
+% Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
+cplexProblem = setCplexParam(cplexProblem, solverParams);
+end
+
+function redirect(l)
+% Write the line of log output
+fprintf(outputfile, '%s\n', l);
+end

--- a/src/base/solvers/setCplexParametersForProblem.m
+++ b/src/base/solvers/setCplexParametersForProblem.m
@@ -21,17 +21,22 @@ cplexProblem.Param.barrier.display.Cur = cobraParams.printLevel;
 cplexProblem.Param.simplex.display.Cur = cobraParams.printLevel;
 cplexProblem.Param.sifting.display.Cur = cobraParams.printLevel;
 
-if isscalar(cobraParams.logFile) && cobraParams.logFile == 1
-    % allow print to command window by setting solverParams.logFile == 1
-    logFile = 1;
-    logToFile = false;
+if isscalar(cobraParams.logFile)
+    if cobraParams.logFile == 1
+        % allow print to command window by setting solverParams.logFile == 1
+        logToFile = false;
+        cplexProblem.DisplayFunc = @(x) redirect(1,x);
+    else
+        % any other scalar will be assumed to indicate no logging
+        logFile = 0;
+        logToFile = false;
+    end
 else
     logFile = fopen(cobraParams.logFile,'a');
     logToFile = true;
+    cplexProblem.DisplayFunc = @(x) redirect(logFile,x);
 end
 
-
-cplexProblem.DisplayFunc = @(x) redirect(logFile,x);
 % set tolerances
 cplexProblem.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
 cplexProblem.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;

--- a/src/base/solvers/solveCobraMIQP.m
+++ b/src/base/solvers/solveCobraMIQP.m
@@ -292,15 +292,6 @@ switch solver
 
         % optimize the problem
         Result = CplexMIQPProblem.solve();
-    
-        if Result.status == 6 && cobraParams.method == -1 
-            % we had an automatic try and cplex returned a non optimal
-            % solution. This sometimes happens with automatic solver
-            % selection, and using the simplex solver 'can' correct this
-            % behaviour, so lets give it a try.
-            CplexQPProblem.Param.qpmethod = 1;
-            Result = CplexQPProblem.solve();
-        end
         
         if logToFile
             % Close the output file

--- a/src/base/solvers/solveCobraMIQP.m
+++ b/src/base/solvers/solveCobraMIQP.m
@@ -283,63 +283,20 @@ switch solver
    case 'ibm_cplex'
         % Free academic licenses for the IBM CPLEX solver can be obtained from
         % https://www.ibm.com/developerworks/community/blogs/jfp/entry/CPLEX_Is_Free_For_Students?lang=en
-
-        cplexlp = Cplex();
-        if (~isempty(csense))
-            b_L(csense == 'E') = b(csense == 'E');
-            b_U(csense == 'E') = b(csense == 'E');
-            b_L(csense == 'G') = b(csense == 'G');
-            b_U(csense == 'G') = inf;
-            b_L(csense == 'L') = -inf;
-            b_U(csense == 'L') = b(csense == 'L');
-        elseif isfield(MILPproblem, 'b_L') && isfield(MILPproblem, 'b_U')
-            b_L = MILPproblem.b_L;
-            b_U = MILPproblem.b_U;
-        else
-            b_L = b;
-            b_U = b;
-        end
-        intVars = (vartype == 'B') | (vartype == 'I');
-        % intVars
-        % pause;
-        cplexlp.Model.A = A;
-        cplexlp.Model.rhs = b_U;
-        cplexlp.Model.lhs = b_L;
-        cplexlp.Model.ub = ub;
-        cplexlp.Model.lb = lb;
-        cplexlp.Model.obj = osense * c;
-        cplexlp.Model.name = 'CobraMIQP';
-        cplexlp.Model.Q = F;
-        % Make sure, that the vartype is in the correct orientation, cplex
-        % is quite picky here..
-        if size(vartype,1) > size(vartype,2)
-            vartype = vartype';
-        end
-        cplexlp.Model.ctype = vartype;
-
-
-        cplexlp.Param.timelimit.Cur = cobraParams.timeLimit;
-        cplexlp.Param.output.writelevel.Cur = cobraParams.printLevel;
+        CplexMIQPProblem = buildCplexProblemFromCOBRAStruct(MIQPproblem);
+        [CplexMIQPProblem, logFile, logToFile] = setCplexParametersForProblem(CplexMIQPProblem,cobraParams,solverParams,'MIQP');
         
-        if cobraParams.printLevel == 0  % set display function as empty
-            cplexlp.DisplayFunc=[];
-        end
-        % set tolerances
-        cplexlp.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
-        cplexlp.Param.mip.tolerances.absmipgap.Cur =  cobraParams.absMipGapTol;
-        cplexlp.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;
-        cplexlp.Param.mip.tolerances.mipgap.Cur =  cobraParams.relMipGapTol;
-        cplexlp.Param.mip.tolerances.integrality.Cur =  cobraParams.intTol;
+        %Update Tolerance According to actual setting
+        cobraParams.feasTol = CplexMIQPProblem.Param.simplex.tolerances.feasibility.Cur;
 
-        % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
-        cplexlp = setCplexParam(cplexlp, solverParams);
 
-        % Set up callback to print out intermediate solutions
-        % only set this up if you know that you actually need these
-        % results.  Otherwise do not specify intSolInd and contSolInd
-
-        % Solve problem
-        Result = cplexlp.solve();
+        % optimize the problem
+        Result = CplexMIQPProblem.solve();
+    
+        if logToFile
+            % Close the output file
+            fclose(logFile);
+        end        
 
         % Get results
         stat = Result.status;

--- a/src/base/solvers/solveCobraMIQP.m
+++ b/src/base/solvers/solveCobraMIQP.m
@@ -211,6 +211,8 @@ switch solver
            stat = -1; % Solution not optimal or solver problem
         end
         solStat = stat;
+        
+        
     case 'gurobi'
      % Free academic licenses for the Gurobi solver can be obtained from
         % http://www.gurobi.com/html/academic.html
@@ -278,6 +280,87 @@ switch solver
            stat = -1; % Solution not optimal or solver problem
         end
         %%
+   case 'ibm_cplex'
+        % Free academic licenses for the IBM CPLEX solver can be obtained from
+        % https://www.ibm.com/developerworks/community/blogs/jfp/entry/CPLEX_Is_Free_For_Students?lang=en
+
+        cplexlp = Cplex();
+        if (~isempty(csense))
+            b_L(csense == 'E') = b(csense == 'E');
+            b_U(csense == 'E') = b(csense == 'E');
+            b_L(csense == 'G') = b(csense == 'G');
+            b_U(csense == 'G') = inf;
+            b_L(csense == 'L') = -inf;
+            b_U(csense == 'L') = b(csense == 'L');
+        elseif isfield(MILPproblem, 'b_L') && isfield(MILPproblem, 'b_U')
+            b_L = MILPproblem.b_L;
+            b_U = MILPproblem.b_U;
+        else
+            b_L = b;
+            b_U = b;
+        end
+        intVars = (vartype == 'B') | (vartype == 'I');
+        % intVars
+        % pause;
+        cplexlp.Model.A = A;
+        cplexlp.Model.rhs = b_U;
+        cplexlp.Model.lhs = b_L;
+        cplexlp.Model.ub = ub;
+        cplexlp.Model.lb = lb;
+        cplexlp.Model.obj = osense * c;
+        cplexlp.Model.name = 'CobraMIQP';
+        cplexlp.Model.Q = F;
+        % Make sure, that the vartype is in the correct orientation, cplex
+        % is quite picky here..
+        if size(vartype,1) > size(vartype,2)
+            vartype = vartype';
+        end
+        cplexlp.Model.ctype = vartype;
+
+
+        cplexlp.Param.timelimit.Cur = cobraParams.timeLimit;
+        cplexlp.Param.output.writelevel.Cur = cobraParams.printLevel;
+        
+        if cobraParams.printLevel == 0  % set display function as empty
+            cplexlp.DisplayFunc=[];
+        end
+        % set tolerances
+        cplexlp.Param.simplex.tolerances.optimality.Cur = cobraParams.optTol;
+        cplexlp.Param.mip.tolerances.absmipgap.Cur =  cobraParams.absMipGapTol;
+        cplexlp.Param.simplex.tolerances.feasibility.Cur = cobraParams.feasTol;
+        cplexlp.Param.mip.tolerances.mipgap.Cur =  cobraParams.relMipGapTol;
+        cplexlp.Param.mip.tolerances.integrality.Cur =  cobraParams.intTol;
+
+        % Set IBM-Cplex-specific parameters. Will overide Cobra solver parameters
+        cplexlp = setCplexParam(cplexlp, solverParams);
+
+        % Set up callback to print out intermediate solutions
+        % only set this up if you know that you actually need these
+        % results.  Otherwise do not specify intSolInd and contSolInd
+
+        % Solve problem
+        Result = cplexlp.solve();
+
+        % Get results
+        stat = Result.status;
+        if (stat == 101 || stat == 102 || stat == 1)
+            solStat = 1; % Opt integer within tolerance
+            % Return solution if problem is feasible, bounded and optimal
+            x = Result.x;
+            f = osense*Result.objval;
+        elseif (stat == 103 || stat == 3)
+            solStat = 0; % Integer infeas
+        elseif (stat == 118 || stat == 119 || stat == 2)
+            solStat = 2; % Unbounded
+        elseif (stat == 106 || stat == 106 || stat == 108 || stat == 110 || stat == 112 || stat == 114 || stat == 117)
+            solStat = -1; % No integer solution exists
+        else
+            solStat = 3; % Other problem, but integer solution exists
+        end
+        if exist([pwd filesep 'clone1.log'],'file')
+            delete('clone1.log')
+        end        
+        
     otherwise
         if isempty(solver)
             error('There is no solver for MIQP problems available');

--- a/src/base/solvers/solveCobraMIQP.m
+++ b/src/base/solvers/solveCobraMIQP.m
@@ -293,6 +293,15 @@ switch solver
         % optimize the problem
         Result = CplexMIQPProblem.solve();
     
+        if Result.status == 6 && cobraParams.method == -1 
+            % we had an automatic try and cplex returned a non optimal
+            % solution. This sometimes happens with automatic solver
+            % selection, and using the simplex solver 'can' correct this
+            % behaviour, so lets give it a try.
+            CplexQPProblem.Param.qpmethod = 1;
+            Result = CplexQPProblem.solve();
+        end
+        
         if logToFile
             % Close the output file
             fclose(logFile);

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -155,9 +155,12 @@ switch solver
 
         % optimize the problem
         Result = CplexQPProblem.solve();
-        residual = QPproblem.osense*QPproblem.c  + QPproblem.F*Result.x - QPproblem.A' * Result.dual - Result.reducedcost;
-        tmp=norm(residual,inf);        
-        
+        if isfield(Result,'x')
+            residual = QPproblem.osense*QPproblem.c  + QPproblem.F*Result.x - QPproblem.A' * Result.dual - Result.reducedcost;
+            tmp=norm(residual,inf);        
+        else
+            tmp = 0;
+        end        
         if (Result.status == 6 || tmp > cobraParams.feasTol ) && cobraParams.method == -1 
             % we had an automatic try and cplex returned a non optimal
             % solution, or a solution that is not good enough. This sometimes happens 

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -155,20 +155,6 @@ switch solver
 
         % optimize the problem
         Result = CplexQPProblem.solve();
-        if isfield(Result,'x')
-            residual = QPproblem.osense*QPproblem.c  + QPproblem.F*Result.x - QPproblem.A' * Result.dual - Result.reducedcost;
-            tmp=norm(residual,inf);        
-        else
-            tmp = 0;
-        end        
-        if (Result.status == 6 || tmp > cobraParams.feasTol ) && cobraParams.method == -1 
-            % we had an automatic try and cplex returned a non optimal
-            % solution, or a solution that is not good enough. This sometimes happens 
-            % with automatic solver selection, and using the simplex solver 'can' correct this
-            % behaviour, so lets give it a try, as the selection was set to automatic anyways.
-            CplexQPProblem.Param.qpmethod.Cur = 1;
-            Result = CplexQPProblem.solve();
-        end
         if logToFile
             % Close the output file
             fclose(logFile);

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -155,12 +155,15 @@ switch solver
 
         % optimize the problem
         Result = CplexQPProblem.solve();
-        if Result.status == 6 && cobraParams.method == -1 
+        residual = QPproblem.osense*QPproblem.c  + QPproblem.F*Result.x - QPproblem.A' * Result.dual - Result.reducedcost;
+        tmp=norm(residual,inf);        
+        
+        if (Result.status == 6 || tmp > cobraParams.feasTol ) && cobraParams.method == -1 
             % we had an automatic try and cplex returned a non optimal
-            % solution. This sometimes happens with automatic solver
-            % selection, and using the simplex solver 'can' correct this
-            % behaviour, so lets give it a try.
-            CplexQPProblem.Param.qpmethod = 1;
+            % solution, or a solution that is not good enough. This sometimes happens 
+            % with automatic solver selection, and using the simplex solver 'can' correct this
+            % behaviour, so lets give it a try, as the selection was set to automatic anyways.
+            CplexQPProblem.Param.qpmethod.Cur = 1;
             Result = CplexQPProblem.solve();
         end
         if logToFile

--- a/src/base/solvers/solveCobraQP.m
+++ b/src/base/solvers/solveCobraQP.m
@@ -153,10 +153,16 @@ switch solver
         %Update Tolerance According to actual setting
         cobraParams.feasTol = CplexQPProblem.Param.simplex.tolerances.feasibility.Cur;
 
-
         % optimize the problem
         Result = CplexQPProblem.solve();
-    
+        if Result.status == 6 && cobraParams.method == -1 
+            % we had an automatic try and cplex returned a non optimal
+            % solution. This sometimes happens with automatic solver
+            % selection, and using the simplex solver 'can' correct this
+            % behaviour, so lets give it a try.
+            CplexQPProblem.Param.qpmethod = 1;
+            Result = CplexQPProblem.solve();
+        end
         if logToFile
             % Close the output file
             fclose(logFile);

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -166,7 +166,7 @@ if ~isempty(pttoolboxPath)
             doQP = true & solverQPOK;
         end
         if ismember(currentSolver,solverPkgs.MILP)
-            solverMILPOK = changeCobraSolver(solverPkgs.LP{k}, 'QP', 0);
+            solverMILPOK = changeCobraSolver(solverPkgs.LP{k}, 'MILP', 0);
             doMILP = true & solverMILPOK;
         end
         if solverLPOK 

--- a/test/verifiedTests/analysis/testFVA/testFVA.m
+++ b/test/verifiedTests/analysis/testFVA/testFVA.m
@@ -57,7 +57,7 @@ for k = 1:length(solverPkgs.LP)
         doQP = true & solverQPOK;
     end
     if ismember(currentSolver,solverPkgs.MILP)
-        solverMILPOK = changeCobraSolver(solverPkgs.LP{k}, 'QP', 0);
+        solverMILPOK = changeCobraSolver(solverPkgs.LP{k}, 'MILP', 0);
         doMILP = true & solverMILPOK;
     end
     % change the COBRA solver (LP)


### PR DESCRIPTION
This is a continuation of #1401 

Added a fallback option for the qp solver type selection if the method parameter is set to automatic (default). Cplex tends to then return non-optimal solutions, which can be resolved using the simplex method.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
