### PR TITLE
Update performRegressions.m

### DIFF
--- a/src/analysis/persephone/performRegressions.m
+++ b/src/analysis/persephone/performRegressions.m
@@ -182,7 +182,8 @@ if ~isempty(nonEmptyResults)
                 predictorTable.N(i) = mdl.NumObservations;
                 % Add regression estimate
                 if mixedEffectRegression == true
-                    predictorTable{i,{'estimate','SE','tStat','pValue'}} = double(mdl.Coefficients(2,{'Estimate','SE','tStat','pValue'}));
+                    predictorTable{i,{'estimate','SE','tStat','pValue'}} = ...
+                        double(mdl.Coefficients(j, {'Estimate','SE','tStat','pValue'}));
                 else
                     predictorTable{i,{'estimate','SE','tStat','pValue'}} = mdl.Coefficients{j,:};
                 end


### PR DESCRIPTION
Bug fix to performRegressions. The old version produced the same results for each argument in a mixed effects regression, as it had a hard-coded coefficient in the code.

*Please include a short description of enhancement here*

**I hereby confirm that I have:**

- [ X] Tested my code on my own machine
- [ X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [ X] Selected `develop` as a target branch (top left drop-down menu)

