### PR TITLE
Proposal buildFluxDistLayout with a color gradient

### DIFF
--- a/src/visualization/maps/ReconMap/buildFluxDistLayout.m
+++ b/src/visualization/maps/ReconMap/buildFluxDistLayout.m
@@ -48,6 +48,7 @@ end
 if ~exist('content','var')
     normalizedFluxes = normalizeFluxes(abs(solution.v), thickness);
     content = 'name%09reactionIdentifier%09lineWidth%09color%0D';
+    cmap = makeColorGradient('#ff0000', defaultColor, 11);
     for i=1:length(solution.v)
         mapReactionId = model.rxns{i};
         
@@ -57,7 +58,8 @@ if ~exist('content','var')
         end
         
         if solution.v(i) ~= 0
-            line = strcat('%09', mapReactionId, '%09', num2str(normalizedFluxes(i)), '%09', defaultColor, '%0D');
+            color = cmap{round(normalizedFluxes(i)) + 1};
+            line = strcat('%09', mapReactionId, '%09', 1, '%09', color, '%0D');            
             content = strcat(content, line);
         end
         

--- a/src/visualization/maps/ReconMap/buildFluxDistLayout.m
+++ b/src/visualization/maps/ReconMap/buildFluxDistLayout.m
@@ -83,10 +83,10 @@ if ~exist('content','var')
                 color = defaultColor;
             else
                 thickness = 1;
-                if solution.v(i) > 0
-                    color = cmap{round(normalizedFluxes(i)) + 1};
-                else
+                if solution.v(i) < 0 && exist('ncmap','var')
                     color = ncmap{round(normalizedFluxes(i)) + 1};
+                else
+                    color = cmap{round(normalizedFluxes(i)) + 1};
                 end
             end
             

--- a/src/visualization/maps/ReconMap/makeColorGradient.m
+++ b/src/visualization/maps/ReconMap/makeColorGradient.m
@@ -1,0 +1,39 @@
+function [cmap] = makeColorGradient(col1, col2, ncol)
+% Generates a color gradient in hex format, based on color 1 and 2
+%
+% USAGE:
+%
+%    [cmap] = makeColorGradient(col1, col2, ncol)
+%
+% INPUTS:
+%    col1:                      First color
+%    col2:                      Last color
+%    ncol:                      Number of colors in between
+%
+% OUTPUT:
+%    cmap:                      Color gradient map with the corresponding
+%                               colors in hex format
+%
+% .. Author: - Nicolas Mendoza-Mejia May/2021
+
+hexformat = "#%02x%02x%02x";
+
+rgb1 = sscanf(col1, hexformat);
+rgb2 = sscanf(col2, hexformat);
+
+T = (rgb2 -rgb1)/(ncol - 1);
+rgb = zeros(3, ncol);
+
+for i=1:3
+   if T(i) ~= 0
+    rgb(i, :) =  rgb1(i):T(i):rgb2(i);
+   end
+end
+
+rgb = round(rgb);
+cmap = cell(1, ncol);
+for i=1:ncol
+   cmap{i} = sprintf(hexformat, rgb(1, i), rgb(2, i), rgb(3, i));
+end
+
+end


### PR DESCRIPTION
This is a proposal to use color gradient when building a layout to plot a flux distribution in ReconMap, instead of the current approach that is based on size of the lines.

**Advantages**
- It is easier to understand
- It could represent negative fluxes as well (Not implemented yet)

**Example**
![imagen](https://user-images.githubusercontent.com/58706237/119242891-52ab2a80-bb27-11eb-83c5-13f9c3a5d9ec.png)


This is still a work in progress. What do you think, should I continue?

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)
