### PR TITLE
Fix bug in verifyRuleSyntax that always failed large models

### DIFF
--- a/src/reconstruction/modelGeneration/modelVerification/verifyRuleSyntax.m
+++ b/src/reconstruction/modelGeneration/modelVerification/verifyRuleSyntax.m
@@ -26,7 +26,7 @@ if ~isempty(ruleString)
         % now, either our x is not large enough, or the formula is invalid.
         % lets grab the largest number from the formula
         try
-            res = regexp(ruleString,'tokens');
+            res = regexp(ruleString, '(\d+)', 'tokens');
             vals = cellfun(@(x) str2num(x{1}),res);
             % update x to the given values 
             x = true(max(vals),1);


### PR DESCRIPTION
The regexp call was incomplete, lacking a pattern to find the numbers in the rules string. This lead to an error and thus a failed rule verification. This means, verifyModel, which calls verifyRuleSyntax, always failed if any rule references a gene above the magic index of 10001. This should be fixed now.
With the advent of large pan-GEMs, models of this size could become more relevant.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

