### PR TITLE
Improve installation time via shallow updates of submodules

### DIFF
--- a/initCobraToolbox.m
+++ b/initCobraToolbox.m
@@ -224,7 +224,7 @@ if installedGit
         %This means that the checked-out commit -- which is the one that the super-project (core) needs -- is not associated with a local branch name.
         %[status_gitSubmodule, result_gitSubmodule] = system(['git submodule update --init --remote --no-fetch ' depthFlag]);%old
         %[status_gitSubmodule, result_gitSubmodule] = system(['git submodule foreach git submodule update --init --recursive']);% 23/9/21 RF submodules point to master
-        [status_gitSubmodule, result_gitSubmodule] = system('git submodule update --init --recursive');% 23/9/21 RF submodules point to master, don't pull in remote changes
+        [status_gitSubmodule, result_gitSubmodule] = system('recommend_shallow=true git submodule update --init --recursive');% 23/9/21 RF submodules point to master, don't pull in remote changes
         %[status_gitSubmodule, result_gitSubmodule] = system('git submodule foreach git checkout master');
         [status_gitSubmodule, result_gitSubmodule] = system('git submodule foreach git checkout master');% 30/9/21 RF submodules point to master, don't pull in remote changes
         


### PR DESCRIPTION
*Please include a short description of enhancement here*
During installation, submodule updates were taking hours. Shallow updating made it much faster for me (under a minute).

Just a suggestion since there are some trade-offs:

* I don't know if this syntax works on non-POSIX shells.
* It may vary with between git versions; although it should not be a problem since it is just about setting an env variable.

Also, setting a `jobs=$n_cores` env variable might also shorten the installation time.

**I hereby confirm that I have:**

- [ ] Tested my code on my own machine
- [ ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ ] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
