### PR TITLE
Fix links in the index page template

### DIFF
--- a/documentation/source/_templates/README.html
+++ b/documentation/source/_templates/README.html
@@ -9,28 +9,28 @@
 <div class="wrapper">
     <ul class="metro">
         <li class="small-tile-text color_class1 scale-10">
-            <a class="tile" href="https://opencobra.github.io/cobratoolbox/latest/installation.html">
+            <a class="tile" href="https://opencobra.github.io/cobratoolbox/stable/installation.html">
                 <img src="/cobratoolbox/stable/_static/img/icon1.png" height="110px" alt="installation">
             </a>
             <div>Installation</div>
         </li>
         &nbsp;&nbsp;&nbsp;&nbsp;
         <li class="small-tile-text color_class2 scale-10">
-            <a class="tile" href="https://opencobra.github.io/cobratoolbox/latest/tutorials/index.html">
+            <a class="tile" href="https://opencobra.github.io/cobratoolbox/stable/tutorials/index.html">
             <img src="/cobratoolbox/stable/_static/img/icon2.png" height="110px" alt="tutorials">
             </a>
               <div>Tutorials</div>
         </li>
         &nbsp;&nbsp;&nbsp;&nbsp;
         <li class="small-tile-text color_class3 scale-10">
-            <a class="tile" href="https://opencobra.github.io/cobratoolbox/latest/contributing.html">
+            <a class="tile" href="https://opencobra.github.io/cobratoolbox/stable/contributing.html">
             <img src="/cobratoolbox/stable/_static/img/icon3.png" height="110px" alt="contributing">
             </a>
               <div>Contributing</div>
         </li>
         &nbsp;&nbsp;&nbsp;&nbsp;
         <li class="small-tile-text color_class4 scale-10">
-            <a class="tile" href="https://opencobra.github.io/cobratoolbox/latest/modules/index.html">
+            <a class="tile" href="https://opencobra.github.io/cobratoolbox/stable/modules/index.html">
             <img src="/cobratoolbox/stable/_static/img/icon4.png" height="110px" alt="documentation">
             </a>
               <div>Documentation</div>


### PR DESCRIPTION
Fix links in the index page template, change links to /installation.html, /tutorials/index.html, /contributing.html and /modules/index.html to the ones from /stable path.

**I hereby confirm that I have:**

- [ ] Tested my code on my own machine
- [ ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ ] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
