### PR TITLE
Remove nRxns from subSystem

### DIFF
--- a/src/base/io/utilities/convertOldStyleModel.m
+++ b/src/base/io/utilities/convertOldStyleModel.m
@@ -271,7 +271,6 @@ for i = 1: numel(modelfields)
     end
 end
 
-nRxns=length(model.subSystems);
 if isfield(model,'subSystems')
     numericPos = cellfun(@(x) isnumeric(x), model.subSystems);
     if all(numericPos)


### PR DESCRIPTION
Line 274 - `nRxns=length(model.subSystems);` - is unused and causes errors if model struct doesn't have the field - if needed could be inside the `if isfield(model, 'subSystems')`

*Please include a short description of enhancement here*

**I hereby confirm that I have:**

- [ ] Tested my code on my own machine
- [ ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ ] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
