### PR TITLE
Mg pipe update

### DIFF
--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
@@ -10,6 +10,9 @@ function [init, netSecretionFluxes, netUptakeFluxes, Y, modelStats, summary, sta
 %    abunFilePath:           char with path and name of file from which to retrieve abundance information
 %    computeProfiles:        boolean defining whether flux variability analysis to 
 %                            compute the metabolic profiles should be performed.
+% solver:                    String, indicates which solver is to be used
+%                            for solving WBMs. OPTIONAL, defaults to GLPK.
+%                            It is highly recommended to use gurobi or cplex
 %   
 % OPTIONAL INPUTS:
 %    resPath:                char with path of directory where results are saved
@@ -39,12 +42,6 @@ function [init, netSecretionFluxes, netUptakeFluxes, Y, modelStats, summary, sta
 %    pruneModels:            boolean indicating whether reactions that do not carry flux on the
 %                            input diet should be removed from the microbe models. 
 %                            Recommended for large datasets (default = false)
-%    simulateMicrobiotaModel: apply different diets (according to the user's input) 
-%                           to the microbiota models and run simulations computing FVAs
-%                           on exchanges reactions of the microbiota models. 
-%                           The output is saved in multiple .mat objects. 
-%                           Intermediate saving checkpoints are present
-%                           (default = false)
 %
 %
 % OUTPUTS:

--- a/src/analysis/wholeBody/PSCMToolbox/setConstraints/diets/EUAverageDietNew.m
+++ b/src/analysis/wholeBody/PSCMToolbox/setConstraints/diets/EUAverageDietNew.m
@@ -101,7 +101,6 @@ Diet = {%'Exchange reactions'	'Total in mmol/(human*day)'
 'EX_tchola(e)'	'10'
 'EX_dgchol(e)'	'10'
 'EX_M01989(e)'	'10'
-'EX_M01989(e)'	'10'
 
     };
 Diet = regexprep(Diet,'EX_','Diet_EX_');


### PR DESCRIPTION
initMgPipe previously defines 'CBT_LP_SOLVER' as a global variable to initialise the cobra toolbox. In this step the solver was being set to the default ('glpk') which caused issues downstream (microbiotaModelSimulator became extremely slow). Now solver is an optional input and this default assignment is only called upon if the user has not defined a solver. 

Additionally, a duplicate diet component which caused errors in adaptVMHDietToAGORA.m was deleted.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
