### PR TITLE
Remove atomically resolve tutorial link

### DIFF
--- a/stable/tutorials/index.html
+++ b/stable/tutorials/index.html
@@ -286,13 +286,6 @@
               </a>
              </li>
              <li>
-              <a href="tutorial_atomicallyResolveReconstruction.html">
-               <span class="doc">
-                Atomically resolve a metabolic reconstruction
-               </span>
-              </a>
-             </li>
-             <li>
               <a href="tutorial_benchmarkWBMsolvers.html">
                <span class="doc">
                 Benchmark solvers for solving whole body metabolic models


### PR DESCRIPTION
Removed link to the tutorial on atomically resolving a metabolic reconstruction.

*Please include a short description of enhancement here*

**I hereby confirm that I have:**

- [ ] Tested my code on my own machine
- [ ] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ ] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
