### PR TITLE
feat: gene SBO terms in XML output

### DIFF
--- a/src/base/io/utilities/writeSBML.m
+++ b/src/base/io/utilities/writeSBML.m
@@ -333,6 +333,7 @@ if isfield(model,'genes')
             tmp_fbc_geneProduct.fbc_name = model.proteins{i};
         end
         
+        tmp_fbc_geneProduct.sboTerm = 243;
         tmp_fbc_geneProduct.annotation = makeSBMLAnnotationString(model,tmp_fbc_geneProduct.fbc_id,GeneProductAnnotations,i);
         if i==1
             sbmlModel.fbc_geneProduct=tmp_fbc_geneProduct;


### PR DESCRIPTION
hi! I'm working in increasing the compatibility of models exported with cobrapy/cobratoolbox so that no fields are lost when going from one to the other one. I noticed that cobratoolbox does not record SBO terms for genes by default (which cobrapy does), so here I'm adding that setting, as afaik the gene field is solely intended to store that type of species, so there should not be a need to ask the user to do it. Let me know if this makes sense to you.

http://www.ebi.ac.uk/sbo/main/SBO:0000243

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)