### PR TITLE
FEA: correct hypergeometric test statistics

### DIFF
--- a/src/analysis/fluxEnrichmentAnalysis/FEA.m
+++ b/src/analysis/fluxEnrichmentAnalysis/FEA.m
@@ -42,7 +42,7 @@ if strcmp(group, 'subSystems') && isfield(model,'subSystems')
 end
 
 % compute frequency of enriched terms
-groups = eval(['model.' group]);
+groups = model.(group);
 if iscell([groups{:}])
    [uniquehSubsystemsA] = unique([groups{:}]);
    presenceindicator = false(numel(uniquehSubsystemsA),numel(model.rxns));
@@ -55,7 +55,7 @@ else
     [uniquehSubsystemsA, ~, K] = unique(groups);
 end
 % fetch group
-enRxns = eval(['model.' group '(rxnSet)']);
+enRxns = model.(group)(rxnSet);
 m = length(uniquehSubsystemsA);
 allSubsystems = zeros(1, m);
 
@@ -72,15 +72,20 @@ else
     [uniquehSubsystems, ~, J] = unique(enRxns);
 end
 
-occ = histc(J, 1:numel(uniquehSubsystems));
-[l, p] = intersect(uniquehSubsystemsA, uniquehSubsystems);
+occ = histcounts(J, 0.5:1:(numel(uniquehSubsystems) + 0.5))'; 
+[~, p] = intersect(uniquehSubsystemsA, uniquehSubsystems);
 allSubsystems(p) = occ;
 
 % compute total number of reactions per group
-nRxns = histc(K, 1:numel(uniquehSubsystemsA));  % the number of reactions per susbsystem
+nRxns = histcounts(K, 0.5:1:(numel(uniquehSubsystemsA) + 0.5))';  % the number of reactions per subsystem
 
-% Compute p-values
-gopvalues = hygepdf(allSubsystems', max(nRxns), max(allSubsystems), nRxns);
+% Compute p-values using upper-tail hypergeometric CDF
+% hygecdf(X, M, K, N): P(x >= X) = 1 - P(x <= X-1)
+%   X = allSubsystems  : successes drawn (reactions from rxnSet in each subsystem)
+%   M = total reactions : population size
+%   K = nRxns           : success states in population (total reactions per subsystem)
+%   N = length(rxnSet)  : number of draws (size of the reaction set)
+gopvalues = 1 - hygecdf(allSubsystems' - 1, length(model.rxns), nRxns, length(rxnSet));
 
 % take out the zeros for one-sided test
 nonZerInd = find(allSubsystems);
@@ -89,7 +94,7 @@ nonZerInd = find(allSubsystems);
 [m, rxnInd] = sort(gopvalues);
 
 % intersect non zero sets with ordered pvalues
-[~, nonZeroInd] = intersect(rxnInd, nonZerInd)
+[~, nonZeroInd] = intersect(rxnInd, nonZerInd);
 orderedPval = rxnInd(sort(nonZeroInd));
 
 % Build result cell

--- a/src/analysis/fluxEnrichmentAnalysis/FEA.m
+++ b/src/analysis/fluxEnrichmentAnalysis/FEA.m
@@ -28,6 +28,10 @@ end
 if ~isvector(rxnSet)
     error('Please provide the indices of the reactions e.g. 1:10')
 end
+if isempty(rxnSet)
+    resultCell = {'P-value', 'Adjusted P-value', 'Group', 'Enriched set size', 'Total set size'};
+    return;
+end
 if ~ischar(group)
     error('Please provide the group name as string of characters e.g. ''subSystems'' ')
 end
@@ -85,7 +89,7 @@ nRxns = histcounts(K, 0.5:1:(numel(uniquehSubsystemsA) + 0.5))';  % the number o
 %   M = total reactions : population size
 %   K = nRxns           : success states in population (total reactions per subsystem)
 %   N = length(rxnSet)  : number of draws (size of the reaction set)
-gopvalues = 1 - hygecdf(allSubsystems' - 1, length(model.rxns), nRxns, length(rxnSet));
+gopvalues = hygecdf(allSubsystems' - 1, length(model.rxns), nRxns, length(rxnSet), 'upper');
 
 % take out the zeros for one-sided test
 nonZerInd = find(allSubsystems);

--- a/test/verifiedTests/analysis/testFEA/testFEA.m
+++ b/test/verifiedTests/analysis/testFEA/testFEA.m
@@ -1,7 +1,7 @@
 % The COBRAToolbox: testFEA.m
 %
 % Purpose:
-%     - testFEA tests the Flux Enrichemnt Analysis
+%     - testFEA tests the Flux Enrichment Analysis
 %     function
 %
 % Author:
@@ -9,27 +9,75 @@
 
 global CBTDIR
 
-%Test requirements
-requiredToolboxes = {'bioinformatics_toolbox','statistics_toolbox'};
-prepareTest('toolboxes',requiredToolboxes);
+% Test requirements
+requiredToolboxes = {'bioinformatics_toolbox', 'statistics_toolbox'};
+prepareTest('toolboxes', requiredToolboxes);
 
 % save the current path
 currentDir = pwd;
 
 % initialize the test
 fileDir = fileparts(which('testFEA'));
-cd(fileDir);    
+cd(fileDir);
 
-
-% load the model and reference data
-load('testDataFEA.mat');
+% load a model
 model = getDistributedModel('ecoli_core_model.mat');
 
 % run FEA
-resultCellFtest = FEA(model, 1:10, 'subSystems');
+rxnSet = 1:10;
+resultCellFtest = FEA(model, rxnSet, 'subSystems');
 
-% assert equality of test results and reference data
-assert(isequal(resultCellFtest, resultCellF));
+% --- Validate output structure ---
+% Header row should be present
+assert(isequal(resultCellFtest(1, :), {'P-value', 'Adjusted P-value', 'Group', 'Enriched set size', 'Total set size'}));
+
+% Results should have rows (header + at least one enriched group)
+assert(size(resultCellFtest, 1) > 1, 'FEA should return at least one enriched group');
+assert(size(resultCellFtest, 2) == 5, 'FEA result should have 5 columns');
+
+% --- Validate p-values ---
+pvals = cell2mat(resultCellFtest(2:end, 1));
+adjPvals = cell2mat(resultCellFtest(2:end, 2));
+
+% P-values must be in [0, 1]
+assert(all(pvals >= 0 & pvals <= 1), 'P-values must be between 0 and 1');
+assert(all(adjPvals >= 0 & adjPvals <= 1), 'Adjusted p-values must be between 0 and 1');
+
+% Adjusted p-values (BH-FDR) should be >= raw p-values
+assert(all(adjPvals >= pvals - 1e-12), 'BH-adjusted p-values should be >= raw p-values');
+
+% P-values should be sorted in ascending order
+assert(all(diff(pvals) >= -1e-12), 'P-values should be in ascending order');
+
+% --- Validate enriched set sizes ---
+enrichedSizes = cell2mat(resultCellFtest(2:end, 4));
+totalSizes = cell2mat(resultCellFtest(2:end, 5));
+
+% Enriched set size should not exceed total set size
+assert(all(enrichedSizes <= totalSizes), 'Enriched set size cannot exceed total set size');
+
+% Enriched set sizes should be > 0 (zero-count subsystems are filtered out)
+assert(all(enrichedSizes > 0), 'Enriched set sizes should be positive');
+
+% --- Validate against manual hypergeometric calculation for one group ---
+% Find a subsystem and verify the p-value manually
+groups = model.subSystems(rxnSet);
+allGroups = model.subSystems;
+M = length(model.rxns);  % population size
+N = length(rxnSet);       % sample size
+
+% Pick the first result group
+testGroup = resultCellFtest{2, 3};
+% Count successes in sample (X)
+X = sum(cellfun(@(x) any(strcmp(x, testGroup)), groups));
+% Count successes in population (K)
+Kpop = sum(cellfun(@(x) any(strcmp(x, testGroup)), allGroups));
+% Manual upper-tail p-value: P(x >= X)
+expectedPval = 1 - hygecdf(X - 1, M, Kpop, N);
+assert(abs(resultCellFtest{2, 1} - expectedPval) < 1e-10, ...
+    'P-value for first group does not match manual hypergeometric calculation');
+
+% --- Error handling tests ---
 
 % check when the groups argument is not a string
 try

--- a/test/verifiedTests/analysis/testFEA/testFEA.m
+++ b/test/verifiedTests/analysis/testFEA/testFEA.m
@@ -73,7 +73,7 @@ X = sum(cellfun(@(x) any(strcmp(x, testGroup)), groups));
 % Count successes in population (K)
 Kpop = sum(cellfun(@(x) any(strcmp(x, testGroup)), allGroups));
 % Manual upper-tail p-value: P(x >= X)
-expectedPval = 1 - hygecdf(X - 1, M, Kpop, N);
+expectedPval = hygecdf(X - 1, M, Kpop, N, 'upper');
 assert(abs(resultCellFtest{2, 1} - expectedPval) < 1e-10, ...
     'P-value for first group does not match manual hypergeometric calculation');
 
@@ -99,6 +99,11 @@ try
 catch ME
     assert(length(ME.message) > 0)
 end
+
+% check empty rxnSet returns header-only result
+resultCellEmpty = FEA(model, [], 'subSystems');
+assert(size(resultCellEmpty, 1) == 1, 'Empty rxnSet should return header only');
+assert(isequal(resultCellEmpty(1, :), {'P-value', 'Adjusted P-value', 'Group', 'Enriched set size', 'Total set size'}));
 
 % change the directory
 cd(currentDir)


### PR DESCRIPTION
## Summary

Fixes statistical bugs in `FEA.m` (Flux Enrichment Analysis).

## Changes

### FEA.m
- Use `hygecdf` (upper-tail CDF) instead of `hygepdf` (point probability)
- Replace `eval()` with dynamic field access `model.(group)` for safety
- Replace deprecated `histc` with `histcounts`
- Fix missing semicolon causing unintended console output

### testFEA.m
- Updated test to validate statistical correctness independently (output structure, p-value ranges, BH-FDR properties, manual hypergeometric verification) instead of comparing against stale reference data generated by the buggy function
- Kept all existing error-handling tests
