### PR TITLE
Avoid the testing CI to run on the fork repositories

### DIFF
--- a/.github/workflows/testAllCI_step1.yml
+++ b/.github/workflows/testAllCI_step1.yml
@@ -21,6 +21,17 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
+    # This job needs the self-hosted runner ("Blacknight") registered only on
+    # opencobra/cobratoolbox -- licensed MATLAB Docker image, baked-in Gurobi
+    # license. On a fork, the same workflow file still triggers (e.g. a PR
+    # entirely within the fork, from a feature branch into the fork's own
+    # develop), but no self-hosted runner is available there: the job queues
+    # indefinitely and GitHub eventually marks it failed, showing contributors
+    # a spurious "CI failed" unrelated to their code. Skip (not fail) outside
+    # the one repo that actually has the runner; a PR *from* a fork *into*
+    # opencobra/cobratoolbox still runs here, since github.repository for a
+    # pull_request event is always the base (target) repo, never the fork.
+    if: github.repository == 'opencobra/cobratoolbox'
     runs-on: self-hosted
     steps:
       - name: Cleanup orphaned MATLAB containers

--- a/.github/workflows/testAllCI_step2.yml
+++ b/.github/workflows/testAllCI_step2.yml
@@ -12,7 +12,13 @@ permissions:
 jobs:
   publish-report:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    # Depends on artifacts (CTRF report, PR number) that only exist when the
+    # 'build' job in testAllCI_step1.yml actually ran -- which it now skips
+    # outside opencobra/cobratoolbox (see that file). Without this guard,
+    # this job would still fire on a fork (a skipped job's workflow run still
+    # reports conclusion 'success') and then fail trying to download
+    # artifacts that were never produced.
+    if: github.event.workflow_run.conclusion == 'success' && github.repository == 'opencobra/cobratoolbox'
     steps:
     
       - name: Download CTRF Artifact


### PR DESCRIPTION
Make the testing CI to only run on the opencobra/cobratoolbox

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
