### PR TITLE
Increase verbosity of error during load

### DIFF
--- a/src/base/io/readCbModel.m
+++ b/src/base/io/readCbModel.m
@@ -229,7 +229,7 @@ switch fileType
             modeloptions = {S.(varname), varname};
         end
         if size(modeloptions, 1) == 0
-            error(['There were no valid models in the mat file.\n Please load the model manually via '' load ' fileName ''' and check it with verifyModel() to validate it']);
+            error(['There were no valid models in the mat file.\n Please load the model manually via '' load ' fileName ''' and check it with verifyModel() to validate it.\nTry using convertOldStyleModel() before verifyModel() to bring the model structure up to date.']);
         end
         model = modeloptions{1, 1};
         if modeloptions{1, 3}


### PR DESCRIPTION
Add additional information during a failed load attempt in order to better handle old models, where errors might have arisen just because of the old format.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
