### PR TITLE
fixed bug in split keywords in nutrition toolbox

### DIFF
--- a/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/vmhFoodFinder.m
+++ b/src/analysis/wholeBody/Nutrition_Modelling_Toolbox/vmhFoodFinder.m
@@ -382,7 +382,7 @@ if ~isempty(colourChangeIdx)
 end
 end
 
-function keyWordsSplit = splitKeyWord(keyWords, adjust)
+function finalSplitKeys = splitKeyWord(keyWords, adjust)
 % Function to split items based on ;
 %
 % Usage:
@@ -417,7 +417,14 @@ else
     keyWordsSplit = strrep(keyWordsSplit, ' ;', ';');
 end
 % Split the keywords on ;
-keyWordsSplit = split(keyWordsSplit, ';');
-
-keyWordsSplit(cellfun(@isempty, keyWordsSplit)) = [];
+finalSplitKeys = {};
+for i = 1:size(keyWordsSplit,1)
+    if contains(keyWordsSplit(i), ';')
+        splitKeys = split(keyWordsSplit(i), ';');
+        finalSplitKeys = [finalSplitKeys;splitKeys];
+    else
+        finalSplitKeys = [finalSplitKeys;keyWordsSplit(i)];
+    end
+end
+finalSplitKeys(cellfun(@isempty, keyWordsSplit)) = [];
 end


### PR DESCRIPTION
Fixed bug in vmhFoodFinder where splitting key words caused errors. Made for loop to fix error message

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [x] Selected `develop` as a target branch (top left drop-down menu)