### PR TITLE
Fixing bug with paramepsilon

### DIFF
--- a/src/dataIntegration/XomicsToModel/thermoKernel/thermoKernel.m
+++ b/src/dataIntegration/XomicsToModel/thermoKernel/thermoKernel.m
@@ -144,7 +144,7 @@ end
 %set parameters according to feastol
 feasTol = getCobraSolverParams('LP', 'feasTol');
 if ~isfield(param,'epsilon')
-    param.epsilon = feasTol;
+    param.epsilon = feasTol*10;
 end
 if ~isfield(param,'normalizeZeroNormWeights')
     param.normalizeZeroNormWeights=0;


### PR DESCRIPTION
Change param.epsilon=feasTol to param.epsilon=feasTol*10 to get a small size result

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
