### PR TITLE
nutritionToolbox fixes

### DIFF
--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/generateInSilicoDiet.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/generateInSilicoDiet.m
@@ -161,29 +161,29 @@ if analyseMacros
     % Initialise the axis for the figure
     ax1 = nexttile;
     % Create the bar chart
-    bar(dietMacroLabel.Properties.VariableNames(2:end), lipids);
+    bar(categorical(dietMacroLabel.Properties.VariableNames(2:end)), lipids);
     % Add the title
     title(ax1, 'Comparison of lipids between the original and in silico diets')
     % Add axis
     ylabel(ax1, 'Lipids (g)')
 
     ax2 = nexttile;
-    bar(dietMacroLabel.Properties.VariableNames(2:end), carbohydrates);
+    bar(categorical(dietMacroLabel.Properties.VariableNames(2:end)), carbohydrates);
     title(ax2, 'Comparison of carbohydrates between the original and in silico diets')
     ylabel(ax2, 'Carbohydrates (g)')
 
     ax3 = nexttile;
-    bar(dietMacroLabel.Properties.VariableNames(2:end), protein);
+    bar(categorical(dietMacroLabel.Properties.VariableNames(2:end)), protein);
     title(ax3, 'Comparison of protein between the original and in silico diets')
     ylabel(ax3, 'Protein (g)')
 
     ax4 = nexttile;
-    bar(dietMacroLabel.Properties.VariableNames(2:end), sugars);
+    bar(categorical(dietMacroLabel.Properties.VariableNames(2:end)), sugars);
     title(ax4, 'Comparison of sugars between the original and in silico diets')
     ylabel(ax4, 'Sugar (g)')
 
     ax5 = nexttile;
-    bar(dietMacroLabel.Properties.VariableNames(2:end), energy);
+    bar(categorical(dietMacroLabel.Properties.VariableNames(2:end)), energy);
     title(ax5, 'Comparison of energy between the original and in silico diets')
     ylabel(ax5, 'Energy (kcal)')
     

--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
@@ -49,7 +49,6 @@ end
 
 if strcmpi(macroType, 'metabolites')
     % Load metabolite category tables
-  git add 
     load('frida2024_infoFile.mat', "nutrientInfoFileFrida");
     nutrientVmhTable = nutrientVmhTable(nutrientVmhTable.metBool ==1,:);
     nutrientInfoFileFrida = nutrientInfoFileFrida(nutrientInfoFileFrida.metBool==1,:);

--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
@@ -49,12 +49,12 @@ end
 
 if strcmpi(macroType, 'metabolites')
     % Load metabolite category tables
-    load("usda2vmhInfoFile.mat", "usda2vmhInfoFile");
+  git add 
     load('frida2024_infoFile.mat', "nutrientInfoFileFrida");
-    usda2vmhInfoFile = usda2vmhInfoFile(usda2vmhInfoFile.metBool ==1,:);
+    nutrientVmhTable = nutrientVmhTable(nutrientVmhTable.metBool ==1,:);
     nutrientInfoFileFrida = nutrientInfoFileFrida(nutrientInfoFileFrida.metBool==1,:);
     % Combine the two and extract the unique values
-    metInfo = [usda2vmhInfoFile.vmhID,usda2vmhInfoFile.macroCategory;
+    metInfo = [nutrientVmhTable.vmhID,nutrientVmhTable.macroCategory;
         nutrientInfoFileFrida.vmhID, nutrientInfoFileFrida.macroCategory];
     
     [~, uniqueIdx] = unique(metInfo(:,1));

--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/setFoodRxnsWbm.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/setFoodRxnsWbm.m
@@ -85,7 +85,7 @@ if sum(strcmpi(database, 'usda')) > 0
     sugar2 = foodMacroUsda(foodMacroUsda.nutrient_id == 2000,3:end);
     sugar2{1, isnan(table2array(sugar2))} = 0;   
      
-    sugarUsda = [foodMacroUsda(foodMacroUsda.nutrient_id == 1079,2), sugar1+sugar2];
+    sugarUsda = [foodMacroUsda(foodMacroUsda.nutrient_id == 1079,2), array2table(table2array(sugar1) + table2array(sugar2), 'VariableNames', sugar1.Properties.VariableNames)];
 
     % Rename the way macros is named to energy to be able to match with
     % frida


### PR DESCRIPTION
Testing of nutritionToolbox tutorial highlighted three small issues: two related to different versions of matlab- one causing an error with the 'bar' function in generateInSilicoDiet and the other causing an issue with accessing a table/double  in setFoodRxnWbm. The third issue was due to a renaming of a file in the papers submodule that is called upon but the name in the code was not yet updated.

**I hereby confirm that I have:**

- [ X ] Tested my code on my own machine
- [ X ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ X ] Selected `develop` as a target branch (top left drop-down menu)