### PR TITLE
preparseGPR crashes if the input is a single gene rule

### DIFF
--- a/src/base/preparseGPR.m
+++ b/src/base/preparseGPR.m
@@ -15,7 +15,8 @@ function [preParsedGrRules,genes] = preparseGPR(grRules)
 % .. Author: -  Laurent Heirendt - December 2017
 
 %using regexprep all cells must be char row vectors.
-glt=length(grRules);
+glt=size(grRules,1);
+if glt>2
 for g=1:glt
     if ~ischar(grRules{g})
         if iscell(grRules{g})
@@ -25,6 +26,7 @@ for g=1:glt
             error(['grRules ' int2str(g)  ' is not a character array'])
         end
     end
+end
 end
     preParsedGrRules = regexprep(grRules, '[\]\}]',')'); %replace other brackets by parenthesis.
     preParsedGrRules = regexprep(preParsedGrRules, '[\[\{]','('); %replace other brackets by parenthesis.


### PR DESCRIPTION
The preparseGPR function caused data2model to crash since it was given a single gene rule as input but only worked with the entire grRules field. I fixed this. Hopefully, this does not introduce any other problems.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
