### PR TITLE
bugfixes to nutrition toolbox

### DIFF
--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/generateInSilicoDiet.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/generateInSilicoDiet.m
@@ -107,18 +107,21 @@ for i = 4:size(toCreateDiet,2)
         if metFlux{strcmpi(metFlux(:,1), 'diet_ex_pi[d]'),2} == 0
             metFlux{strcmpi(metFlux(:,1), 'diet_ex_pi[d]'),2} = 14;
         end
+    else
+        metFlux(end+1, 1:2) = {'Diet_EX_pi[d]', 14};
     end
     
     % If choline is present in less than 5.3 mmol/human/day in the diet it
-    % will be set to 5.3 as per the highest recommended intake for humans (
+    % will be set to 5.3mmol/human/day as per the highest recommended intake for humans (
     % EFSA Panel on Dietetic Products, Nutrition and Allergies (NDA), 
     % doi.org/10.2903/j.efsa.2016.4484) to make the WBMs feasible.
 
     if ~isempty(metFlux(strcmpi(metFlux(:,1), 'diet_ex_chol[d]')))
         if metFlux{strcmpi(metFlux(:,1), 'diet_ex_chol[d]'),2} <= 5.3
             metFlux{strcmpi(metFlux(:,1), 'diet_ex_chol[d]'),2} = 5.3;
-
         end
+    else
+        metFlux(end+1, 1:2) = {'Diet_EX_chol[d]', 5.3};
     end
 
     % Convert the dietary flux vector to a table

--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietComposition.m
@@ -219,7 +219,11 @@ Categories={'Vitamins/Minerals/Elements','Carbohydrates','Proteins','Lipids','Ot
 for i=1:length(molMass)
     if strcmp(macroType, 'metabolites')
         molMassInd=find(strcmp(metInfo(:,1),mets{i}));
+        if ~isempty(molMassInd)
         cat=metaboliteCategories{molMassInd};
+        end
+    else
+        cat = 'Other';
     end
 
     switch cat

--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietEnergy.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/getDietEnergy.m
@@ -77,7 +77,12 @@ if strcmp(databaseType, 'metabolites')
         met = strrep(met, 'Diet_EX_','');
         met = strrep(met, '[d]','');
 
-        category = metInfo{strcmp(metInfo(:,1),met),2};
+        energyCatIdx = strcmp(metInfo(:,1), met);
+        if any(energyCatIdx)
+            category = metInfo{energyCatIdx,2};
+        else
+            category = 'Other';
+        end
 
         if strcmp(category, 'Lipids')
             cal = 9; %kcal/g


### PR DESCRIPTION
Functions have been updated to ensure if phosphate is not present in the diet it is added.
Functions have been updated to ensure if the user changes the database with novel nutrients, but does not adjust the info file with the corresponding maronutrient group, the code treats the metabolites as Other.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)