### PR TITLE
Fix lrs output read ray

### DIFF
--- a/src/analysis/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
+++ b/src/analysis/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
@@ -16,8 +16,11 @@ fid = fopen(filename);
 
 % pause(eps)
 while 1
+    tline = fgetl(fid);
     if strcmp(fgetl(fid), 'begin')
         break;
+    elseif ~ischar(tline)
+        error('Could not read lrs output file.'); 
     end
 end
 

--- a/src/analysis/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
+++ b/src/analysis/topology/extremeRays/lrs/lrsInterface/lrsOutputReadRay.m
@@ -17,7 +17,7 @@ fid = fopen(filename);
 % pause(eps)
 while 1
     tline = fgetl(fid);
-    if strcmp(fgetl(fid), 'begin')
+    if strcmp(tline, 'begin')
         break;
     elseif ~ischar(tline)
         error('Could not read lrs output file.'); 


### PR DESCRIPTION
A new attempt since the bug remains, this time via devTools. If the input file of lrsOutputReadRay is an empty file, the function gets stuck in an infinite loop. Personally I have never been able to run testAll successfully because of this. A quick fix where an empty input file throws an error.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
