### PR TITLE
Adding support for table fields in the model struct

### DIFF
--- a/src/base/utilities/extendIndicesInDimenion.m
+++ b/src/base/utilities/extendIndicesInDimenion.m
@@ -20,10 +20,14 @@ function added = extendIndicesInDimenion(input,dimension,value, sizeIncrease)
 % NOTE:  
 %     Based on https://stackoverflow.com/questions/22537326/on-shape-agnostic-slicing-of-ndarrays
 
-
 inputDimensions = ndims(input);
 S.subs = repmat({':'},1,inputDimensions);
 S.subs{dimension} = (size(input,dimension)+1):(size(input,dimension)+sizeIncrease);
 S.type = '()';
-added = subsasgn(input,S,value);
+if ~istable(input)
+    added = subsasgn(input,S,value);
+else
+    % this can only happen for the first dimension, everything else will
+    % error!
+    added = [input;repmat(value,sizeIncrease,1)];
 end

--- a/src/base/utilities/getDefaultTableRow.m
+++ b/src/base/utilities/getDefaultTableRow.m
@@ -1,0 +1,18 @@
+function defaultRow = getDefaultTableRow(tableRow)
+% get a default table row
+% USAGE:
+%   defaultRow = getDefaultTableRow(tablerow)
+%
+% INPUT:
+%    tableRow:        The row for which to define a default row
+%  
+% OUTPUT:
+%    defaultRow:      A row with default values for different data types
+%
+
+defaultRow = tableRow(1,:);
+% get the default values in a cell array to convert to a table row
+for i = 1:size(tableRow,2)
+    defaultRow{1,i} = getDefaultValue(tableRow{1,i});
+end
+end

--- a/src/base/utilities/getDefaultValue.m
+++ b/src/base/utilities/getDefaultValue.m
@@ -1,0 +1,29 @@
+
+function defValue = getDefaultValue(value)
+% get the default value for a given value (NaN for numeric, empty strings for textual, false for logical)
+% USAGE:
+%    defValue = getDefaultValue(value)
+%
+% INPUT:
+%    value:     The value to get a default for
+%
+% OUTPUT: 
+%    defValue:    The default value for the given values type.
+
+    if isnumeric(value)
+        valClass = class(value);
+        defValue = cast(NaN,valClass);
+        defValue = repmat(defValue,size(value));
+    elseif isstring(value)
+        defValue = "";
+    elseif ischar(value)
+        defValue = '';
+    elseif islogical(value)
+        defValue = false;
+        defValue = repmat(defValue,size(value));
+    elseif iscell(value)
+        % recursive use, get the default for each element of the cell
+        % array.
+        defValue = cellfun(@(x) getDefaultValue(x),value,'Uniform',false);
+    end
+end

--- a/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testBatchAddition.m
@@ -27,6 +27,9 @@ model = getDistributedModel('ecoli_core_model.mat');
 fprintf('>> Testing Metabolite Batch Addition...\n');
 metNames = {'A','b','c'};
 metFormulas = {'C','CO2','H2OKOPF'};
+
+%Also, implicitly test whether tables are handled correctly
+model.tableField = table(model.mets,model.mets);
 modelBatch = addMultipleMetabolites(model,metNames,'metCharges', [ -1 1 0],...
     'metFormulas', metFormulas, 'metKEGGID',{'C000012','C000023','C000055'});
 assert(all(ismember(metNames,modelBatch.mets)));
@@ -35,6 +38,8 @@ assert(isequal(modelBatch.metFormulas(pos(pres)),columnVector(metFormulas)));
 assert(isequal(modelBatch.metCharges(pos(pres)),[-1; 1;0]));
 assert(verifyModel(modelBatch,'simpleCheck',true));
 assert(isfield(modelBatch,'metKEGGID'));
+assert(isequal(size(modelBatch.tableField,1),size(modelBatch.mets,1)));
+assert(isequal(size(modelBatch.tableField,2),size(model.tableField,2)));
 
 %Assert duplication check
 assert(verifyCobraFunctionError('addMultipleMetabolites', 'inputs',{model,model.mets(1:3)}))


### PR DESCRIPTION
Currently the dynamic field adaption does not handle table fields since they can't properly be modified with `subsasgn`. This PR adds support for table fields.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
