### PR TITLE
Update parseNCBItaxonomy.m

### DIFF
--- a/src/reconstruction/demeter/src/integration/parseNCBItaxonomy.m
+++ b/src/reconstruction/demeter/src/integration/parseNCBItaxonomy.m
@@ -34,7 +34,7 @@ lineage = {
 % type 1
 taxonomy = struct();
 for i = 1:length(lineage)
-    n = regexp(hmtlString, ['ALT="', lineage{i}, '">([^<]+)'], 'tokens');
+    n = regexp(hmtlString, ['(?i)ALT="', lineage{i}, '">([^<]+)'], 'tokens');
     if ~isempty(n)
         n = [n{:}];
         if ~isempty(n{1, 1})
@@ -50,7 +50,7 @@ taxFields = fieldnames(taxonomy);
 if isempty(taxFields)
     taxonomy = struct();
     for i = 1:length(lineage)
-        n = regexp(hmtlString, ['TITLE="', lineage{i}, '">([^<]+)'], 'tokens');
+        n = regexp(hmtlString, ['(?i)TITLE="', lineage{i}, '">([^<]+)'], 'tokens');
         if ~isempty(n)
             n = [n{:}];
             if ~isempty(n{1, 1})


### PR DESCRIPTION
Made the ALT= and TITLE= regexpr case insensitive due to the new NCBI or MATLAB parser using alt= and title=. Change to make it robust in case capitalisation changes again in the future

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
