### PR TITLE
Allow for extended species names

### DIFF
--- a/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/createPersonalizedModel.m
+++ b/src/analysis/multiSpecies/microbiomeModelingToolbox/mgPipe/createPersonalizedModel.m
@@ -88,8 +88,7 @@ if isempty(mapP)
     matStart=0;
     cnt=1;
     for i = 1:length(presBac)
-        % find the indices of where there merged matrices are on the C
-        % matrix
+        % find the indices of where there merged matrices are on the C matrix
         matInd1=[];
         for j=1:size(couplingMatrixRed{i,1},1)
             matInd1(size(matInd1,1)+1,1)=j+matStart;
@@ -99,7 +98,27 @@ if isempty(mapP)
             pruned_model.ctrs{cnt,1}=couplingMatrixRed{i,4}{j,1};
             cnt=cnt+1;
         end
-        matInd2=find(strncmp(pruned_model.rxns,[presBac{i,1} '_'],length(presBac{i,1})+1));%finding indixes of specific reactions
+        thisBac   = presBac{i,1};               
+        rxns      = pruned_model.rxns;
+
+        % start with all reactions for this bacterium prefix
+        mask = strncmp(rxns, [thisBac '_'], length(thisBac)+1);
+
+        % Find "child" bacteria whose names extend this one
+        allBacs   = presBac(:,1);
+        childMask = strncmp(allBacs, [thisBac '_'], length(thisBac)+1);
+        childNames = allBacs(childMask);
+
+        % exclude reactions belonging to any child bacterium
+        for c = 1:numel(childNames)
+            child = childNames{c};
+            maskChild = strncmp(rxns, [child '_'], length(child)+1);
+            mask = mask & ~maskChild;
+        end
+
+        % final indices
+        matInd2 = find(mask);
+        pruned_model.rxns(matInd2)
         % merge the C matrix
         pruned_model.C(matInd1,matInd2) = couplingMatrixRed{i,1};
         


### PR DESCRIPTION
Previously, species names (e.g., panFirmicutes_bacterium_CAG_176) could be prefixes of longer model names (e.g., panFirmicutes_bacterium_CAG_176_63_11), which caused extra reactions to be selected and resulted in a dimension mismatch.

Fix applied:

Select all reactions beginning with bacteriumID + "_".

Identify any "child" IDs that also start with this prefix.

Exclude reactions beginning with any childID + "_".

This ensures that only reactions belonging to the intended bacterium are selected, correctly matching the dimensions of the coupling matrix. 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
