### PR TITLE
HotFix: Adapt MIRIAM to new registry.org API

### DIFF
--- a/src/base/io/definitions/getRegisteredDatabases.m
+++ b/src/base/io/definitions/getRegisteredDatabases.m
@@ -18,14 +18,15 @@ persistent databases
 if isempty(databases)
     % load from external site        
     try
-        dbs = webread('http://identifiers.org/rest/collections');        
+        dbs = webread('https://registry.api.identifiers.org/resolutionApi/getResolverDataset');        
     catch
         error('Could not load the databases registered with identifiers.org.\nThis is likely due to a missing internet connection.\nPlease try this again later');
     end
+    dbs = dbs.payload.namespaces;
     % extract relevant information
-    dbnames = cellfun(@(x) x.name, dbs,'Uniform',0);
-    dbpatterns = cellfun(@(x) x.pattern, dbs,'Uniform',0);
-    dbprefix = cellfun(@(x) x.prefix, dbs,'Uniform',0);    
+    dbnames = {dbs.name};
+    dbpatterns = {dbs.pattern};
+    dbprefix = {dbs.prefix};    
     % collate as struct
     databases = struct('name',dbnames,'pattern',dbpatterns,'prefix',dbprefix);
 end

--- a/test/verifiedTests/reconstruction/testModelManipulation/testMIRIAMAnnotation.m
+++ b/test/verifiedTests/reconstruction/testModelManipulation/testMIRIAMAnnotation.m
@@ -20,7 +20,7 @@ model = getDistributedModel('ecoli_core_model.mat');
 try
     dbs = getRegisteredDatabases();
 catch
-    error(CBT_MISSING_REQUIREMENTS_ERROR_ID, strjoin('Could not get the data from identifiers.org. Check your internet Connection.'));
+    error(CBT_MISSING_REQUIREMENTS_ERROR_ID, sprintf('Could not get the data from identifiers.org. Check your internet Connection.'));
 end
 
 errorMessage = sprintf('The following databases are not defined on identifiers.org:\n%s',strjoin({'NonExistentDB'},'\n'));


### PR DESCRIPTION
The registry.org API is changing due to a change in their setup. This means we have to adapt the automated fetch script to obtain the specifications for registry.org databases which are not explicitly specified in the Toolbox. 
This PR adapts the respective function.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
