### PR TITLE
Small bug fix for Microbiome Modelling Toolbox

### DIFF
--- a/src/analysis/multiSpecies/SteadyCom/subroutines/SteadyComSubroutines.m
+++ b/src/analysis/multiSpecies/SteadyCom/subroutines/SteadyComSubroutines.m
@@ -234,7 +234,7 @@ else
         spName = spAbbr;
     end
     if isfield(infoCom, 'spBm')
-        indCom.spBm = modelCom.rxns(infoCom.spBm);
+        indCom.spBm = modelCom.rxns(infoCom.spBm); %modelCom.infoCom.spBm
     end
     if isfield(infoCom,'spATPM')
         indCom.spATPM = modelCom.rxns(infoCom.spATPM);

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/createMultipleSpeciesModel.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/createMultipleSpeciesModel.m
@@ -1,4 +1,4 @@
-function [modelJoint] = createMultipleSpeciesModel(models, varargin)
+function [modelJoint] = createMultipleSpeciesModel(models, biomasses, varargin)
 % Based on the implementation from *Klitgord and Segre 2010, PMID 21124952*.
 % The present implementation has been used in *PMID 23022739*, *PMID 25841013*,
 % *PMID 25901891*, *PMID 27893703*.
@@ -24,6 +24,9 @@ function [modelJoint] = createMultipleSpeciesModel(models, varargin)
 %
 %                         * models{1,1} = model 1
 %                         * models{2,1} = model 2...
+%    biomasses:           Cell array containing names of biomass objective
+%                         functions of models to join. Needs to be the same
+%                         length as models.
 %
 % OPTIONAL INPUTS:
 %    nameTagsModels:    cell array of tags for reaction/metabolite abbreviation
@@ -144,7 +147,6 @@ metIndices =~cellfun(@isempty, regexp(modelHost.mets, '\[e0\]$'));
 modelHost.mets(metIndices) = strrep(modelHost.mets(metIndices), '[e0]', '[e]');
 end
 %% Remove futile cycles that may appear after joining (optional)
-
 if remCyclesFlag
     database = loadVMHDatabase;
 
@@ -156,8 +158,7 @@ if remCyclesFlag
     unionRxns=unique(unionRxns);
     for i = 1:modelNumber
         model=models{i, 1};
-        biomassReaction=model.rxns(find(strncmp(model.rxns, 'bio', 3)));
-        model = removeFutileCycles(model, biomassReaction, database,unionRxns);
+        model = removeFutileCycles(model, biomasses{i}, database,unionRxns);
         models{i, 1} = model;
     end
 end

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/joinModelsPairwiseFromList.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/pairwiseInteractionModeling/joinModelsPairwiseFromList.m
@@ -185,12 +185,16 @@ for i = 1:length(modelList)
             model1
             model2
             };
+        modelBiomasses = {
+            biomasses{i}
+            biomasses{k}
+            };
         nameTagsModels = {
             strcat(modelList{i}, '_')
             strcat(modelList{k}, '_')
             };
         if isempty(find(contains(existingModels,['pairedModel', '_', modelList{i}, '_', modelList{k}, '.mat'])))
-            [pairedModel] = createMultipleSpeciesModel(models, 'nameTagsModels', nameTagsModels,'mergeGenesFlag', mergeGenesFlag, 'remCyclesFlag', remCyclesFlag);
+            [pairedModel] = createMultipleSpeciesModel(models, modelBiomasses, 'nameTagsModels', nameTagsModels,'mergeGenesFlag', mergeGenesFlag, 'remCyclesFlag', remCyclesFlag);
             [pairedModel] = coupleRxnList2Rxn(pairedModel, pairedModel.rxns(strmatch(nameTagsModels{1, 1}, pairedModel.rxns)), strcat(nameTagsModels{1, 1}, biomasses{i}), c, u);
             [pairedModel] = coupleRxnList2Rxn(pairedModel, pairedModel.rxns(strmatch(nameTagsModels{2, 1}, pairedModel.rxns)), strcat(nameTagsModels{2, 1}, biomasses{k}), c, u);
             pairedModelsTemp{k} = pairedModel;

--- a/src/reconstruction/refinement/addCOBRAConstraints.m
+++ b/src/reconstruction/refinement/addCOBRAConstraints.m
@@ -147,12 +147,12 @@ if ~all(fieldsPresent)
     if any(fieldsPresent)        
         for i = 1:numel(ConstraintFields)
             if ~isfield(model,ConstraintFields{i})
-                model = createEmptyField(model,ConstraintFields{i});
+                model = createEmptyFields(model,ConstraintFields{i});
             else
                 if ~isempty(model.(ConstraintFields{i}))
                     error('Inconsistent Field sizes detected. Expected an empty field but %s was non empty',ConstraintFields{i})            
                 else
-                    model = createEmptyField(model,ConstraintFields{i}); %Replace the existing to make sure the dimensions are correct.
+                    model = createEmptyFields(model,ConstraintFields{i}); %Replace the existing to make sure the dimensions are correct.
                 end
             end
         end


### PR DESCRIPTION
- Removed a typo (`createEmptyField` was called in `addCOBRAConstraints` but its correct name is `createEmptyFields`)
- In the latest update of MMT in December 2022, the `biomasses` variable was added to the joinModelsPairwiseFromList function. However, this variable is lost at createMultipleSpeciesModel, which overwrites the biomass reaction name (        `biomassReaction=model.rxns(find(strncmp(model.rxns, 'bio', 3)));`), ignoring the previously defined `biomasses` value.

**I  hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu) (← sorry, I had reloaded the page... Now it's the correct branch!)