### PR TITLE
feat: SBO terms for reaction bounds

### DIFF
--- a/src/base/io/utilities/writeSBML.m
+++ b/src/base/io/utilities/writeSBML.m
@@ -387,6 +387,11 @@ if ~isempty(listUniqueValues)
         
         fbc_parameter.id=listUniqueNames{i,1};
         fbc_parameter.value=listUniqueValues(i);
+        if fbc_parameter.value == -1000 || fbc_parameter.value == +1000 || fbc_parameter.value == 0 || isinf(fbc_parameter.value)
+            fbc_parameter.sboTerm=626;
+        else
+            fbc_parameter.sboTerm=625;
+        end
         if i==1
             sbmlModel.parameter=fbc_parameter;
         else

--- a/test/verifiedTests/base/testIO/testWriteSBML.m
+++ b/test/verifiedTests/base/testIO/testWriteSBML.m
@@ -38,6 +38,19 @@ testModelXML = rmfield(testModelXML,'rxnReferences');
 % assess any potential differences
 assert(~any(numDiff))
 
+% obtain SBML structure
+testSBMLstruct = writeSBML(testModelSBML,'testModelSBML.sbml');
+
+% asses if lower/upper bounds have proper SBO terms assigned
+for i = 1:length(testSBMLstruct.parameter)
+    value = testSBMLstruct.parameter(i).value;
+    if abs(value) == 1000 || isinf(value) || value == 0
+        assert(testSBMLstruct.parameter(i).sboTerm == 626)
+    else
+        assert(testSBMLstruct.parameter(i).sboTerm == 625)
+    end
+end
+
 % remove the written file to clean up
 delete 'testModelSBML.sbml.xml';
 


### PR DESCRIPTION
Added SBO terms for all lower/upper bounds, based on the definitions from SBO:

* Measured/estimated bounds: http://www.ebi.ac.uk/sbo/main/SBO:0000625
* Default bounds (`-Inf`, `-1000`, `0`, `+1000` or `+Inf`): http://www.ebi.ac.uk/sbo/main/SBO:0000626

These definitions are consistent with cobrapy's after merge of https://github.com/opencobra/cobrapy/pull/949

Tested here: https://github.com/BenjaSanchez/yeast-GEM/commit/086b1cb58a936efe745009b0431ff78e77b0a4be

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)