### PR TITLE
Fix Compartment merger

### DIFF
--- a/src/reconstruction/refinement/mergeTwoModels.m
+++ b/src/reconstruction/refinement/mergeTwoModels.m
@@ -170,8 +170,8 @@ end
 %Making the comps fields unique
 if(isfield(modelNew, 'comps'))
     [ucomps,ia,ic] = unique(modelNew.comps);
-    toKeep = true(size(modelNew.comps));
-    toKeep(ia) = false;
+    toKeep = false(size(modelNew.comps));
+    toKeep(ia) = true;
     modelNew = removeFieldEntriesForType(modelNew,~toKeep,'comps',numel(toKeep));
 end
 showprogress(1.0, 'Finished merging models ...');


### PR DESCRIPTION
This PR fixes a bug when combining models with compartments. 
At the moment all compartments are being removed, leaving an empty, and thus invalid, `comps` field, which can cause issues in further processing.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
