### PR TITLE
Fix bug in adaptVMHdiet that duplicates essential metabolites when renamed

### DIFF
--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/adaptVMHDietToAGORA.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/adaptVMHDietToAGORA.m
@@ -59,7 +59,7 @@ adaptedDietConstraints(:, 1) = strrep(adaptedDietConstraints(:, 1), 'EX_glc(e)',
 adaptedDietConstraints(:, 1) = strrep(adaptedDietConstraints(:, 1), 'EX_sbt-d(e)', 'EX_sbt_D(e)');
 
 % Add essential metabolites not yet included in the entered diet
-MissingUptakes = setdiff(essentialMetabolites, VMHDietConstraints(:, 1));
+MissingUptakes = setdiff(essentialMetabolites, adaptedDietConstraints(:, 1));
 % add the missing exchange reactions to the adapted diet
 CLength = size(adaptedDietConstraints, 1);
 for i = 1:length(MissingUptakes)


### PR DESCRIPTION
Since commit https://github.com/opencobra/cobratoolbox/commit/c82f9f4bfcb9d1cb4681040343894fd74a6f32d1 some metabolites are renamed at the beginning of the script. But the next step that adds a list of essential metabolites get the list of missing metabolites from the original (unmodified) variable. That duplicates some metabolites in the diet.

To avoid reversion, it could be a good idea to also write a test that checks uniqueness of the metabolites in a diet after being processed by adaptVMHDietToAGORA.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [ ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)