### PR TITLE
fix(findMIIS): use size(A,1) to get number of rows

### DIFF
--- a/src/analysis/findMIIS/findMIIS.m
+++ b/src/analysis/findMIIS/findMIIS.m
@@ -42,7 +42,7 @@ if ~isfield(LPProblem,'A')
 end
 
 if ~isfield(LPProblem,'csense')
-    nMet=size(LPProblem.A);
+    nMet=size(LPProblem.A,1);
     if printLevel>0
         fprintf('%s\n','Assuming equality constraints, i.e. S*v=b');
     end


### PR DESCRIPTION
## Summary

Fixes a bug in `findMIIS.m` where `size(LPProblem.A)` returns `[m, n]` instead of just `m`.

## Bug

When `csense` is not provided, the function defaults it to all equalities. But `nMet = size(LPProblem.A)` returns a 2-element vector, so `LPProblem.csense(1:nMet, 1) = 'E'` creates a `csense` of length `n` (columns) instead of `m` (rows). This causes an index-out-of-bounds error downstream when building CPLEX constraint bounds (`b_L`, `b_U`).

## Fix

`size(LPProblem.A)` → `size(LPProblem.A, 1)`

## Testing

Existing test (`testfindMIIS.m`) already covers this path — it passes a model without `csense`.
