### PR TITLE
Add MatGPT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,3 +75,6 @@
 [submodule "external/base/io/xlread"]
 	path = external/base/io/xlread
 	url = https://github.com/tpfau/xlread
+[submodule "external/visualization/MatGPT"]
+	path = external/visualization/MatGPT
+	url = git@github.com:toshiakit/MatGPT.git


### PR DESCRIPTION
MatGPT submodule is added to external/visualization subfolder
**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)