### PR TITLE
BugFix automatic glpk solver MgPipe

### DIFF
--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/initMgPipe.m
@@ -76,7 +76,7 @@ parser = inputParser();
 parser.addRequired('modPath', @ischar);
 parser.addRequired('abunFilePath', @ischar);
 parser.addRequired('computeProfiles', @islogical);
-parser.addParameter('solver', @ischar);
+parser.addParameter('solver', '',@ischar);
 parser.addParameter('resPath', [pwd filesep 'Results'], @ischar);
 parser.addParameter('dietFilePath', @ischar);
 parser.addParameter('infoFilePath', '', @ischar);
@@ -116,7 +116,7 @@ adaptMedium = parser.Results.adaptMedium;
 pruneModels = parser.Results.pruneModels;
 
 % check if the solver is defined by the user
-if exist(solver)
+if ~isempty(solver)
     changeCobraSolver(solver, 'LP')
 else
     % otherwise use the default solver (*note: glpk takes excessive time
@@ -214,7 +214,7 @@ fprintf(' > Microbiome Toolbox pipeline initialized successfully.\n');
 
 init = true;
 
-[netSecretionFluxes, netUptakeFluxes, Y, modelStats, summary, statistics, modelsOK] = mgPipe(modPath, abunFilePath, computeProfiles, resPath, dietFilePath, infoFilePath, biomasses, hostPath, hostBiomassRxn, hostBiomassRxnFlux, figForm, numWorkers, rDiet, pDiet, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium, pruneModels);
+[netSecretionFluxes, netUptakeFluxes, Y, modelStats, summary, statistics, modelsOK] = mgPipe(modPath, abunFilePath, computeProfiles, resPath, dietFilePath, infoFilePath, biomasses, hostPath, hostBiomassRxn, hostBiomassRxnFlux, figForm, numWorkers, rDiet, pDiet, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium, pruneModels, solver);
 
 cd(currentDir)
 

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/mgPipe.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/mgPipe.m
@@ -273,7 +273,7 @@ end
 % also computed and saved in a file called "simRes".
 
 load([resPath filesep 'mapInfo.mat'])
-[exchanges, netProduction, netUptake, presolve, infeasModels] = microbiotaModelSimulator(resPath, exMets, sampNames, dietFilePath, hostPath, hostBiomassRxn, hostBiomassRxnFlux, numWorkers, rDiet, pDiet, computeProfiles, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium);
+[exchanges, netProduction, netUptake, presolve, infeasModels] = microbiotaModelSimulator(resPath, exMets, sampNames, dietFilePath, hostPath, hostBiomassRxn, hostBiomassRxnFlux, numWorkers, rDiet, pDiet, computeProfiles, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium, solver);
 % Finally, NMPCs (net maximal production capability) are computed in a metabolite
 % resolved manner and saved in a comma delimited file in the results folder. NMPCs
 % indicate the maximal production of each metabolite and are computing summing

--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/microbiotaModelSimulator.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/microbiotaModelSimulator.m
@@ -1,4 +1,4 @@
-function [exchanges, netProduction, netUptake, growthRates, infeasModels] = microbiotaModelSimulator(resPath, exMets, sampNames, dietFilePath, hostPath, hostBiomassRxn, hostBiomassRxnFlux, numWorkers, rDiet, pDiet, computeProfiles, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium)
+function [exchanges, netProduction, netUptake, growthRates, infeasModels] = microbiotaModelSimulator(resPath, exMets, sampNames, dietFilePath, hostPath, hostBiomassRxn, hostBiomassRxnFlux, numWorkers, rDiet, pDiet, computeProfiles, lowerBMBound, upperBMBound, includeHumanMets, adaptMedium, solver)
 
 % This function is called from the MgPipe pipeline. Its purpose is to apply
 % different diets (according to the user's input) to the microbiota models
@@ -54,7 +54,10 @@ global CBT_LP_SOLVER
 if isempty(CBT_LP_SOLVER)
     initCobraToolbox
 end
-solver = CBT_LP_SOLVER;
+
+if isempty(solver)
+    solver = CBT_LP_SOLVER;
+end
 
 if numWorkers>0 && ~isempty(ver('parallel'))
     % with parallelization


### PR DESCRIPTION
Issue that on various systems the solver was automatically set to glpk vastly increasing computation times. Added inputs in mgpipe.m and microbiotaModelSimulator.m to accept the solver variable. Now only the solver will be set based on the global variable if the solver input is left empty.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
