### PR TITLE
Fixed bug: metSmiles field was created from wrong column

### DIFF
--- a/src/reconstruction/rBioNet/data2model.m
+++ b/src/reconstruction/rBioNet/data2model.m
@@ -182,7 +182,7 @@ for k = 1:S(1) % Check all metabolites in model
         met_k{k,6} = metabolites{line,7};   %metPubChemID
         met_k{k,7} = metabolites{line,9};   %metInChIString
         met_k{k,8} = metabolites{line,11};  %metHMDB
-        met_k{k,9} = metabolites{line,12};  %metSmiles
+        met_k{k,9} = metabolites{line,10};  %metSmiles
     end
 end
 


### PR DESCRIPTION
metSmiles field was created from the wrong column in the rBioNet metabolite database.  I changed that to column 10, which contains metSmiles.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
