### PR TITLE
Allowing https to work with cobrapy 015 and up

### DIFF
--- a/src/base/io/utilities/SBML/getDataBases.m
+++ b/src/base/io/utilities/SBML/getDataBases.m
@@ -27,7 +27,7 @@ function [databases,ids,qualifiers] = getDataBases(Ressources,qualifier)
 try
     %Try to parse identifiers.org ids. if this doesn't work leave them
     %empty.
-    tokens = cellfun(@(x) regexp(x,'http://identifiers\.org/([^/]*)/(.*)','tokens'),Ressources);
+    tokens = cellfun(@(x) regexp(x,'https?://identifiers\.org/([^/]*)/(.*)','tokens'),Ressources);
 catch
     tokens = {};
 end


### PR DESCRIPTION
Cobrapy outputs identifiers using https:// and not http://
Modified the regexp to make it work. Also checked that identifiers.org accepts both http and https connections.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
