### PR TITLE
bug fix for initMgPipe.m and readInputTableForPipeline.m

### DIFF
--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
@@ -123,7 +123,12 @@ end
 
 % test if abundances are normalized
 abundance = readInputTableForPipeline(abunFilePath);
-totalAbun=sum(str2double(abundance(2:end,2:end)),1);
+if contains(version,'(R202') % for Matlab R2020a and newer
+	totalAbun=sum(cell2mat(abundance(2:end,2:end)),1);
+else
+	totalAbun=sum(str2double(abundance(2:end,2:end)),1);
+end
+
 if any(totalAbun > 1.01)
     error('Abundances are not normalized. Please run the function normalizeCoverage!')
 end

--- a/src/reconstruction/demeter/src/integration/readInputTableForPipeline.m
+++ b/src/reconstruction/demeter/src/integration/readInputTableForPipeline.m
@@ -41,7 +41,7 @@ else % if the table is not a text file
                 if isnumeric(gettab.(getcols{j}))
                     formattedTable(2:length(gettab.(getcols{j}))+1,j)=cellstr(num2str(gettab.(getcols{j})));
                 else
-                    formattedTable(2:length(gettab.(getcols{j}))+1,j)=cellstr(gettab.(getcols{j}));
+                    formattedTable(2:length(cellstr(gettab.(getcols{j})))+1,j)=cellstr(gettab.(getcols{j}));
                 end
             end
         else


### PR DESCRIPTION
*Please include a short description of enhancement here*
	modified:   ../../../src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
			bug fix: totalAbun was always NaN in Matlab R2020a or higher version

	modified:   ../../../src/reconstruction/demeter/src/integration/readInputTableForPipeline.m
			bug fix: when the number of species is smaller than the length of species name,
			return value of length(gettab.(getcols{j})  becomes the length of species name.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
