### PR TITLE
Changing to https, to allow non git registered users to clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,4 +74,4 @@
 	branch = master
 [submodule "external/base/io/xlread"]
 	path = external/base/io/xlread
-	url = git@github.com:tpfau/xlread.git
+	url = https://github.com/tpfau/xlread


### PR DESCRIPTION
Git identiication made cloning for non registered users impossible. 
Changing it to https, to allow cloning also by users not having registered with git.


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
