### PR TITLE
Bugfix printRxnFormula

### DIFF
--- a/src/analysis/exploration/printRxnFormula.m
+++ b/src/analysis/exploration/printRxnFormula.m
@@ -132,19 +132,22 @@ formulas = cell(size(rxnAbbrList));
 for i = 1:length(rxnAbbrList)
 
     rxnAbbr = rxnAbbrList{i};
-    rxnID = find(contains(model.rxns, rxnAbbr));
     
-    % To account for any duplicates in rxn IDs
-    if size(rxnID,1) > 1
-        error("It seems you have duplicated reaction IDs in your model. Reaction in question %s", rxnAbbr)
-    end
+    
     % The solution line made it so the i'th reaction was printed regardless of which
     % reactions were put in, giving a wrong output
     % rxnID = i;
     
     % this original line has caused issues if reaction abbr were not unique
     % (which should generally not be present)
-    %  rxnID = findRxnIDs(model, rxnAbbr);
+    % Uncommented this line and added a conditional statement that stops
+    % the code when multiple indexes are returned.
+     rxnID = findRxnIDs(model, rxnAbbr);
+    
+    % To account for any duplicates in rxn IDs
+    if size(rxnID,1) > 1
+        error("It seems you have duplicated reaction IDs in your model. Reaction in question %s", rxnAbbr)
+    end
     
     if (rxnID > 0)
 

--- a/src/analysis/exploration/printRxnFormula.m
+++ b/src/analysis/exploration/printRxnFormula.m
@@ -132,12 +132,20 @@ formulas = cell(size(rxnAbbrList));
 for i = 1:length(rxnAbbrList)
 
     rxnAbbr = rxnAbbrList{i};
-
-    rxnID = i;
+    rxnID = find(contains(model.rxns, rxnAbbr));
+    
+    % To account for any duplicates in rxn IDs
+    if size(rxnID,1) > 1
+        error("It seems you have duplicated reaction IDs in your model. Reaction in question %s", rxnAbbr)
+    end
+    % The solution line made it so the i'th reaction was printed regardless of which
+    % reactions were put in, giving a wrong output
+    % rxnID = i;
+    
     % this original line has caused issues if reaction abbr were not unique
     % (which should generally not be present)
     %  rxnID = findRxnIDs(model, rxnAbbr);
-
+    
     if (rxnID > 0)
 
         Srxn = full(model.S(:, rxnID));


### PR DESCRIPTION
printRxnFormula had an update for duplicated rxnIDs. The update however made it so that the iteration became the index being extracted from the S-matrix instead of the index belonging the the reaction. I.e., If you wanted to print a formula of a 1 reaction, the function would always print the formula of the first reaction, regardless of the input.
Changed the code to find index of reactions and put an error in to stop the code when duplicated reaction IDs are found. The code also tells the user which rxnabbrevation caused the error.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
