### PR TITLE
docs: document change-based CI test selection, concurrency & coverage gating

### DIFF
--- a/documentation/DevelopersDocumentation/testAll_CI_Documentation.md
+++ b/documentation/DevelopersDocumentation/testAll_CI_Documentation.md
@@ -9,6 +9,18 @@ This repository implements a GitHub Actions workflow to automate testing and rep
 
 This design ensures security while allowing test reports to be posted on pull requests, including those from forked repositories.
 
+`testAllCI_step1` runs on a **self-hosted, MATLAB-licensed runner** and, beyond
+running the tests, now also:
+
+- **selects only the tests relevant to a PR** via a dependency analysis of the
+  changed files, instead of re-running the whole suite every time
+  (see [Change-Based Test Selection](#-change-based-test-selection-dependency-analysis));
+- **cancels superseded runs** of the same PR through a concurrency group
+  (see [Concurrency](#-concurrency-one-run-per-pr));
+- **computes code coverage** (patched MOcov + jsonlab) and uploads it to Codecov,
+  gated on **patch** coverage (see [Code Coverage Gating](#-code-coverage-gating));
+- resolves a **fast/full execution mode** (see [Execution Modes](#-execution-modes-fastfull)).
+
 ---
 
 ## ⚠️ Important Note
@@ -143,6 +155,141 @@ The `cobra-report` format is exclusively designed for COBRA Toolbox by COBRA dev
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+---
+
+## ⚡ Change-Based Test Selection (Dependency Analysis)
+
+Re-running the **entire** MATLAB suite on every pull request is wasteful: the
+single self-hosted runner serializes jobs, so a full run can take hours and block
+every other PR. `testAllCI_step1` therefore analyses each PR's changed files and
+runs **only the tests that depend on them**.
+
+### How it works
+
+A pre-MATLAB step — **"Analyze changed files and select relevant tests"** — runs
+`.github/scripts/select_tests.py`, which performs a static, token-based **reverse
+dependency analysis** over `src/` and `test/`:
+
+1. Every `src/**/*.m` is indexed by its function name (== filename, per MATLAB).
+2. A file "depends on" a source function if its text references that name as a
+   token. (Comments are intentionally **not** stripped — an extra edge only makes
+   us run *more* tests, which is safe; a missed edge would not be.)
+3. Starting from the PR's changed `src/` files, the analysis walks the reverse
+   edges transitively to reach every `test*.m` that uses them, directly or through
+   intermediate source functions. Changed `test*.m` files are always included.
+
+The analysis **over-approximates** — it errs toward running more tests, never
+fewer — so it will not silently skip a test that should have run.
+
+The selected tests are passed to MATLAB as a `runTestSuite()` regexp in the
+`COBRA_TESTS` environment variable. `test/testAll.m` reads it:
+
+```matlab
+testFilter = getenv('COBRA_TESTS');
+if isempty(testFilter)
+    [result, resultTable] = runTestSuite();          % full suite
+else
+    [result, resultTable] = runTestSuite(testFilter); % selected tests only
+end
+```
+
+The workflow step exposes three outputs, consumed by later steps via
+`steps.select.outputs`:
+
+| Output        | Meaning                                                        |
+| ------------- | -------------------------------------------------------------- |
+| `mode`        | `full` \| `selective` \| `none`                                |
+| `run_tests`   | `true` \| `false` (when `false`, the MATLAB + report steps are skipped) |
+| `test_filter` | the `runTestSuite()` regexp (empty when `full`)                |
+
+### When the FULL suite runs anyway (conservative, fail-safe policy)
+
+To avoid ever missing a needed test, the full suite runs when **any** of these hold:
+
+- the PR carries a **`ci-full`** label (`COBRA_FORCE_FULL`);
+- the PR targets **`master`** (release baseline must stay thorough);
+- a changed path is **core/shared**: `src/base/**`, `initCobraToolbox.m`, the test
+  harness (`test/*.m`), `.github/**`, `external/**`, or `codecov.yml`;
+- a changed `src/` file cannot be indexed;
+- the selection already reaches **≥ 90%** of the suite (`FULL_FRACTION`);
+- `BASE_REF` is empty (manual / `workflow_dispatch`) or the selector errors.
+
+If only non-code paths changed (docs, tutorials, …) and nothing reaches a test,
+`mode=none` and the MATLAB run is skipped entirely.
+
+### Running the selector locally
+
+```bash
+git diff --name-only --diff-filter=ACMRT origin/develop...HEAD > changed.txt
+python3 .github/scripts/select_tests.py --changed changed.txt --root .
+# machine output (mode / run_tests / test_filter) on stdout; a summary on stderr
+```
+
+See `.github/scripts/README.md` for the full contract.
+
+---
+
+## 🔁 Concurrency: One Run per PR
+
+The self-hosted runner processes one job at a time, so pushing several times to a
+PR used to pile up redundant queued runs behind each other. A concurrency group
+now cancels the in-flight run for a PR when a new commit is pushed:
+
+```yaml
+concurrency:
+  group: cobratoolboxCI-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+The group is keyed on the **PR number**, so different PRs never cancel each other —
+only superseded runs of the *same* PR are cancelled.
+
+---
+
+## 🏃 Execution Modes (fast/full)
+
+Independently of *which* test files are selected, each test can run in a `fast` or
+`full` mode (feature "testAll performance modes"), resolved by
+`getCobraTestMode()` and announced by `testAll.m`:
+
+- **fast** (default on PRs to `develop`) — quick feedback on the VM;
+- **full** — PRs targeting `master` run the complete breadth so the coverage-gate
+  baseline stays thorough.
+
+Set `COBRA_TEST_MODE=full` to force the complete suite locally.
+
+---
+
+## 📊 Code Coverage Gating
+
+`testAllCI_step1` runs inside a `matlab-cov` Docker image that bakes a **patched
+MOcov + jsonlab** (with `MOCOV_PATH`/`JSONLAB_PATH` set in the image ENV) so
+`test/testAll.m` computes coverage and emits `coverage.xml` / `coverage.json`.
+Coverage is **best-effort**: a failure of the coverage tooling is surfaced as a
+warning but never fails the (already reported) test run. The report is always
+uploaded as an artifact and, best-effort, to Codecov.
+
+Because a **selective** run exercises only part of `src/`, overall **project**
+coverage drops versus the full-suite base. `codecov.yml` therefore makes the
+**project** status *informational* (reported, never blocking) and gates on
+**patch** coverage — the lines the PR actually changed:
+
+```yaml
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 10%
+        informational: false
+```
+
+This is also a built-in check on the selector: if it missed the test that
+exercises the changed code, patch coverage falls and the gate flags it.
 
 ---
 


### PR DESCRIPTION
Updates the developer CI documentation (`documentation/DevelopersDocumentation/testAll_CI_Documentation.md`) to cover the recent `testAllCI_step1` improvements now on `develop`:

- **Change-Based Test Selection** — dependency analysis of the PR diff via `.github/scripts/select_tests.py`, so CI runs only the relevant tests instead of the whole suite.
- **Concurrency** — per-PR group that cancels superseded runs.
- **Execution Modes (fast/full)**.
- **Code Coverage Gating** — project status informational, patch status blocking.

Docs only; no workflow or website changes. The site rebuilds automatically on the next `develop -> master` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)