### PR TITLE
Beginner tools

### DIFF
--- a/deprecated/_maps_old/drawCbMap.m
+++ b/deprecated/_maps_old/drawCbMap.m
@@ -105,7 +105,7 @@ end
 if ~isfield(options,'textSize')
     options.textSize = ones(max(nNodes,nEdges),1)*12;
     if strcmp(CB_MAP_OUTPUT,'svg')
-        options.textSize = ones(max(nNodes,nEdges),1)*6;
+        options.textSize = ones(max(nNodes,nEdges),1)*10;
     end
 end
 %Font Color
@@ -286,7 +286,7 @@ for i = 1:size(map.rxnLabelPosition,2)
       if isfield(options, 'rxnTextSize')
         drawText(map.rxnLabelPosition(1,i),map.rxnLabelPosition(2,i),map.connectionAbb{find(map.rxnIndex(i)==map.connection,1)},options.rxnTextSize(i),'italic');
       else
-        drawText(map.rxnLabelPosition(1,i),map.rxnLabelPosition(2,i),map.connectionAbb{find(map.rxnIndex(i)==map.connection,1)},8,'italic');
+        drawText(map.rxnLabelPosition(1,i),map.rxnLabelPosition(2,i),map.connectionAbb{find(map.rxnIndex(i)==map.connection,1)},10,'italic');
       end
     end
 end

--- a/deprecated/_maps_old/drawFlux.m
+++ b/deprecated/_maps_old/drawFlux.m
@@ -51,11 +51,12 @@ if ~isfield(options,'rxnDirMultiplier'), options.rxnDirMultiplier = 2; end
 if ~isfield(options,'rxnDirFlag'), rxnDirFlag = false; else rxnDirFlag = options.rxnDirFlag; end
 rxnListZero = model.rxns(abs(flux)<=1e-9);
 absFlag=false;
+origFlux = flux; %need this to set the arrow directions correct if abs is used -mfarshada
 switch lower(options.scaleType)
     case {1, 'linear'}
         options.scaleTypeLabel='Linear;';
     case {2 ,'linear absolute'}
-        flux=abs(flux);
+        flux=abs(flux); 
         absFlag=true;
         options.scaleTypeLabel='Linear absolute;';
     case {3,'log10'}
@@ -109,8 +110,8 @@ end
 if rxnDirFlag
     options.rxnDir = zeros(length(map.connectionAbb),1);
     for i = 1:length(map.connectionAbb)
-        options.rxnDir(ismember(map.connectionAbb,model.rxns(flux>0))) = 1;
-        options.rxnDir(ismember(map.connectionAbb,model.rxns(flux<0))) = -1;
+        options.rxnDir(ismember(map.connectionAbb,model.rxns(origFlux>0))) = -1; %was 1, inconsistent with drawLine -mfarshada
+        options.rxnDir(ismember(map.connectionAbb,model.rxns(origFlux<0))) = 1; %was -1 
     end
 end
 


### PR DESCRIPTION
*Please include a short description of enhancement here*
When using drawFlux() the bigger and smaller arrows seem backward with respect to the actual flux direction. This seems due to incompatibility with drawLine(). Possibly other functions using drawLine() are also affected. This is a quick (temporary) fix for drawFlux() only. There are other issues with drawLine() too, e.g. showing the default exchange fluxes inwards. Maybe a better approach would be to overhaul that function, but that would be more complicated.

I understand these parts of the code are now "deprecated", but many FBA beginners still rely on the current tutorial and the simple E. coli core model. It would be nice to keep these parts of the code working and up-to-date. Thank you!

Tested with the following settings:
map=readCbMap('ecoli_core_map');
options = [];
options.scaleType = 'linear absolute';
options.lb = 0; %using absolute
options.ub = 20;
changeCbMapOutput('svg'); %or 'matlab'
options.zeroFluxWidth = 5;
options.rxnDirFlag = true;
options.edgeArrowColor = zeros(size(map.connection,1),3);
options.edgeWeight = 25 * ones(size(map.connection,1),1);
options.colorScale = parula(300);

**I hereby confirm that I have:**

- [x ] Tested my code on my own machine
- [x ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x ] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
