### PR TITLE
Bug fix for loadPSCMfile.m

### DIFF
--- a/src/analysis/wholeBody/PSCMToolbox/io/loadPSCMfile.m
+++ b/src/analysis/wholeBody/PSCMToolbox/io/loadPSCMfile.m
@@ -19,14 +19,14 @@ function variable = loadPSCMfile(fileName, searchDirectory)
 % variable:             Matlab variable returned
 %
 % EXAMPLE: 
-%           % Giving only WBM nickname loads the latest available WBM:
-%           male = loadPSCMfile('Harvey');
-%           % Giving the exact name of the .mat file loads the exact
-%           specified mode:
-%           female = loadPSCMfile('Harvetta_1_03d'); 
-%           % Specifiying the search directory loads the .mat file
-%           within that directory:
-%           male = loadPSCMfile('Harvetta','MYDIRECTORY')
+%               % Giving only WBM nickname loads the latest available WBM:
+%               male = loadPSCMfile('Harvey');
+%               % Giving the exact name of the .mat file loads the exact
+%               specified mode:
+%               female = loadPSCMfile('Harvetta_1_03d'); 
+%               % Also specifiying the search directory loads the .mat file
+%               within that directory:
+%               male = loadPSCMfile('Harvetta','MYDIRECTORY')
 %
 % AUTHORS:
 %   - Ines Thiele, 2020
@@ -131,8 +131,8 @@ function nameOfWBM = findLatestWBM(filename, searchDirectory, excludeVersion)
 % Author: 
 %         - Tim Hensen, August 2024
 
-if nargin <2
-    searchDirectory = 'WBM_reconstructions';
+if isempty(searchDirectory)
+    searchDirectory = what('2020_WholeBodyModelling\Data').path;
 end
 
 if nargin<3


### PR DESCRIPTION
Bug fix for loadPSCMfile.m This fix solves the problem that no WBM model was loaded into memory if only the model nickname was given as the user input. The updated function does load the latest WBM model in the cobratoolbox if the user only inputs the model nickname. For example, femaleWBM = loadPSCMfile('Harvetta').

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)