### PR TITLE
ci: prevent self-hosted runner checkout deadlock from root-owned Docker leftovers

### DIFF
--- a/.github/workflows/testAllCI_step1.yml
+++ b/.github/workflows/testAllCI_step1.yml
@@ -18,6 +18,21 @@ jobs:
         run: docker ps -q --filter ancestor=matlab | xargs -r docker rm -f
         continue-on-error: true
 
+      # The MATLAB test step below runs in Docker as root and writes regenerable outputs
+      # (e.g. test/verifiedTests/analysis/testCalculateFluxShifts/resultsPostOptimization/)
+      # into the mounted workspace, owned by root. On the NEXT run, actions/checkout's
+      # git-clean runs as the runner user and cannot unlink those root-owned files (EACCES),
+      # so "Check out merged PR code" exits 1 before any test runs. Because checkout precedes
+      # the existing chown steps, one leftover deadlocks CI permanently. Reclaim ownership
+      # BEFORE checkout so git-clean can proceed; also auto-heals an already-stuck runner.
+      # No-op on a fresh runner (guarded on an existing workspace).
+      - name: Reclaim self-hosted workspace ownership (pre-checkout)
+        run: |
+          if [ -n "${GITHUB_WORKSPACE}" ] && [ -d "${GITHUB_WORKSPACE}" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" || true
+          fi
+        continue-on-error: true
+
       - name: Check out merged PR code
         uses: actions/checkout@v6
         with:
@@ -102,7 +117,11 @@ jobs:
                 exit(0);"
             '
 
+      # Run even if the Docker test step failed, so a failed run still hands the
+      # workspace back to the runner user instead of leaking root-owned files that
+      # would deadlock the next checkout.
       - name: Fix workspace permissions after Docker run
+        if: always()
         run: sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}"
         continue-on-error: true
 


### PR DESCRIPTION
## Problem

`cobratoolboxCI` (`.github/workflows/testAllCI_step1.yml`) has been failing on **every** `develop` run since `8e51eaaff` (last green run: `1dd2d6890`). The failure is in the **`Check out merged PR code`** step (~12–14 s), **before any MATLAB test runs** — so it is independent of the code under test:

```
File was unable to be removed Error: EACCES: permission denied, unlink
'.../test/verifiedTests/analysis/testCalculateFluxShifts/resultsPostOptimization/fluxShifts/SRR8994378_S47D_flux_shifts.xls'
→ Unable to clean or reset the repository. → Process completed with exit code 1.
```

### Root cause

The test suite runs in Docker as **root** (`docker run` with no `--user`), so it writes regenerable test outputs (this path is `.gitignore`d) into the mounted workspace **owned by root**. On the next run, `actions/checkout`'s `git clean` runs as the **runner user** and cannot `unlink` those root-owned files → `EACCES` → checkout aborts.

Because checkout runs **before** the two existing `sudo chown` steps, once one root-owned file exists the checkout fails first and the repair steps never run — a self-perpetuating deadlock that cannot self-heal.

## Fix (workflow-only; no test-logic or toolbox change)

1. **`Reclaim self-hosted workspace ownership (pre-checkout)`** — a new step before checkout that `sudo chown`s the reused workspace back to the runner user so `git clean` can always proceed. This also **auto-heals the currently stuck runner** on the next run (no manual ops required). No-op on a fresh runner.
2. **`if: always()`** on `Fix workspace permissions after Docker run` — so a *failed* test run still hands the workspace back to the runner user instead of leaking root-owned files.

I deliberately did **not** add `docker run --user <uid>` — running the MATLAB/xvfb container as a non-root UID risks breaking licensing/display setup and needs separate testing.

## Validation

- YAML parses cleanly; the `build` job now has 17 steps.
- Change is confined to `.github/workflows/testAllCI_step1.yml` (+21 lines); no test or source files touched.
- Diagnosis cross-checked against runs [29546321997](https://github.com/opencobra/cobratoolbox/actions/runs/29546321997) (`aa91ae217`) and 29567492927 (`07260e10f`) — both fail identically at checkout, before any test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
