### PR TITLE
Making warning of missing genes more explicit

### DIFF
--- a/src/analysis/exploration/findRxnsFromGenes.m
+++ b/src/analysis/exploration/findRxnsFromGenes.m
@@ -58,14 +58,14 @@ end
 if isfield(model, 'geneNames')
     model.geneNames = regexprep(model.geneNames,'-','_DASH_');
     model.geneNames = regexprep(model.geneNames,'\.','_POINT_');
-else%to stay compatible with old style models
+else %to stay compatible with old style models
     model.geneNames = regexprep(model.genes,'-','_DASH_');
     model.geneNames = regexprep(model.geneNames,'\.','_POINT_');
 end
 genes = regexprep(genes,'-','_DASH_');
 genes = regexprep(genes,'\.','_POINT_');
 
-%find where the genes are located in the geneNames
+% find where the genes are located in the geneNames
 GeneID = zeros(size(genes));
 [~, geneIndModel, inModel] = intersect(model.geneNames, genes);
 GeneID(inModel) = geneIndModel;%set location of genes in model
@@ -73,7 +73,9 @@ GeneID(inModel) = geneIndModel;%set location of genes in model
 results = struct();
 ListResults = {};
 if any(GeneID == 0)
-    warning('A gene was not found in the model!')
+    notpresent = GeneID == 0;
+    missingGenes = strjoin(genes(notpresent),',\n');
+    warning('The following gene(s) were not fond in the model:\n%s',missingGenes)
     if any(GeneID > 0)
         Ind = find(GeneID == 0);
         GeneID(Ind) = [];

--- a/test/verifiedTests/analysis/testExploration/testFindRxnsFromGenes.m
+++ b/test/verifiedTests/analysis/testExploration/testFindRxnsFromGenes.m
@@ -24,7 +24,15 @@ model = convertOldStyleModel(model);
 
 % get reactions for gene list, include gene not in model and nested cell
 geneList = {'b0115'; {'b0722'; 'MadeUp'}};
+
 [geneRxnsStruct, geneRxnsArray] = findRxnsFromGenes(model, geneList, 0, 1);
+
+%Check warning message
+warningmessage = lastwarn;
+assert(strfind(warningmessage,'MadeUp')>0);
+assert(isempty(strfind(warningmessage,'b0722')));
+assert(isempty(strfind(warningmessage,'b0115')));
+
 
 % find gene indeces of genes in model
 geneInd = find(ismember(model.genes, {'b0115'; 'b0722'}));


### PR DESCRIPTION
Updating findRxnsFromGenes making the warning message when searching for missing genes more explicit, as it is often unclear, which genes where not found in the model.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
