### PR TITLE
Fix columnVector for correctly manipulating empty row and column vectors

### DIFF
--- a/src/base/columnVector.m
+++ b/src/base/columnVector.m
@@ -17,7 +17,7 @@ function vecT = columnVector(vec)
 
 [n, m] = size(vec);
 
-if n < m
+if (m ~= 1 && n < m) || n == 1
     vecT = vec';
 else
     vecT = vec;

--- a/test/verifiedTests/base/testIO/testConvertOldStyleModel.m
+++ b/test/verifiedTests/base/testIO/testConvertOldStyleModel.m
@@ -136,5 +136,12 @@ fixedModel = convertOldStyleModel(testModel);
 assert(fixedModel.rxnConfidenceScores(3) == 0);
 % this should again be valid, subSystems Field is fixed and confidence Scores properly converted..
 assert(verifyModel(fixedModel,'simpleCheck',true));
+
+% if the old style A is the same as S (no additional constraint), test that convertOldStyleModel returns the correct empty vectors
+modelWithA = fixedModel;
+modelWithA.A = fixedModel.S;
+modelConverted = convertOldStyleModel(modelWithA);
+assert(verifyModel(modelConverted,'simpleCheck',true));
+
 % change the directory
 cd(currentDir)

--- a/test/verifiedTests/base/testTools/testColumnVector.m
+++ b/test/verifiedTests/base/testTools/testColumnVector.m
@@ -47,5 +47,9 @@ end
 assert(size(vec1, 1) == size(vec, 2))
 assert(size(vec1, 2) == size(vec, 1))
 
+% check correct manipulation of empty column and row vectors
+assert(isequal(size(columnVector(zeros(0, 1))), [0, 1]))
+assert(isequal(size(columnVector(zeros(1, 0))), [0, 1]))
+
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
*Please include a short description of enhancement here*
`columnVector(zeros(0, 1))` and `columnVector(zeros(1, 0))` both return `1x0 empty row vector`, which is not exactly correct. And this causes, for example, `convertOldStyleModel(modelWithA)` not passing `verifyModel( *, 'simpleCheck', true)` if modelWithA has *.A equal to *.S (though unusual) because `convertOldStyleModel` will add empty row vectors for `*.ctrs`, `*.dsense` and `*.d`.

This pull request makes `columnVector(zeros(0, 1))` and `columnVector(zeros(1, 0))` both return `0x1 empty column vector`. Tests are added accordingly.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
