### PR TITLE
Small bug in field reordering

### DIFF
--- a/src/analysis/FBA/optimizeCbModel.m
+++ b/src/analysis/FBA/optimizeCbModel.m
@@ -436,11 +436,11 @@ if (solution.stat == 1)
         solution.s = solution.slack;
     end
     fieldOrder = {'full';'obj';'rcost';'dual';'slack';'solver';'algorithm';'stat';'origStat';'time';'basis';'vars_v';'vars_w';'ctrs_y';'ctrs_s';'f';'x';'v';'w';'y';'s'};
-    % reorder fields for better reradability
+    % reorder fields for better readability
     currentfields = fieldnames(solution);
     presentfields = ismember(fieldOrder,currentfields);
     absentfields = ~ismember(currentfields,fieldOrder);
-    solution = orderfields(solution,[currentfields(absentfields),fieldOrder(presentfields)]);
+    solution = orderfields(solution,[currentfields(absentfields);fieldOrder(presentfields)]);
 else
     %some sort of error occured.
     if printLevel>0


### PR DESCRIPTION
There seems to be an error in the concatenation of the reordered fields. At least, it affects me when running one model instance with ibm_cplex with allowLoops = false

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
