### PR TITLE
Debug the empty vbasis and cbasis situation

### DIFF
--- a/src/base/solvers/solveCobraLP.m
+++ b/src/base/solvers/solveCobraLP.m
@@ -903,9 +903,13 @@ switch solver
                     pause(0.1)
                 end
 
-                % save the basis
-                basis.vbasis=resultgurobi.vbasis;
-                basis.cbasis=resultgurobi.cbasis;
+                % save the basis (only available if crossover was used or simplex method)
+                if isfield(resultgurobi, 'vbasis')
+                    basis.vbasis = resultgurobi.vbasis;
+                end
+                if isfield(resultgurobi, 'cbasis')
+                    basis.cbasis = resultgurobi.cbasis;
+                end
             end
         end
 


### PR DESCRIPTION
Debug the empty vbasis and cbasis situation
This will allow running Gurobi with the crossover=0 option

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
