### PR TITLE
Update loadPSCMfile.m

### DIFF
--- a/src/analysis/wholeBody/PSCMToolbox/io/loadPSCMfile.m
+++ b/src/analysis/wholeBody/PSCMToolbox/io/loadPSCMfile.m
@@ -65,7 +65,7 @@ if ~contains(nameOfWBM,'.mat')
 end
 
 % Check if fileName can be found
-if isempty(which(nameOfWBM))
+if ~isfile(nameOfWBM)
     % Find .mat files that can be loaded in prespecified directory
     if ~isempty(searchDirectory)
         availableWBMs = what(searchDirectory).mat;


### PR DESCRIPTION
Changed code to use isfile instead of which.

This removes a bug where the WBM cannot be read if it is not on the path, but it does exist locally on the machine reducing confusion why models cannot be loaded.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)
