### PR TITLE
Change the speckit naming convention 

### DIFF
--- a/.specify/extensions/git/git-config.yml
+++ b/.specify/extensions/git/git-config.yml
@@ -2,7 +2,7 @@
 # Copied to .specify/extensions/git/git-config.yml on install
 
 # Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
-branch_numbering: sequential
+branch_numbering: timestamp
 
 # Commit message used by `git commit` during repository initialization
 init_commit_message: "[Spec Kit] Initial commit"

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,7 +1,7 @@
 {
   "ai": "claude",
   "ai_skills": true,
-  "branch_numbering": "sequential",
+  "branch_numbering": "timestamp",
   "here": false,
   "integration": "claude",
   "script": "sh",


### PR DESCRIPTION
Change the setting to name the specs based on YYYYMMDD-HHMMSS-<short-name> to avoid collisions of different specs by two developers with the same number 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the guidelines in the [Contributing Guide](https://opencobra.github.io/cobratoolbox/docs/contributing.html)
- [X] Selected `develop` as a target branch (top left drop-down menu)

*(Note: You may replace [ ] with [X] to check the box)*
