### PR TITLE
Added support in sampler for C,d inequality constraints

### DIFF
--- a/src/analysis/sampling/CHRR/chrrParseModel.m
+++ b/src/analysis/sampling/CHRR/chrrParseModel.m
@@ -18,6 +18,11 @@ function [P,model] = chrrParseModel(model)
 %               * .lb - `n x 1` lower bounds on fluxes
 %               * .ub - `n x 1` upper bounds on fluxes
 %
+% OPTIONAL INPUTS:
+%               * .C - 'k x n' matrix of additional inequality constraints
+%               * .d - 'k x 1' rhs of the above constraints
+%               * .dsense - 'k x 1' the sense of the above constraints ('L' or 'G')
+%
 % OUTPUTS:
 %    P:        A structure with fields:
 %
@@ -29,11 +34,26 @@ function [P,model] = chrrParseModel(model)
 % .. Authors:
 %       - Ben Cousins and Hulda Haraldsdóttir, 10/2016
 %       - Ben Cousins, 12/2017, Moved objective function handling to preprocess function
+%       - Ben Cousins, 05/2019, Added support for C,d inequalities.
 
 dim = length(model.lb);
 
 P.A = [eye(dim); -eye(dim)];
-P.b = [model.ub; -model.lb];
+P.b = [model.ub; -model.lb]; 
+
+if isfield(model,'C') && isfield(model,'d')
+   for i=1:size(model.C,1)
+      if model.dsense(i)=='G'
+          % convert constraint to <=
+          model.C(i,:) = model.C(i,:)*-1;
+          model.d(i) = model.d(i)*-1;
+      elseif model.dsense{i}=='E'
+          error('Equality constraints not supported in C,d fields.');
+      end
+   end
+   P.A = [P.A; model.C];
+   P.b = [P.b; model.d];
+end
 
 P.A_eq = model.S;
 P.b_eq = model.b;


### PR DESCRIPTION
Added support in the CHRR sampler for inequality constraints that are present in the COBRA model fields model.C and model.d. The sense of the inequalities should be in the field model.dsense. If either of the fields model.C or model.d are missing, the behavior of the new function is equivalent to the current function in the COBRA toolbox.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
