### PR TITLE
Resolve syntax error that made the QP solution infeasible

### DIFF
--- a/src/analysis/wholeBody/PSCMToolbox/optimizeWBModel.m
+++ b/src/analysis/wholeBody/PSCMToolbox/optimizeWBModel.m
@@ -86,10 +86,10 @@ if ~exist('param','var')
     param = struct;
 end
 
-if ~isfield(param,'minNorm')
+if ~isfield('param','minNorm')
     param.minNorm = 0;
 end
-if ~isfield(param,'secondsTimeLimit')
+if ~isfield('param','secondsTimeLimit')
     param.secondsTimeLimit = 100;
 end
 if isfield(model,'osenseStr')


### PR DESCRIPTION
A syntax-related bug in the optimisation routine was identified and corrected. This issue had caused the quadratic programming (QP) solver to return infeasible solutions despite valid model inputs. The correction ensures the proper formulation of the QP problem and restores stable, feasible optimisation behaviour.

I hereby confirm that I have:
 Tested my code on my own machine
Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
