### PR TITLE
Bug fix optimizeWBModel

### DIFF
--- a/src/analysis/wholeBody/PSCMToolbox/optimizeWBModel.m
+++ b/src/analysis/wholeBody/PSCMToolbox/optimizeWBModel.m
@@ -86,10 +86,10 @@ if ~exist('param','var')
     param = struct;
 end
 
-if ~isfield('param','minNorm')
+if ~isfield(param,'minNorm')
     param.minNorm = 0;
 end
-if ~isfield('param','secondsTimeLimit')
+if ~isfield(param,'secondsTimeLimit')
     param.secondsTimeLimit = 100;
 end
 if isfield(model,'osenseStr')


### PR DESCRIPTION
*Please include a short description of enhancement here*

I fixed two lines in optimizeWBModel.m where the input parameter "param" was given to the isfield function as a character array instead of a variable. In the updated code, the quotations are removed to so that the param variable can be checked to have the fields "minNorm" and "secondsTimeLimit". 

Best,
Tim Hensen

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)
