### PR TITLE
added rxns as input for printFluxBounds

### DIFF
--- a/src/analysis/exploration/printFluxBounds.m
+++ b/src/analysis/exploration/printFluxBounds.m
@@ -1,18 +1,30 @@
-function printFluxBounds(model)
+function printFluxBounds(model, rxns)
 % Prints the reactionID and upper/lower flux bounds.
 %
 % USAGE:
 %
-%   printFluxBounds(model)
+%   printFluxBounds(model, rxns)
 %
 % INPUTS:
 %    model:    The model to print
 %
-% .. Author: - Thomas Pfau May 2017
+% OPTIONAL INPUTS:
+%    rxns:     a string array of reaction ids for which flux bounds need to
+%              be printed
+%
+% .. Author:
+%       - Thomas Pfau           May 2017
+%       - Chintan Joshi         Feb 2019  optional input 'rxns'; prints
+%                               flux bounds for the desired reactions only
 
-rxnlength = cellfun(@length,model.rxns);
+if nargin < 2 || isempty(rxns)
+    rxns = model.rxns;
+end
+
+rxnlength = cellfun(@length,rxns);
 maxlength = max([rxnlength;11]);
 fprintf(['%' num2str(maxlength) 's\t%14s\t%14s\n'],'Reaction ID','Lower Bound','Upper Bound');
-for i = 1: numel(model.rxns)
-    fprintf(['%' num2str(maxlength) 's\t%14.3f\t%14.3f\n'],model.rxns{i},model.lb(i),model.ub(i));
+for i = 1: numel(rxns)
+    fprintf(['%' num2str(maxlength) 's\t%14.3f\t%14.3f\n'],rxns{i},...
+        model.lb(strcmp(model.rxns,rxns{i})),model.ub(strcmp(model.rxns,rxns{i})));
 end


### PR DESCRIPTION
I have only added a "rxns" argument so anyone can only print the flux bounds for those reactions that they need rather than all the reactions. I couldn't find a test for this function, so left it as is. However, will write one if needed.

**I hereby confirm that I have:**

- [X ] Tested my code on my own machine
- [ X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
